### PR TITLE
Check for break in qry creates table

### DIFF
--- a/pysqldb3/query.py
+++ b/pysqldb3/query.py
@@ -279,7 +279,7 @@ class Query:
 
         # Adds catch for MS [database].[schema].[table]
         select_into = r'(((\$body\$)([^\$]*)(\$body\$;$))|((\$\$)([^\$]*)(\$\$;$)))|(?<!\*)(?<!\*\s)(?<!--)' \
-                      r'(?<!--\s)\s*(select[^\.]*into\s+)(?!temp\s|temporary\s)((([\[][\w\s\.\"]*[\]])|([\"][\w\s\.]*' \
+                      r'(?<!--\s)\s*(select[^\.;]*into\s+)(?!temp\s|temporary\s)((([\[][\w\s\.\"]*[\]])|([\"][\w\s\.]*' \
                       r'[\"])|([\w]+))([.](([\[][\w\s\.\"]*[\]])|([\"][\w\s\.]*[\"])|([\w]+)))?([.](([\[][\w\s\.\"]*' \
                       r'[\]])|([\"][\w\s\.]*[\"])|([\w]+)))?([.](([\[][\w\s\.\"]*[\]])|([\"][\w\s\.]*[\"])|([\w]+)))?)'
         matches = re.findall(select_into, query_string, re.IGNORECASE)


### PR DESCRIPTION
Adds ; to query creates table regex exclusion between `select` and `into`

handles cases for queries like this
`db.query("select * from a; insert into a values(...", temp=False)`


There is an additional issue where the comment parsing isnt picking up for this scenario 
`db.query("select * /*;*/ into a values(...")`  this query should be flagged as creating a table but its not getting picked up 

Closes #29