### PR TITLE
CSV / XLS to table kwargs to pass to pandas 

### DIFF
--- a/pysqldb3/pysqldb3.py
+++ b/pysqldb3/pysqldb3.py
@@ -9,6 +9,7 @@ import plotly.express as px
 import configparser
 import os
 from .Config import write_config
+import pyarrow.csv as pyarrowcsv
 
 write_config(confi_path=os.path.dirname(os.path.abspath(__file__)) + "\\config.cfg")
 config = configparser.ConfigParser()
@@ -807,6 +808,10 @@ class DbConnect:
         for col in df.dtypes.items():
             col_name, col_type = col[0], type_decoder(col[1], varchar_length=allowed_length)
 
+            # autodetect date and force to text (common error)
+            if 'date' in col_name.lower() and col_type in ('int', 'bigint', 'float'):
+                col_type = 'varchar(500)'
+
             if column_type_overrides and col_name in column_type_overrides.keys():
                 input_schema.append([clean_column(col_name), column_type_overrides[col_name]])
             else:
@@ -989,6 +994,145 @@ class DbConnect:
         return self._bulk_file_to_table(input_file=input_file, schema=schema, table=table,
                                         table_schema=table_schema, print_cmd=print_cmd, excel_header=False, days=days)
 
+    def csv_to_table_pyarrow(self, input_file=None, overwrite=False, schema=None, table=None, temp=True, sep=',',
+                     long_varchar_check=False, column_type_overrides=None, days=7, **kwargs):
+        """
+        Imports csv file to database. This uses pyarrow datatypes to generate the table schema.
+
+        ** This is an alternative route for importing - faster and better type inference, but not as fully featured as pandas **
+
+        :param input_file: File path to csv file; if None, prompts user input
+        :param overwrite: If table exists in database, will overwrite; defaults to False
+        :param schema: Schema of table; if None, defaults to db's default schema
+        :param table: Name for final database table; defaults to filename in path
+        :param temp: Boolean for temporary table; defaults to True
+        :param sep: Separator for csv file, defaults to comma (,)
+        :param long_varchar_check: Boolean to allow unlimited/max varchar columns; defaults to False
+        :param column_type_overrides: Dict of type key=column name, value=column type. Will manually set the
+        raw column name as that type in the query, regardless of the pandas/postgres/sql server automatic
+        detection. **Will not override a custom table_schema, if inputted**
+        :param days: if temp=True, the number of days that the temp table will be kept. Defaults to 7.
+        :param **kwargs: parameters to pass to pandas for read csv (ex. skiprows=1)
+        :return:
+        """
+
+        if not schema:
+            schema = self.default_schema
+
+        if not input_file:
+            input_file = file_loc('file')
+
+        if not table:
+            table = os.path.basename(input_file).split('.')[0]
+
+        if not overwrite and self.table_exists(schema=schema, table=table):
+            print('Must set overwrite=True; table already exists.')
+            return
+
+        # Use pyarrow to get existing data and schema
+        data = pyarrowcsv.read_csv(input_file, parse_options=pyarrowcsv.ParseOptions(delimiter=sep),
+                                   read_options=pyarrowcsv.ReadOptions(**kwargs))
+        if '' in [col.name for col in data.schema]:
+            data = data.rename_columns([(lambda x: 'unnamed' if x == '' else x)(col.name) for col in data.schema])
+
+        allow_max = False
+
+        if 'ogc_fid' in [i.name for i in data.schema]:
+            data = data.drop(['ogc_fid'])
+
+        table_schema = self.dataframe_to_table_schema_pyarrow(data, table, overwrite=overwrite, schema=schema,
+                                                              temp=temp,
+                                                              allow_max_varchar=allow_max,
+                                                              column_type_overrides=column_type_overrides,
+                                                              days=days)
+        # Default to bulk importer
+
+        try:
+            success = self._bulk_csv_to_table(input_file=input_file, schema=schema, table=table,
+                                              table_schema=table_schema, days=days)
+
+            if not success:
+                raise AssertionError('Bulk CSV loading failed.'.format(schema, table))
+
+        except Exception as e:
+            print(e)
+            # fall back to pandas dataframe to table
+            # Calls dataframe_to_table fn
+            self.dataframe_to_table(data.to_pandas(), table, table_schema=table_schema, overwrite=overwrite,
+                                    schema=schema,
+                                    temp=temp, days=days)
+
+    def dataframe_to_table_schema_pyarrow(self, data, table, schema=None, overwrite=False, temp=True, allow_max_varchar=False,
+                                          column_type_overrides=None, days=7):
+
+        """
+        Translates Pandas DataFrame into empty database table.
+        :param df: Pandas DataFrame to be added to database
+        :param table: Table name to be used in database
+        :param schema: Database schema to use for destination in database (defaults database object's default schema)
+        :param overwrite: If table exists in database will overwrite if True (defaults to False)
+        :param temp: Optional flag to make table as not-temporary (defaults to True)
+        :param allow_max_varchar: Boolean to allow unlimited/max varchar columns; defaults to False
+        :param column_type_overrides: Dict of type key=column name, value=column type. Will manually set the
+                raw column name as that type in the query, regardless of the pandas/postgres/sql server automatic
+                detection.
+        :param days: if temp=True, the number of days that the temp table will be kept. Defaults to 7.
+        :return: Table schema that was created from DataFrame
+        """
+        if not schema:
+            schema = self.default_schema
+
+        input_schema = list()
+
+        if allow_max_varchar:
+            allowed_length = VARCHAR_MAX[self.type]
+        else:
+            allowed_length = 500
+
+        # Parse df for schema
+        for col in data.schema:
+            col_name, col_type = col.name, type_decoder_pyarrow(col.type, varchar_length=allowed_length)
+
+
+            if column_type_overrides and col_name in column_type_overrides.keys():
+                input_schema.append([clean_column(col_name), column_type_overrides[col_name]])
+            else:
+                input_schema.append([clean_column(col_name), col_type])
+
+        if overwrite:
+            self.drop_table(schema=schema, table=table, cascade=False)
+
+        # Create table in database
+        qry = """
+                CREATE TABLE {s}.{t} (
+                {cols}
+                )
+        """.format(s=schema, t=table,
+                   cols=str(['"' + str(i[0]) + '" ' + i[1] for i in input_schema])[1:-1].replace("'", ""))
+
+        self.query(qry.replace('\n', ' '), timeme=False, temp=temp, days=days)
+        return input_schema
+
+
+    def _bulk_csv_to_table_pyarrow(self, input_file=None, schema=None, table=None, table_schema=None, print_cmd=False, days=7):
+        """
+        Shell for bulk_file_to_table. Routed to by csv_to_table when record count is >= 1,000.
+
+        ** This is an alternative route for importing - faster and better type inference, but not as fully featured as pandas **
+
+        
+        :param input_file: Source CSV filepath
+        :param schema: Schema to write to; defaults to db's default schema
+        :param table: Destination table name to write data to; defaults to user/date defined
+        :param table_schema:
+        :param print_cmd: Optional flag to print the GDAL command that is being used; defaults to False
+        :param days: if temp=True, the number of days that the temp table will be kept. Defaults to 7.
+        :return:
+        """
+
+        return self._bulk_file_to_table(input_file=input_file, schema=schema, table=table,
+                                        table_schema=table_schema, print_cmd=print_cmd, excel_header=False, days=days)
+
     def _bulk_xlsx_to_table(self, input_file=None, schema=None, table=None, table_schema=None, print_cmd=False,
                             header=True, days=7):
         """
@@ -1004,6 +1148,19 @@ class DbConnect:
         """
         return self._bulk_file_to_table(input_file=input_file, schema=schema, table=table,
                                         table_schema=table_schema, print_cmd=print_cmd, excel_header=header, days=days)
+    @staticmethod
+    def __double_cast_for_ints(i, column_names, column_type):
+        """
+        This will create the cast statements for insert query which is used by _bulk_file_to_table
+        :param i: index position
+        :param column_names: column name list
+        :param column_type: column datatype
+        :return: castting string for insert query
+        """
+        if column_type == 'bigint':
+            return 'CAST(CAST("' + column_names[i] + '"as float) as bigint)'
+        else:
+            return 'CAST("' + column_names[i] + '" as ' + column_type + ')'
 
     def _bulk_file_to_table(self, input_file=None, schema=None, table=None, table_schema=None, print_cmd=False,
                             excel_header=True, days=7):
@@ -1097,8 +1254,12 @@ class DbConnect:
 
                 # Cast all fields to new type to move from stg to final table
                 # take staging field name from stg table
-                cols = ['CAST("' + column_names[i] + '" as ' + col_type + ')' for i, (col_name, col_type) in
+
+
+                cols = [self.__double_cast_for_ints(i, column_names, col_type) for i, (col_name, col_type) in
                         enumerate(table_schema)]
+                # cols = ['CAST("' + column_names[i] + '" as ' + col_type + ')' for i, (col_name, col_type) in
+                #         enumerate(table_schema)]
                 # cols = [c.encode('utf-8') for c in cols]
                 cols = str(cols).replace("'", "")[1:-1]
             else:

--- a/pysqldb3/pysqldb3.py
+++ b/pysqldb3/pysqldb3.py
@@ -874,7 +874,7 @@ class DbConnect:
         print('\n{c} rows added to {s}.{t}\n'.format(c=df.cnt.values[0], s=schema, t=table))
 
     def csv_to_table(self, input_file=None, overwrite=False, schema=None, table=None, temp=True, sep=',',
-                     long_varchar_check=False, column_type_overrides=None, days=7):
+                     long_varchar_check=False, column_type_overrides=None, days=7, **kwargs):
         """
         Imports csv file to database. This uses pandas datatypes to generate the table schema.
         :param input_file: File path to csv file; if None, prompts user input
@@ -888,6 +888,7 @@ class DbConnect:
         raw column name as that type in the query, regardless of the pandas/postgres/sql server automatic
         detection. **Will not override a custom table_schema, if inputted**
         :param days: if temp=True, the number of days that the temp table will be kept. Defaults to 7.
+        :param **kwargs: parameters to pass to pandas for read csv (ex. skiprows=1)
         :return:
         """
 
@@ -928,7 +929,7 @@ class DbConnect:
 
                 df = data.get_chunk(1000)
         else:
-            df = pd.read_csv(input_file, sep=sep)
+            df = pd.read_csv(input_file, sep=sep, **kwargs)
             allow_max = long_varchar_check and contains_long_columns(df)
 
         if 'ogc_fid' in df.columns:

--- a/pysqldb3/pysqldb3.py
+++ b/pysqldb3/pysqldb3.py
@@ -1108,7 +1108,7 @@ class DbConnect:
                 cols = []
                 for c in _:
                     if len(set(c[0]) - {' ', ':', '.'}) != len(set(c[0])):
-                        cols.append('"'+c[0]+'"'+' as '+c[0].strip().replace(' ', '_').replace('.', '_').replace(':', '_'))
+                        cols.append('"'+c[0]+'"'+' as '+c[0].strip().replace(' ', '_').replace('.', '_').replace(':', '_').replace('\n', '_'))
                     else:
                         cols.append(c[0])
                 cols = str(cols).replace("'", "")[1:-1]
@@ -1223,7 +1223,7 @@ class DbConnect:
             # Match previous styles
             cols = []
             for c in df.columns:
-                cols.append(c.strip().replace(' ', '_').replace('.', '_'))
+                cols.append(c.strip().replace(' ', '_').replace('.', '_').replace(':', '_').replace('\n', '_'))
             df.columns= cols
 
             if 'ogc_fid' in df.columns:
@@ -1243,7 +1243,10 @@ class DbConnect:
 
                     success = self._bulk_csv_to_table(input_file=temp_file, schema=schema, table=table,
                                                       table_schema=table_schema, days=days)
-                    os.remove(temp_file)
+                    try:
+                        os.remove(temp_file)
+                    except Exception as e:
+                        print(f'Could not remove temp file\n{e}')
 
                     if not success:
                         raise AssertionError('Bulk file loading failed.'.format(schema, table))

--- a/pysqldb3/pysqldb3.py
+++ b/pysqldb3/pysqldb3.py
@@ -1168,7 +1168,7 @@ class DbConnect:
         return True
 
     def xls_to_table(self, input_file=None, sheet_name=0, overwrite=False, schema=None, table=None, temp=True,
-                     column_type_overrides=None, days=7):
+                     column_type_overrides=None, days=7, **kwargs):
         """
         Imports xls/x file to database. This uses pandas datatypes to generate the table schema.
         :param input_file: File path to csv file; if None, prompts user input
@@ -1248,7 +1248,7 @@ class DbConnect:
 
                     df = pd.DataFrame(sheet_data[1:], columns=cols)
                 elif extension == 'xls':
-                    df = pd.read_excel(input_file, sheet_name=sheet_name)
+                    df = pd.read_excel(input_file, sheet_name=sheet_name, **kwargs)
 
                 # Replace with .xlsx of just the desired sheet
                 input_file = "C:\\Users\\{}\\Documents".format(getpass.getuser()) + "\\" + \
@@ -1275,7 +1275,6 @@ class DbConnect:
                     multi_sheet = len(ef.sheet_names) > 1
 
         # Try bulk input
-        if not multi_sheet and extension == 'xlsx' and not column_type_overrides:
             # Bulk input
             success = self._bulk_xlsx_to_table(input_file=input_file, schema=schema, table="stg_{}".format(table))
 
@@ -1324,7 +1323,7 @@ class DbConnect:
                 df = pd.DataFrame(sheet_data[1:], columns=cols)
 
             else:
-                df = pd.read_excel(input_file, sheet_name=sheet_name)
+                df = pd.read_excel(input_file, sheet_name=sheet_name, **kwargs)
 
             # Call dataframe_to_table fn
             self.dataframe_to_table(df, table, overwrite=overwrite, schema=schema, temp=temp,

--- a/pysqldb3/pysqldb3.py
+++ b/pysqldb3/pysqldb3.py
@@ -1320,13 +1320,15 @@ class DbConnect:
                 ';' (semicolon)
                 '\t' (tab)
                 ' ' (space)
-
             """)
 
         if quote_strings:
             OGR_QUOTE_STRINGS = 'IF_AMBIGUOUS'
         else:
             OGR_QUOTE_STRINGS = 'IF_NEEDED'
+
+        # escape double quote columns
+        query = query.replace('"', '\\"')
 
         if self.type == PG:
             cmd = WRITE_CSV_CMD_PG.format(

--- a/pysqldb3/pysqldb3.py
+++ b/pysqldb3/pysqldb3.py
@@ -947,7 +947,7 @@ class DbConnect:
                 temp_file = os.path.dirname(input_file)+'\\'f'_temp_data_{datetime.datetime.now().strftime("%Y%m%d%H%M%S")}.csv'
 
 
-                with pd.read_csv(input_file, chunksize=10 ** 15, **kwargs) as reader:
+                with pd.read_csv(input_file, chunksize=10 ** 15, sep=sep, **kwargs) as reader:
                     for chunk in reader:
                         chunk.to_csv(temp_file, mode='a', index=False, header=True)
 

--- a/pysqldb3/tests/helpers.py
+++ b/pysqldb3/tests/helpers.py
@@ -4,6 +4,7 @@ import pandas as pd
 import requests
 import zipfile
 import configparser
+import csv
 from xlrd import open_workbook
 from xlutils.copy import copy
 from zipfile import ZipFile
@@ -30,6 +31,17 @@ def set_up_test_csv():
 
     data['neighborhood'][0] = data['neighborhood'][0] * 500
     df.to_csv(os.path.dirname(os.path.abspath(__file__)) + "\\test_data\\varchar.csv", index=False, header=False)
+
+    # add csv with extra header line
+    data2 = [
+        ['header to skip', 'header to skip', 'header to skip'],
+        ['real_header1', 'real header2', 'real header 3'],
+        [1,2,3]
+    ]
+    with open(os.path.dirname(os.path.abspath(__file__)) + "\\test_data\\test4.csv", 'w', newline='') as csvfile:
+        w = csv.writer(csvfile, delimiter=',')
+        for row in data2:
+            w.writerow(row)
 
 
 def set_up_test_table_sql(sql, schema='dbo'):

--- a/pysqldb3/tests/helpers.py
+++ b/pysqldb3/tests/helpers.py
@@ -36,9 +36,20 @@ def set_up_test_csv():
     data2 = [
         ['header to skip', 'header to skip', 'header to skip'],
         ['real_header1', 'real header2', 'real header 3'],
-        [1,2,3]
+        [1, 2, 3],
+        [9, 9, 9]
     ]
+
     with open(os.path.dirname(os.path.abspath(__file__)) + "\\test_data\\test4.csv", 'w', newline='') as csvfile:
+        w = csv.writer(csvfile, delimiter=',')
+        for row in data2:
+            w.writerow(row)
+
+    # create bulk csv with extra header to skip
+    for i in range(1000):
+        data2.append([1, 2, 3])
+
+    with open(os.path.dirname(os.path.abspath(__file__)) + "\\test_data\\test5.csv", 'w', newline='') as csvfile:
         w = csv.writer(csvfile, delimiter=',')
         for row in data2:
             w.writerow(row)

--- a/pysqldb3/tests/helpers.py
+++ b/pysqldb3/tests/helpers.py
@@ -5,6 +5,7 @@ import requests
 import zipfile
 import configparser
 import csv
+import openpyxl
 from xlrd import open_workbook
 from xlutils.copy import copy
 from zipfile import ZipFile
@@ -317,7 +318,7 @@ def set_up_xls():
     if os.path.isfile(xls_file1):
         clean_up_file(xls_file1)
 
-    test_df1 = pd.DataFrame({'a': {0: 1, 1: 2}, 'b': {0: 3, 1: 4}, 'Unnamed: 0': {0: 0, 1: 1}})
+    test_df1 = pd.DataFrame({'a': {0: 1, 1: 2, 2:3}, 'b': {0: 3, 1: 4, 2:5}, 'Unnamed: 0': {0: 0, 1: 1, 2:6}})
     test_df1.to_excel(os.path.join(DIR, 'test_xls.xls'), index=False)
     print ('%s created\n' % os.path.basename(xls_file1))
 
@@ -341,3 +342,22 @@ def set_up_xls():
         row = 0
     w.save(xls_file2)
     print ('%s created\n' % os.path.basename(xls_file2))
+
+
+    # set up xls files for kwargs testing
+    wb = openpyxl.Workbook()
+    sheet = wb.active
+    c1 = sheet.cell(row=1, column=1)
+    c1.value = "skip me"
+    for c in range(1,4):
+        cell = sheet.cell(row=2, column=c)
+        cell.value = f'header {c}'
+        cell2 = sheet.cell(row=3, column=c)
+        cell2.value = c
+        cell3 = sheet.cell(row=3, column=c)
+        cell3.value = c+1
+
+    wb.save(DIR + "\\xls_kwargs_test.xls")
+    _df = pd.read_excel(DIR + "\\xls_kwargs_test.xls")
+    _df.to_excel(DIR + "\\xls_kwargs_test.xlsx", index=False)
+

--- a/pysqldb3/tests/test_csv_to_table.py
+++ b/pysqldb3/tests/test_csv_to_table.py
@@ -34,7 +34,7 @@ class TestCsvToTablePG:
 
     def test_csv_to_table_basic(self):
         # csv_to_table
-        db.query('drop table if exists working.{}'.format(create_table_name))
+        db.query('drop table if exists {}.{}'.format(pg_schema, create_table_name))
 
         fp = os.path.dirname(os.path.abspath(__file__)) + "\\test_data\\test.csv"
         db.csv_to_table(input_file=fp, table=create_table_name, schema=pg_schema)
@@ -84,7 +84,7 @@ class TestCsvToTablePG:
 
         # Check to see if table is in database
         assert db.table_exists(table=create_table_name, schema=pg_schema)
-        db_df = db.dfquery("select * from working.{}".format(create_table_name))
+        db_df = db.dfquery("select * from {}.{}".format(create_table_name))
 
         # Modify to make column types altered
         altered_column_type_df = pd.DataFrame([{'a': '1.0', 'b': 2, 'c': 3, 'd': 'text'}, {'a': '4.0', 'b': 5, 'c': 6, 'd': 'another'}])
@@ -109,7 +109,7 @@ class TestCsvToTablePG:
 
     def test_csv_to_table_separator(self):
         # csv_to_table
-        db.query('drop table if exists working.{}'.format(create_table_name))
+        db.query('drop table if exists {}.{}'.format(pg_schema, create_table_name))
 
         fp = os.path.dirname(os.path.abspath(__file__)) + "\\test_data\\test2.csv"
         db.csv_to_table(
@@ -120,7 +120,7 @@ class TestCsvToTablePG:
 
         # Check to see if table is in database
         assert db.table_exists(table=create_table_name, schema=pg_schema)
-        db_df = db.dfquery("select * from working.{}".format(create_table_name))
+        db_df = db.dfquery("select * from {}.{}".format(pg_schema, create_table_name))
 
         # Get csv df via pd.read_csv
         csv_df = pd.read_csv(fp, sep='|')
@@ -135,7 +135,7 @@ class TestCsvToTablePG:
     # what if the table has no header?
     def test_csv_to_table_no_header(self):
         # csv_to_table
-        db.query('drop table if exists working.{}'.format(create_table_name))
+        db.query('drop table if exists {}.{}'.format(pg_schema,create_table_name))
 
         fp = os.path.dirname(os.path.abspath(__file__)) + "\\test_data\\test3.csv"
         db.csv_to_table(
@@ -144,7 +144,7 @@ class TestCsvToTablePG:
 
         # did it enter the db correctly?
         assert db.table_exists(table=create_table_name, schema=pg_schema)
-        db_df = db.dfquery("select * from working.{}".format(create_table_name))
+        db_df = db.dfquery("select * from {}.{}".format(pg_schema, create_table_name))
 
         # Get csv df via pd.read_csv
         csv_df = pd.read_csv(fp, sep='|')
@@ -160,7 +160,7 @@ class TestCsvToTablePG:
 
     def test_csv_to_table_overwrite(self):
         # Make a table to fill the eventual table location and confirm it exists
-        db.query('create table working.{} as select 10'.format(create_table_name))
+        db.query('create table {}.{} as select 10'.format(pg_schema, create_table_name))
         assert db.table_exists(table=create_table_name, schema=pg_schema)
 
         # csv_to_table
@@ -169,7 +169,7 @@ class TestCsvToTablePG:
 
         # Check to see if table is in database
         assert db.table_exists(table=create_table_name, schema=pg_schema)
-        db_df = db.dfquery("select * from working.{}".format(create_table_name))
+        db_df = db.dfquery("select * from {}.{}".format(pg_schema, create_table_name))
 
         # Get csv df via pd.read_csv
         csv_df = pd.read_csv(fp)
@@ -183,7 +183,7 @@ class TestCsvToTablePG:
 
     def test_csv_to_table_long_column(self):
         # csv_to_table
-        db.query('drop table if exists working.{}'.format(create_table_name))
+        db.query('drop table if exists {}.{}'.format(pg_schema, create_table_name))
 
         base_string = 'text'*150
         fp = os.path.dirname(os.path.abspath(__file__)) + "\\test_data\\varchar.csv"
@@ -192,7 +192,7 @@ class TestCsvToTablePG:
 
         # Check to see if table is in database
         assert db.table_exists(table=create_table_name, schema=pg_schema)
-        db_df = db.dfquery("select * from working.{}".format(create_table_name))
+        db_df = db.dfquery("select * from {}.{}".format(pg_schema, create_table_name))
 
         # Get csv df via pd.read_csv
         csv_df = pd.read_csv(fp)
@@ -219,7 +219,7 @@ class TestBulkCSVToTablePG:
 
     def test_bulk_csv_to_table_basic(self):
         # bulk_csv_to_table
-        db.query('drop table if exists working.{}'.format(create_table_name))
+        db.query('drop table if exists {}.{}'.format(pg_schema, create_table_name))
 
         fp = os.path.dirname(os.path.abspath(__file__)) + "\\test_data\\test.csv"
         input_schema = db.dataframe_to_table_schema(df=pd.read_csv(fp), table=create_table_name, schema=pg_schema)
@@ -227,7 +227,7 @@ class TestBulkCSVToTablePG:
 
         # Check to see if table is in database
         assert db.table_exists(table=create_table_name, schema=pg_schema)
-        db_df = db.dfquery("select * from working.{}".format(create_table_name))
+        db_df = db.dfquery("select * from {}.{}".format(pg_schema, create_table_name))
 
         # Get csv df via pd.read_csv
         csv_df = pd.read_csv(fp)
@@ -295,258 +295,280 @@ class TestBulkCSVToTablePG:
         db.cleanup_new_tables()
 
 
-# class TestCsvToTableMS:
-#     @classmethod
-#     def setup_class(cls):
-#         return
-#
-#     def test_csv_to_table_basic(self):
-#         # csv_to_table
-#         if sql.table_exists(schema=sql_schema, table=create_table_name):
-#             sql.query('drop table dbo.{}'.format(create_table_name))
-#
-#         fp = os.path.dirname(os.path.abspath(__file__)) + "\\test_data\\test.csv"
-#         sql.csv_to_table(input_file=fp, table=create_table_name, schema=sql_schema)
-#
-#         # Check to see if table is in database
-#         assert sql.table_exists(table=create_table_name, schema=sql_schema)
-#         sql_df = sql.dfquery("select * from dbo.{}".format(create_table_name))
-#
-#         # Get csv df via pd.read_csv
-#         csv_df = pd.read_csv(fp)
-#         csv_df.columns = [c.replace(' ', '_') for c in list(csv_df.columns)]  # TODO: look into this difference
-#
-#         # Assert df equality, including dtypes and columns
-#         pd.testing.assert_frame_equal(sql_df, csv_df)
-#
-#         # Cleanup
-#         sql.drop_table(schema=sql_schema, table=create_table_name)
-#
-#     def test_csv_to_table_column_override(self):
-#         sql.drop_table(schema=sql_schema, table=create_table_name)
-#
-#         fp = os.path.dirname(os.path.abspath(__file__)) + "\\test_data\\csv_override_ex.csv"
-#         test_df = pd.DataFrame([{'a': 1, 'b': 2, 'c': 3, 'd': 'text'}, {'a': 4, 'b': 5, 'c': 6, 'd': 'another'}])
-#         test_df.to_csv(fp)
-#         sql.csv_to_table(input_file=fp, table=create_table_name, schema=sql_schema,
-#                          column_type_overrides={'a': 'numeric'})
-#
-#         # Check to see if table is in database
-#         assert sql.table_exists(table=create_table_name, schema=sql_schema)
-#
-#         # Assert df column types match override
-#         pd.testing.assert_frame_equal(pd.DataFrame(
-#             [{"column_name": 'a', "data_type": 'numeric'}, {"column_name": 'b', "data_type": 'bigint'},
-#              {"column_name": 'c', "data_type": 'bigint'}, {"column_name": 'd', "data_type": 'varchar'}]),
-#                                       sql.dfquery("""
-#                                             select distinct column_name, data_type
-#                                             from information_schema.columns
-#                                             where table_name = '{}' and lower(column_name) not like '%unnamed%';
-#                                       """.format(create_table_name))
-#                                       )
-#
-#         # Cleanup
-#         sql.drop_table(schema=sql_schema, table=create_table_name)
-#         os.remove(fp)
-#
-#     def test_csv_to_table_separator(self):
-#         # csv_to_table
-#         if sql.table_exists(schema=sql_schema, table=create_table_name):
-#             sql.query('drop table dbo.{}'.format(create_table_name))
-#
-#         fp = os.path.dirname(os.path.abspath(__file__)) + "\\test_data\\test2.csv"
-#         sql.csv_to_table(
-#             input_file=fp,
-#             table=create_table_name, schema=sql_schema,
-#             sep="|"
-#         )
-#
-#         # Check to see if table is in database
-#         assert sql.table_exists(table=create_table_name, schema=sql_schema)
-#         sql_df = sql.dfquery("select * from dbo.{}".format(create_table_name))
-#
-#         # Get csv df via pd.read_csv
-#         csv_df = pd.read_csv(fp, sep='|')
-#         csv_df.columns = [c.replace(' ', '_') for c in list(csv_df.columns)]  # TODO: look into this difference
-#
-#         # Assert df equality, including dtypes and columns
-#         pd.testing.assert_frame_equal(sql_df, csv_df)
-#
-#         # Cleanup
-#         sql.drop_table(schema=sql_schema, table=create_table_name)
-#
-#     # what if the table has no header?
-#     def test_csv_to_table_no_header(self):
-#         # csv_to_table
-#         if sql.table_exists(schema=sql_schema, table=create_table_name):
-#             sql.query('drop table dbo.{}'.format(create_table_name))
-#
-#         fp = os.path.dirname(os.path.abspath(__file__)) + "\\test_data\\test3.csv"
-#         sql.csv_to_table(
-#             input_file=fp,
-#             table=create_table_name, schema=sql_schema, sep="|")
-#
-#         # did it enter the db correctly?
-#         assert sql.table_exists(table=create_table_name, schema=sql_schema)
-#         sql_df = sql.dfquery("select * from dbo.{}".format(create_table_name))
-#
-#         # Get csv df via pd.read_csv
-#         csv_df = pd.read_csv(fp, sep='|')
-#         csv_df.columns = [c.replace(' ', '_') for c in list(csv_df.columns)]  # TODO: look into this difference
-#         csv_df.columns = [c.replace('.', '') for c in list(csv_df.columns)]
-#         csv_df.columns = [c.lower() for c in list(csv_df.columns)]
-#
-#         # Assert df equality, including dtypes and columns
-#         pd.testing.assert_frame_equal(sql_df, csv_df)
-#
-#         # Cleanup
-#         sql.drop_table(schema=sql_schema, table=create_table_name)
-#
-#     def test_csv_to_table_overwrite(self):
-#         if sql.table_exists(schema=sql_schema, table=create_table_name):
-#             sql.query('drop table dbo.{}'.format(create_table_name))
-#
-#         # Make a table to fill the eventual table location and confirm it exists
-#         # Add test_table
-#         sql.query("""
-#         create table dbo.{} (test_col1 int, test_col2 int, geom geometry);
-#         insert into dbo.{} VALUES(1, 2, geometry::Point(985831.79200444, 203371.60461367, 2263));
-#         insert into dbo.{} VALUES(3, 4, geometry::Point(985831.79200444, 203371.60461367, 2263));
-#         """.format(create_table_name, create_table_name, create_table_name))
-#         assert sql.table_exists(table=create_table_name, schema=sql_schema)
-#
-#         # csv_to_table
-#         fp = os.path.dirname(os.path.abspath(__file__)) + "\\test_data\\test.csv"
-#         sql.csv_to_table(input_file=fp, table=create_table_name, schema=sql_schema, overwrite=True)
-#
-#         # Check to see if table is in database
-#         assert sql.table_exists(table=create_table_name, schema=sql_schema)
-#         sql_df = sql.dfquery("select * from dbo.{}".format(create_table_name))
-#
-#         # Get csv df via pd.read_csv
-#         csv_df = pd.read_csv(fp)
-#         csv_df.columns = [c.replace(' ', '_') for c in list(csv_df.columns)]  # TODO: look into this difference
-#         csv_df.columns = [c.replace('.', '') for c in list(csv_df.columns)]
-#         csv_df.columns = [c.lower() for c in list(csv_df.columns)]
-#
-#         # Assert df equality, including dtypes and columns
-#         pd.testing.assert_frame_equal(sql_df, csv_df)
-#
-#         # Cleanup
-#         sql.drop_table(schema=sql_schema, table=create_table_name)
-#
-#     # Temp test is in logging tests
-#
-#     def test_csv_to_table_long_column(self):
-#         # csv_to_table
-#         if sql.table_exists(schema=sql_schema, table=create_table_name):
-#             sql.drop_table(schema=sql_schema, table=create_table_name)
-#
-#         base_string = 'text'*150
-#         fp = os.path.dirname(os.path.abspath(__file__)) + "\\test_data\\varchar.csv"
-#         sql.dfquery("select '{}' as long_col".format(base_string)).to_csv(fp, index=False)
-#         sql.csv_to_table(input_file=fp, table=create_table_name, schema=sql_schema, long_varchar_check=True)
-#
-#         # Check to see if table is in database
-#         assert sql.table_exists(table=create_table_name, schema=sql_schema)
-#         sql_df = sql.dfquery("select * from dbo.{}".format(create_table_name))
-#
-#         # Get csv df via pd.read_csv
-#         csv_df = pd.read_csv(fp)
-#         csv_df.columns = [c.replace(' ', '_') for c in list(csv_df.columns)]  # TODO: look into this difference
-#
-#         # Confirm long columns are not truncated and are equal with table from long_varchar_check=True
-#         pd.testing.assert_frame_equal(sql_df, csv_df)
-#
-#         # Cleanup
-#         sql.drop_table(schema=sql_schema, table=create_table_name)
-#
-#     @classmethod
-#     def teardown_class(cls):
-#         sql.cleanup_new_tables()
-#
-#
-# class TestBulkCSVToTableMS:
-#     @classmethod
-#     def setup_class(cls):
-#         return
-#
-#     def test_bulk_csv_to_table_basic(self):
-#         # bulk_csv_to_table
-#         if sql.drop_table(schema=sql_schema, table=create_table_name):
-#             sql.query('drop table dbo.{}'.format(create_table_name))
-#
-#         fp = os.path.dirname(os.path.abspath(__file__)) + "\\test_data\\test.csv"
-#         input_schema = sql.dataframe_to_table_schema(df=pd.read_csv(fp), table=create_table_name, schema=sql_schema)
-#         sql._bulk_csv_to_table(input_file=fp, table=create_table_name, schema=sql_schema, table_schema=input_schema)
-#
-#         # Check to see if table is in database
-#         assert sql.table_exists(table=create_table_name, schema=sql_schema)
-#         sql_df = sql.dfquery("select * from dbo.{}".format(create_table_name))
-#
-#         # Get csv df via pd.read_csv
-#         csv_df = pd.read_csv(fp)
-#         csv_df.columns = [c.replace(' ', '_') for c in list(csv_df.columns)]  # TODO: look into this difference
-#
-#         # Assert df equality, including dtypes and columns
-#         pd.testing.assert_frame_equal(sql_df, csv_df)
-#
-#         # Cleanup
-#         sql.drop_table(schema=sql_schema, table=create_table_name)
-#
-#     def test_bulk_csv_to_table_default_schema(self):
-#         # bulk_csv_to_table
-#         if sql.table_exists(table=create_table_name):
-#             sql.query('drop table {}'.format(create_table_name))
-#
-#         fp = os.path.dirname(os.path.abspath(__file__)) + "\\test_data\\test.csv"
-#         input_schema = sql.dataframe_to_table_schema(df=pd.read_csv(fp), table=create_table_name)
-#         sql._bulk_csv_to_table(input_file=fp, table=create_table_name, table_schema=input_schema)
-#
-#         # Check to see if table is in database
-#         # This example is linked to the mssql default server bug
-#         assert sql.table_exists(table=create_table_name)
-#         sql_df = sql.dfquery("select * from {}".format(create_table_name))
-#
-#         # Get csv df via pd.read_csv
-#         csv_df = pd.read_csv(fp)
-#         csv_df.columns = [c.replace(' ', '_') for c in list(csv_df.columns)]  # TODO: look into this difference
-#
-#         # Assert df equality, including dtypes and columns
-#         pd.testing.assert_frame_equal(sql_df, csv_df)
-#
-#         # Cleanup
-#         sql.drop_table(schema=sql.default_schema, table=create_table_name)
-#
-#     def test_bulk_csv_to_table_long_column(self):
-#         # csv_to_table
-#         if sql.table_exists(schema=sql_schema, table=create_table_name):
-#             sql.drop_table(schema=sql_schema, table=create_table_name)
-#
-#         fp = os.path.dirname(os.path.abspath(__file__)) + "\\test_data\\varchar.csv"
-#         pd.DataFrame(['text'*150]*10000, columns=['long_column']).to_csv(fp)
-#         sql.csv_to_table(input_file=fp, table=create_table_name, schema=sql_schema, long_varchar_check=True)
-#
-#         # Check to see if table is in database
-#         assert sql.table_exists(table=create_table_name, schema=sql_schema)
-#         sql_df = sql.dfquery("select * from dbo.{}".format(create_table_name))
-#
-#         # Get csv df via pd.read_csv
-#         csv_df = pd.read_csv(fp)
-#         csv_df.columns = [c.replace(' ', '_') for c in list(csv_df.columns)]  # TODO: look into this difference
-#
-#         # Confirm long columns are not truncated and are equal with table from long_varchar_check=True
-#         pd.testing.assert_frame_equal(sql_df[['long_column']], csv_df[['long_column']])
-#
-#         # Cleanup
-#         sql.drop_table(schema=sql_schema, table=create_table_name)
-#
-#     def test_bulk_csv_to_table_input_schema(self):
-#         # Test input schema
-#         return
-#
-#     # Temp test is in logging tests
-#
-#     @classmethod
-#     def teardown_class(cls):
-#         sql.cleanup_new_tables()
+class TestCsvToTableMS:
+    @classmethod
+    def setup_class(cls):
+        return
+
+    def test_csv_to_table_basic(self):
+        # csv_to_table
+        if sql.table_exists(schema=sql_schema, table=create_table_name):
+            sql.query('drop table {}.{}'.format(sql_schema, create_table_name))
+
+        fp = os.path.dirname(os.path.abspath(__file__)) + "\\test_data\\test.csv"
+        sql.csv_to_table(input_file=fp, table=create_table_name, schema=sql_schema)
+
+        # Check to see if table is in database
+        assert sql.table_exists(table=create_table_name, schema=sql_schema)
+        sql_df = sql.dfquery("select * from {}.{}".format(sql_schema, create_table_name))
+
+        # Get csv df via pd.read_csv
+        csv_df = pd.read_csv(fp)
+        csv_df.columns = [c.replace(' ', '_') for c in list(csv_df.columns)]  # TODO: look into this difference
+
+        # Assert df equality, including dtypes and columns
+        pd.testing.assert_frame_equal(sql_df, csv_df)
+
+        # Cleanup
+        sql.drop_table(schema=sql_schema, table=create_table_name)
+
+    def test_csv_to_table_basic_skip_rows(self):
+        # csv_to_table
+        sql.query('drop table if exists {}.{}'.format(sql_schema, create_table_name))
+
+        fp = os.path.dirname(os.path.abspath(__file__)) + "\\test_data\\test4.csv"
+        sql.csv_to_table(input_file=fp, table=create_table_name, schema=sql_schema,
+                        skiprows=1)
+
+        # Check to see if table is in database
+        assert sql.table_exists(table=create_table_name, schema=sql_schema)
+        db_df = sql.dfquery("select * from {}.{}".format(sql_schema, create_table_name))
+
+        # Get csv df via pd.read_csv
+        csv_df = pd.read_csv(fp, skiprows=1)
+        csv_df.columns = [c.replace(' ', '_') for c in list(csv_df.columns)]  # TODO: look into this difference
+
+        # Assert df equality, including dtypes and columns
+        pd.testing.assert_frame_equal(db_df, csv_df)
+
+        # Cleanup
+        sql.drop_table(schema=sql_schema, table=create_table_name)
+
+    def test_csv_to_table_column_override(self):
+        sql.drop_table(schema=sql_schema, table=create_table_name)
+
+        fp = os.path.dirname(os.path.abspath(__file__)) + "\\test_data\\csv_override_ex.csv"
+        test_df = pd.DataFrame([{'a': 1, 'b': 2, 'c': 3, 'd': 'text'}, {'a': 4, 'b': 5, 'c': 6, 'd': 'another'}])
+        test_df.to_csv(fp)
+        sql.csv_to_table(input_file=fp, table=create_table_name, schema=sql_schema,
+                         column_type_overrides={'a': 'numeric'})
+
+        # Check to see if table is in database
+        assert sql.table_exists(table=create_table_name, schema=sql_schema)
+
+        # Assert df column types match override
+        pd.testing.assert_frame_equal(pd.DataFrame(
+            [{"column_name": 'a', "data_type": 'numeric'}, {"column_name": 'b', "data_type": 'bigint'},
+             {"column_name": 'c', "data_type": 'bigint'}, {"column_name": 'd', "data_type": 'varchar'}]),
+                                      sql.dfquery("""
+                                            select distinct column_name, data_type
+                                            from information_schema.columns
+                                            where table_name = '{}' and lower(column_name) not like '%unnamed%';
+                                      """.format(create_table_name))
+                                      )
+
+        # Cleanup
+        sql.drop_table(schema=sql_schema, table=create_table_name)
+        os.remove(fp)
+
+    def test_csv_to_table_separator(self):
+        # csv_to_table
+        if sql.table_exists(schema=sql_schema, table=create_table_name):
+            sql.query('drop table {}.{}'.format(sql_schema, create_table_name))
+
+        fp = os.path.dirname(os.path.abspath(__file__)) + "\\test_data\\test2.csv"
+        sql.csv_to_table(
+            input_file=fp,
+            table=create_table_name, schema=sql_schema,
+            sep="|"
+        )
+
+        # Check to see if table is in database
+        assert sql.table_exists(table=create_table_name, schema=sql_schema)
+        sql_df = sql.dfquery("select * from {}.{}".format(sql_schema, create_table_name))
+
+        # Get csv df via pd.read_csv
+        csv_df = pd.read_csv(fp, sep='|')
+        csv_df.columns = [c.replace(' ', '_') for c in list(csv_df.columns)]  # TODO: look into this difference
+
+        # Assert df equality, including dtypes and columns
+        pd.testing.assert_frame_equal(sql_df, csv_df)
+
+        # Cleanup
+        sql.drop_table(schema=sql_schema, table=create_table_name)
+
+    # what if the table has no header?
+    def test_csv_to_table_no_header(self):
+        # csv_to_table
+        if sql.table_exists(schema=sql_schema, table=create_table_name):
+            sql.query('drop table {}.{}'.format(sql_schema, create_table_name))
+
+        fp = os.path.dirname(os.path.abspath(__file__)) + "\\test_data\\test3.csv"
+        sql.csv_to_table(
+            input_file=fp,
+            table=create_table_name, schema=sql_schema, sep="|")
+
+        # did it enter the db correctly?
+        assert sql.table_exists(table=create_table_name, schema=sql_schema)
+        sql_df = sql.dfquery("select * from {}.{}".format(sql_schema, create_table_name))
+
+        # Get csv df via pd.read_csv
+        csv_df = pd.read_csv(fp, sep='|')
+        csv_df.columns = [c.replace(' ', '_') for c in list(csv_df.columns)]  # TODO: look into this difference
+        csv_df.columns = [c.replace('.', '') for c in list(csv_df.columns)]
+        csv_df.columns = [c.lower() for c in list(csv_df.columns)]
+
+        # Assert df equality, including dtypes and columns
+        pd.testing.assert_frame_equal(sql_df, csv_df)
+
+        # Cleanup
+        sql.drop_table(schema=sql_schema, table=create_table_name)
+
+    def test_csv_to_table_overwrite(self):
+        if sql.table_exists(schema=sql_schema, table=create_table_name):
+            sql.query('drop table {}.{}'.format(sql_schema, create_table_name))
+
+        # Make a table to fill the eventual table location and confirm it exists
+        # Add test_table
+        sql.query("""
+        create table {s}.{t} (test_col1 int, test_col2 int, geom geometry);
+        insert into {s}.{t} VALUES(1, 2, geometry::Point(985831.79200444, 203371.60461367, 2263));
+        insert into {s}.{t} VALUES(3, 4, geometry::Point(985831.79200444, 203371.60461367, 2263));
+        """.format(s=sql_schema, t=create_table_name))
+        assert sql.table_exists(table=create_table_name, schema=sql_schema)
+
+        # csv_to_table
+        fp = os.path.dirname(os.path.abspath(__file__)) + "\\test_data\\test.csv"
+        sql.csv_to_table(input_file=fp, table=create_table_name, schema=sql_schema, overwrite=True)
+
+        # Check to see if table is in database
+        assert sql.table_exists(table=create_table_name, schema=sql_schema)
+        sql_df = sql.dfquery("select * from {}.{}".format(sql_schema, create_table_name))
+
+        # Get csv df via pd.read_csv
+        csv_df = pd.read_csv(fp)
+        csv_df.columns = [c.replace(' ', '_') for c in list(csv_df.columns)]  # TODO: look into this difference
+        csv_df.columns = [c.replace('.', '') for c in list(csv_df.columns)]
+        csv_df.columns = [c.lower() for c in list(csv_df.columns)]
+
+        # Assert df equality, including dtypes and columns
+        pd.testing.assert_frame_equal(sql_df, csv_df)
+
+        # Cleanup
+        sql.drop_table(schema=sql_schema, table=create_table_name)
+
+    # Temp test is in logging tests
+
+    def test_csv_to_table_long_column(self):
+        # csv_to_table
+        if sql.table_exists(schema=sql_schema, table=create_table_name):
+            sql.drop_table(schema=sql_schema, table=create_table_name)
+
+        base_string = 'text'*150
+        fp = os.path.dirname(os.path.abspath(__file__)) + "\\test_data\\varchar.csv"
+        sql.dfquery("select '{}' as long_col".format(base_string)).to_csv(fp, index=False)
+        sql.csv_to_table(input_file=fp, table=create_table_name, schema=sql_schema, long_varchar_check=True)
+
+        # Check to see if table is in database
+        assert sql.table_exists(table=create_table_name, schema=sql_schema)
+        sql_df = sql.dfquery("select * from {}.{}".format(sql_schema, create_table_name))
+
+        # Get csv df via pd.read_csv
+        csv_df = pd.read_csv(fp)
+        csv_df.columns = [c.replace(' ', '_') for c in list(csv_df.columns)]  # TODO: look into this difference
+
+        # Confirm long columns are not truncated and are equal with table from long_varchar_check=True
+        pd.testing.assert_frame_equal(sql_df, csv_df)
+
+        # Cleanup
+        sql.drop_table(schema=sql_schema, table=create_table_name)
+
+    @classmethod
+    def teardown_class(cls):
+        sql.cleanup_new_tables()
+
+
+class TestBulkCSVToTableMS:
+    @classmethod
+    def setup_class(cls):
+        return
+
+    def test_bulk_csv_to_table_basic(self):
+        # bulk_csv_to_table
+        if sql.drop_table(schema=sql_schema, table=create_table_name):
+            sql.query('drop table {}.{}'.format(sql_schema, create_table_name))
+
+        fp = os.path.dirname(os.path.abspath(__file__)) + "\\test_data\\test.csv"
+        input_schema = sql.dataframe_to_table_schema(df=pd.read_csv(fp), table=create_table_name, schema=sql_schema)
+        sql._bulk_csv_to_table(input_file=fp, table=create_table_name, schema=sql_schema, table_schema=input_schema)
+
+        # Check to see if table is in database
+        assert sql.table_exists(table=create_table_name, schema=sql_schema)
+        sql_df = sql.dfquery("select * from {}.{}".format(sql_schema, create_table_name))
+
+        # Get csv df via pd.read_csv
+        csv_df = pd.read_csv(fp)
+        csv_df.columns = [c.replace(' ', '_') for c in list(csv_df.columns)]  # TODO: look into this difference
+
+        # Assert df equality, including dtypes and columns
+        pd.testing.assert_frame_equal(sql_df, csv_df)
+
+        # Cleanup
+        sql.drop_table(schema=sql_schema, table=create_table_name)
+
+    def test_bulk_csv_to_table_default_schema(self):
+        # bulk_csv_to_table
+        if sql.table_exists(table=create_table_name):
+            sql.query('drop table {}'.format(create_table_name))
+
+        fp = os.path.dirname(os.path.abspath(__file__)) + "\\test_data\\test.csv"
+        input_schema = sql.dataframe_to_table_schema(df=pd.read_csv(fp), table=create_table_name)
+        sql._bulk_csv_to_table(input_file=fp, table=create_table_name, table_schema=input_schema)
+
+        # Check to see if table is in database
+        # This example is linked to the mssql default server bug
+        assert sql.table_exists(table=create_table_name)
+        sql_df = sql.dfquery("select * from {}".format(create_table_name))
+
+        # Get csv df via pd.read_csv
+        csv_df = pd.read_csv(fp)
+        csv_df.columns = [c.replace(' ', '_') for c in list(csv_df.columns)]  # TODO: look into this difference
+
+        # Assert df equality, including dtypes and columns
+        pd.testing.assert_frame_equal(sql_df, csv_df)
+
+        # Cleanup
+        sql.drop_table(schema=sql.default_schema, table=create_table_name)
+
+    def test_bulk_csv_to_table_long_column(self):
+        # csv_to_table
+        if sql.table_exists(schema=sql_schema, table=create_table_name):
+            sql.drop_table(schema=sql_schema, table=create_table_name)
+
+        fp = os.path.dirname(os.path.abspath(__file__)) + "\\test_data\\varchar.csv"
+        pd.DataFrame(['text'*150]*10000, columns=['long_column']).to_csv(fp)
+        sql.csv_to_table(input_file=fp, table=create_table_name, schema=sql_schema, long_varchar_check=True)
+
+        # Check to see if table is in database
+        assert sql.table_exists(table=create_table_name, schema=sql_schema)
+        sql_df = sql.dfquery("select * from {}.{}".format(sql_schema, create_table_name))
+
+        # Get csv df via pd.read_csv
+        csv_df = pd.read_csv(fp)
+        csv_df.columns = [c.replace(' ', '_') for c in list(csv_df.columns)]  # TODO: look into this difference
+
+        # Confirm long columns are not truncated and are equal with table from long_varchar_check=True
+        pd.testing.assert_frame_equal(sql_df[['long_column']], csv_df[['long_column']])
+
+        # Cleanup
+        sql.drop_table(schema=sql_schema, table=create_table_name)
+
+    def test_bulk_csv_to_table_input_schema(self):
+        # Test input schema
+        return
+
+    # Temp test is in logging tests
+
+    @classmethod
+    def teardown_class(cls):
+        sql.cleanup_new_tables()

--- a/pysqldb3/tests/test_csv_to_table.py
+++ b/pysqldb3/tests/test_csv_to_table.py
@@ -15,11 +15,11 @@ db = pysqldb.DbConnect(type=config.get('PG_DB', 'TYPE'),
                        user=config.get('PG_DB', 'DB_USER'),
                        password=config.get('PG_DB', 'DB_PASSWORD'))
 
-sql = pysqldb.DbConnect(type=config.get('SQL_DB', 'TYPE'),
-                        server=config.get('SQL_DB', 'SERVER'),
-                        database=config.get('SQL_DB', 'DB_NAME'),
-                        user=config.get('SQL_DB', 'DB_USER'),
-                        password=config.get('SQL_DB', 'DB_PASSWORD'))
+# sql = pysqldb.DbConnect(type=config.get('SQL_DB', 'TYPE'),
+#                         server=config.get('SQL_DB', 'SERVER'),
+#                         database=config.get('SQL_DB', 'DB_NAME'),
+#                         user=config.get('SQL_DB', 'DB_USER'),
+#                         password=config.get('SQL_DB', 'DB_PASSWORD'))
 
 pg_table_name = 'pg_test_table_{}'.format(db.user)
 create_table_name = 'sample_acs_test_csv_to_table_{}'.format(db.user)
@@ -41,10 +41,32 @@ class TestCsvToTablePG:
 
         # Check to see if table is in database
         assert db.table_exists(table=create_table_name, schema=pg_schema)
-        db_df = db.dfquery("select * from working.{}".format(create_table_name))
+        db_df = db.dfquery("select * from {}.{}".format(pg_schema, create_table_name))
 
         # Get csv df via pd.read_csv
         csv_df = pd.read_csv(fp)
+        csv_df.columns = [c.replace(' ', '_') for c in list(csv_df.columns)]  # TODO: look into this difference
+
+        # Assert df equality, including dtypes and columns
+        pd.testing.assert_frame_equal(db_df, csv_df)
+
+        # Cleanup
+        db.drop_table(schema=pg_schema, table=create_table_name)
+
+    def test_csv_to_table_basic_skip_rows(self):
+        # csv_to_table
+        db.query('drop table if exists {}.{}'.format(pg_schema, create_table_name))
+
+        fp = os.path.dirname(os.path.abspath(__file__)) + "\\test_data\\test4.csv"
+        db.csv_to_table(input_file=fp, table=create_table_name, schema=pg_schema,
+                        skiprows=1)
+
+        # Check to see if table is in database
+        assert db.table_exists(table=create_table_name, schema=pg_schema)
+        db_df = db.dfquery("select * from {}.{}".format(pg_schema, create_table_name))
+
+        # Get csv df via pd.read_csv
+        csv_df = pd.read_csv(fp, skiprows=1)
         csv_df.columns = [c.replace(' ', '_') for c in list(csv_df.columns)]  # TODO: look into this difference
 
         # Assert df equality, including dtypes and columns
@@ -273,258 +295,258 @@ class TestBulkCSVToTablePG:
         db.cleanup_new_tables()
 
 
-class TestCsvToTableMS:
-    @classmethod
-    def setup_class(cls):
-        return
-
-    def test_csv_to_table_basic(self):
-        # csv_to_table
-        if sql.table_exists(schema=sql_schema, table=create_table_name):
-            sql.query('drop table dbo.{}'.format(create_table_name))
-
-        fp = os.path.dirname(os.path.abspath(__file__)) + "\\test_data\\test.csv"
-        sql.csv_to_table(input_file=fp, table=create_table_name, schema=sql_schema)
-
-        # Check to see if table is in database
-        assert sql.table_exists(table=create_table_name, schema=sql_schema)
-        sql_df = sql.dfquery("select * from dbo.{}".format(create_table_name))
-
-        # Get csv df via pd.read_csv
-        csv_df = pd.read_csv(fp)
-        csv_df.columns = [c.replace(' ', '_') for c in list(csv_df.columns)]  # TODO: look into this difference
-
-        # Assert df equality, including dtypes and columns
-        pd.testing.assert_frame_equal(sql_df, csv_df)
-
-        # Cleanup
-        sql.drop_table(schema=sql_schema, table=create_table_name)
-
-    def test_csv_to_table_column_override(self):
-        sql.drop_table(schema=sql_schema, table=create_table_name)
-
-        fp = os.path.dirname(os.path.abspath(__file__)) + "\\test_data\\csv_override_ex.csv"
-        test_df = pd.DataFrame([{'a': 1, 'b': 2, 'c': 3, 'd': 'text'}, {'a': 4, 'b': 5, 'c': 6, 'd': 'another'}])
-        test_df.to_csv(fp)
-        sql.csv_to_table(input_file=fp, table=create_table_name, schema=sql_schema,
-                         column_type_overrides={'a': 'numeric'})
-
-        # Check to see if table is in database
-        assert sql.table_exists(table=create_table_name, schema=sql_schema)
-
-        # Assert df column types match override
-        pd.testing.assert_frame_equal(pd.DataFrame(
-            [{"column_name": 'a', "data_type": 'numeric'}, {"column_name": 'b', "data_type": 'bigint'},
-             {"column_name": 'c', "data_type": 'bigint'}, {"column_name": 'd', "data_type": 'varchar'}]),
-                                      sql.dfquery("""
-                                            select distinct column_name, data_type
-                                            from information_schema.columns
-                                            where table_name = '{}' and lower(column_name) not like '%unnamed%';
-                                      """.format(create_table_name))
-                                      )
-
-        # Cleanup
-        sql.drop_table(schema=sql_schema, table=create_table_name)
-        os.remove(fp)
-
-    def test_csv_to_table_separator(self):
-        # csv_to_table
-        if sql.table_exists(schema=sql_schema, table=create_table_name):
-            sql.query('drop table dbo.{}'.format(create_table_name))
-
-        fp = os.path.dirname(os.path.abspath(__file__)) + "\\test_data\\test2.csv"
-        sql.csv_to_table(
-            input_file=fp,
-            table=create_table_name, schema=sql_schema,
-            sep="|"
-        )
-
-        # Check to see if table is in database
-        assert sql.table_exists(table=create_table_name, schema=sql_schema)
-        sql_df = sql.dfquery("select * from dbo.{}".format(create_table_name))
-
-        # Get csv df via pd.read_csv
-        csv_df = pd.read_csv(fp, sep='|')
-        csv_df.columns = [c.replace(' ', '_') for c in list(csv_df.columns)]  # TODO: look into this difference
-
-        # Assert df equality, including dtypes and columns
-        pd.testing.assert_frame_equal(sql_df, csv_df)
-
-        # Cleanup
-        sql.drop_table(schema=sql_schema, table=create_table_name)
-
-    # what if the table has no header?
-    def test_csv_to_table_no_header(self):
-        # csv_to_table
-        if sql.table_exists(schema=sql_schema, table=create_table_name):
-            sql.query('drop table dbo.{}'.format(create_table_name))
-
-        fp = os.path.dirname(os.path.abspath(__file__)) + "\\test_data\\test3.csv"
-        sql.csv_to_table(
-            input_file=fp,
-            table=create_table_name, schema=sql_schema, sep="|")
-
-        # did it enter the db correctly?
-        assert sql.table_exists(table=create_table_name, schema=sql_schema)
-        sql_df = sql.dfquery("select * from dbo.{}".format(create_table_name))
-
-        # Get csv df via pd.read_csv
-        csv_df = pd.read_csv(fp, sep='|')
-        csv_df.columns = [c.replace(' ', '_') for c in list(csv_df.columns)]  # TODO: look into this difference
-        csv_df.columns = [c.replace('.', '') for c in list(csv_df.columns)]
-        csv_df.columns = [c.lower() for c in list(csv_df.columns)]
-
-        # Assert df equality, including dtypes and columns
-        pd.testing.assert_frame_equal(sql_df, csv_df)
-
-        # Cleanup
-        sql.drop_table(schema=sql_schema, table=create_table_name)
-
-    def test_csv_to_table_overwrite(self):
-        if sql.table_exists(schema=sql_schema, table=create_table_name):
-            sql.query('drop table dbo.{}'.format(create_table_name))
-
-        # Make a table to fill the eventual table location and confirm it exists
-        # Add test_table
-        sql.query("""
-        create table dbo.{} (test_col1 int, test_col2 int, geom geometry);
-        insert into dbo.{} VALUES(1, 2, geometry::Point(985831.79200444, 203371.60461367, 2263));
-        insert into dbo.{} VALUES(3, 4, geometry::Point(985831.79200444, 203371.60461367, 2263));
-        """.format(create_table_name, create_table_name, create_table_name))
-        assert sql.table_exists(table=create_table_name, schema=sql_schema)
-
-        # csv_to_table
-        fp = os.path.dirname(os.path.abspath(__file__)) + "\\test_data\\test.csv"
-        sql.csv_to_table(input_file=fp, table=create_table_name, schema=sql_schema, overwrite=True)
-
-        # Check to see if table is in database
-        assert sql.table_exists(table=create_table_name, schema=sql_schema)
-        sql_df = sql.dfquery("select * from dbo.{}".format(create_table_name))
-
-        # Get csv df via pd.read_csv
-        csv_df = pd.read_csv(fp)
-        csv_df.columns = [c.replace(' ', '_') for c in list(csv_df.columns)]  # TODO: look into this difference
-        csv_df.columns = [c.replace('.', '') for c in list(csv_df.columns)]
-        csv_df.columns = [c.lower() for c in list(csv_df.columns)]
-
-        # Assert df equality, including dtypes and columns
-        pd.testing.assert_frame_equal(sql_df, csv_df)
-
-        # Cleanup
-        sql.drop_table(schema=sql_schema, table=create_table_name)
-
-    # Temp test is in logging tests
-
-    def test_csv_to_table_long_column(self):
-        # csv_to_table
-        if sql.table_exists(schema=sql_schema, table=create_table_name):
-            sql.drop_table(schema=sql_schema, table=create_table_name)
-
-        base_string = 'text'*150
-        fp = os.path.dirname(os.path.abspath(__file__)) + "\\test_data\\varchar.csv"
-        sql.dfquery("select '{}' as long_col".format(base_string)).to_csv(fp, index=False)
-        sql.csv_to_table(input_file=fp, table=create_table_name, schema=sql_schema, long_varchar_check=True)
-
-        # Check to see if table is in database
-        assert sql.table_exists(table=create_table_name, schema=sql_schema)
-        sql_df = sql.dfquery("select * from dbo.{}".format(create_table_name))
-
-        # Get csv df via pd.read_csv
-        csv_df = pd.read_csv(fp)
-        csv_df.columns = [c.replace(' ', '_') for c in list(csv_df.columns)]  # TODO: look into this difference
-
-        # Confirm long columns are not truncated and are equal with table from long_varchar_check=True
-        pd.testing.assert_frame_equal(sql_df, csv_df)
-
-        # Cleanup
-        sql.drop_table(schema=sql_schema, table=create_table_name)
-
-    @classmethod
-    def teardown_class(cls):
-        sql.cleanup_new_tables()
-
-
-class TestBulkCSVToTableMS:
-    @classmethod
-    def setup_class(cls):
-        return
-
-    def test_bulk_csv_to_table_basic(self):
-        # bulk_csv_to_table
-        if sql.drop_table(schema=sql_schema, table=create_table_name):
-            sql.query('drop table dbo.{}'.format(create_table_name))
-
-        fp = os.path.dirname(os.path.abspath(__file__)) + "\\test_data\\test.csv"
-        input_schema = sql.dataframe_to_table_schema(df=pd.read_csv(fp), table=create_table_name, schema=sql_schema)
-        sql._bulk_csv_to_table(input_file=fp, table=create_table_name, schema=sql_schema, table_schema=input_schema)
-
-        # Check to see if table is in database
-        assert sql.table_exists(table=create_table_name, schema=sql_schema)
-        sql_df = sql.dfquery("select * from dbo.{}".format(create_table_name))
-
-        # Get csv df via pd.read_csv
-        csv_df = pd.read_csv(fp)
-        csv_df.columns = [c.replace(' ', '_') for c in list(csv_df.columns)]  # TODO: look into this difference
-
-        # Assert df equality, including dtypes and columns
-        pd.testing.assert_frame_equal(sql_df, csv_df)
-
-        # Cleanup
-        sql.drop_table(schema=sql_schema, table=create_table_name)
-
-    def test_bulk_csv_to_table_default_schema(self):
-        # bulk_csv_to_table
-        if sql.table_exists(table=create_table_name):
-            sql.query('drop table {}'.format(create_table_name))
-
-        fp = os.path.dirname(os.path.abspath(__file__)) + "\\test_data\\test.csv"
-        input_schema = sql.dataframe_to_table_schema(df=pd.read_csv(fp), table=create_table_name)
-        sql._bulk_csv_to_table(input_file=fp, table=create_table_name, table_schema=input_schema)
-
-        # Check to see if table is in database
-        # This example is linked to the mssql default server bug
-        assert sql.table_exists(table=create_table_name)
-        sql_df = sql.dfquery("select * from {}".format(create_table_name))
-
-        # Get csv df via pd.read_csv
-        csv_df = pd.read_csv(fp)
-        csv_df.columns = [c.replace(' ', '_') for c in list(csv_df.columns)]  # TODO: look into this difference
-
-        # Assert df equality, including dtypes and columns
-        pd.testing.assert_frame_equal(sql_df, csv_df)
-
-        # Cleanup
-        sql.drop_table(schema=sql.default_schema, table=create_table_name)
-
-    def test_bulk_csv_to_table_long_column(self):
-        # csv_to_table
-        if sql.table_exists(schema=sql_schema, table=create_table_name):
-            sql.drop_table(schema=sql_schema, table=create_table_name)
-
-        fp = os.path.dirname(os.path.abspath(__file__)) + "\\test_data\\varchar.csv"
-        pd.DataFrame(['text'*150]*10000, columns=['long_column']).to_csv(fp)
-        sql.csv_to_table(input_file=fp, table=create_table_name, schema=sql_schema, long_varchar_check=True)
-
-        # Check to see if table is in database
-        assert sql.table_exists(table=create_table_name, schema=sql_schema)
-        sql_df = sql.dfquery("select * from dbo.{}".format(create_table_name))
-
-        # Get csv df via pd.read_csv
-        csv_df = pd.read_csv(fp)
-        csv_df.columns = [c.replace(' ', '_') for c in list(csv_df.columns)]  # TODO: look into this difference
-
-        # Confirm long columns are not truncated and are equal with table from long_varchar_check=True
-        pd.testing.assert_frame_equal(sql_df[['long_column']], csv_df[['long_column']])
-
-        # Cleanup
-        sql.drop_table(schema=sql_schema, table=create_table_name)
-
-    def test_bulk_csv_to_table_input_schema(self):
-        # Test input schema
-        return
-
-    # Temp test is in logging tests
-
-    @classmethod
-    def teardown_class(cls):
-        sql.cleanup_new_tables()
+# class TestCsvToTableMS:
+#     @classmethod
+#     def setup_class(cls):
+#         return
+#
+#     def test_csv_to_table_basic(self):
+#         # csv_to_table
+#         if sql.table_exists(schema=sql_schema, table=create_table_name):
+#             sql.query('drop table dbo.{}'.format(create_table_name))
+#
+#         fp = os.path.dirname(os.path.abspath(__file__)) + "\\test_data\\test.csv"
+#         sql.csv_to_table(input_file=fp, table=create_table_name, schema=sql_schema)
+#
+#         # Check to see if table is in database
+#         assert sql.table_exists(table=create_table_name, schema=sql_schema)
+#         sql_df = sql.dfquery("select * from dbo.{}".format(create_table_name))
+#
+#         # Get csv df via pd.read_csv
+#         csv_df = pd.read_csv(fp)
+#         csv_df.columns = [c.replace(' ', '_') for c in list(csv_df.columns)]  # TODO: look into this difference
+#
+#         # Assert df equality, including dtypes and columns
+#         pd.testing.assert_frame_equal(sql_df, csv_df)
+#
+#         # Cleanup
+#         sql.drop_table(schema=sql_schema, table=create_table_name)
+#
+#     def test_csv_to_table_column_override(self):
+#         sql.drop_table(schema=sql_schema, table=create_table_name)
+#
+#         fp = os.path.dirname(os.path.abspath(__file__)) + "\\test_data\\csv_override_ex.csv"
+#         test_df = pd.DataFrame([{'a': 1, 'b': 2, 'c': 3, 'd': 'text'}, {'a': 4, 'b': 5, 'c': 6, 'd': 'another'}])
+#         test_df.to_csv(fp)
+#         sql.csv_to_table(input_file=fp, table=create_table_name, schema=sql_schema,
+#                          column_type_overrides={'a': 'numeric'})
+#
+#         # Check to see if table is in database
+#         assert sql.table_exists(table=create_table_name, schema=sql_schema)
+#
+#         # Assert df column types match override
+#         pd.testing.assert_frame_equal(pd.DataFrame(
+#             [{"column_name": 'a', "data_type": 'numeric'}, {"column_name": 'b', "data_type": 'bigint'},
+#              {"column_name": 'c', "data_type": 'bigint'}, {"column_name": 'd', "data_type": 'varchar'}]),
+#                                       sql.dfquery("""
+#                                             select distinct column_name, data_type
+#                                             from information_schema.columns
+#                                             where table_name = '{}' and lower(column_name) not like '%unnamed%';
+#                                       """.format(create_table_name))
+#                                       )
+#
+#         # Cleanup
+#         sql.drop_table(schema=sql_schema, table=create_table_name)
+#         os.remove(fp)
+#
+#     def test_csv_to_table_separator(self):
+#         # csv_to_table
+#         if sql.table_exists(schema=sql_schema, table=create_table_name):
+#             sql.query('drop table dbo.{}'.format(create_table_name))
+#
+#         fp = os.path.dirname(os.path.abspath(__file__)) + "\\test_data\\test2.csv"
+#         sql.csv_to_table(
+#             input_file=fp,
+#             table=create_table_name, schema=sql_schema,
+#             sep="|"
+#         )
+#
+#         # Check to see if table is in database
+#         assert sql.table_exists(table=create_table_name, schema=sql_schema)
+#         sql_df = sql.dfquery("select * from dbo.{}".format(create_table_name))
+#
+#         # Get csv df via pd.read_csv
+#         csv_df = pd.read_csv(fp, sep='|')
+#         csv_df.columns = [c.replace(' ', '_') for c in list(csv_df.columns)]  # TODO: look into this difference
+#
+#         # Assert df equality, including dtypes and columns
+#         pd.testing.assert_frame_equal(sql_df, csv_df)
+#
+#         # Cleanup
+#         sql.drop_table(schema=sql_schema, table=create_table_name)
+#
+#     # what if the table has no header?
+#     def test_csv_to_table_no_header(self):
+#         # csv_to_table
+#         if sql.table_exists(schema=sql_schema, table=create_table_name):
+#             sql.query('drop table dbo.{}'.format(create_table_name))
+#
+#         fp = os.path.dirname(os.path.abspath(__file__)) + "\\test_data\\test3.csv"
+#         sql.csv_to_table(
+#             input_file=fp,
+#             table=create_table_name, schema=sql_schema, sep="|")
+#
+#         # did it enter the db correctly?
+#         assert sql.table_exists(table=create_table_name, schema=sql_schema)
+#         sql_df = sql.dfquery("select * from dbo.{}".format(create_table_name))
+#
+#         # Get csv df via pd.read_csv
+#         csv_df = pd.read_csv(fp, sep='|')
+#         csv_df.columns = [c.replace(' ', '_') for c in list(csv_df.columns)]  # TODO: look into this difference
+#         csv_df.columns = [c.replace('.', '') for c in list(csv_df.columns)]
+#         csv_df.columns = [c.lower() for c in list(csv_df.columns)]
+#
+#         # Assert df equality, including dtypes and columns
+#         pd.testing.assert_frame_equal(sql_df, csv_df)
+#
+#         # Cleanup
+#         sql.drop_table(schema=sql_schema, table=create_table_name)
+#
+#     def test_csv_to_table_overwrite(self):
+#         if sql.table_exists(schema=sql_schema, table=create_table_name):
+#             sql.query('drop table dbo.{}'.format(create_table_name))
+#
+#         # Make a table to fill the eventual table location and confirm it exists
+#         # Add test_table
+#         sql.query("""
+#         create table dbo.{} (test_col1 int, test_col2 int, geom geometry);
+#         insert into dbo.{} VALUES(1, 2, geometry::Point(985831.79200444, 203371.60461367, 2263));
+#         insert into dbo.{} VALUES(3, 4, geometry::Point(985831.79200444, 203371.60461367, 2263));
+#         """.format(create_table_name, create_table_name, create_table_name))
+#         assert sql.table_exists(table=create_table_name, schema=sql_schema)
+#
+#         # csv_to_table
+#         fp = os.path.dirname(os.path.abspath(__file__)) + "\\test_data\\test.csv"
+#         sql.csv_to_table(input_file=fp, table=create_table_name, schema=sql_schema, overwrite=True)
+#
+#         # Check to see if table is in database
+#         assert sql.table_exists(table=create_table_name, schema=sql_schema)
+#         sql_df = sql.dfquery("select * from dbo.{}".format(create_table_name))
+#
+#         # Get csv df via pd.read_csv
+#         csv_df = pd.read_csv(fp)
+#         csv_df.columns = [c.replace(' ', '_') for c in list(csv_df.columns)]  # TODO: look into this difference
+#         csv_df.columns = [c.replace('.', '') for c in list(csv_df.columns)]
+#         csv_df.columns = [c.lower() for c in list(csv_df.columns)]
+#
+#         # Assert df equality, including dtypes and columns
+#         pd.testing.assert_frame_equal(sql_df, csv_df)
+#
+#         # Cleanup
+#         sql.drop_table(schema=sql_schema, table=create_table_name)
+#
+#     # Temp test is in logging tests
+#
+#     def test_csv_to_table_long_column(self):
+#         # csv_to_table
+#         if sql.table_exists(schema=sql_schema, table=create_table_name):
+#             sql.drop_table(schema=sql_schema, table=create_table_name)
+#
+#         base_string = 'text'*150
+#         fp = os.path.dirname(os.path.abspath(__file__)) + "\\test_data\\varchar.csv"
+#         sql.dfquery("select '{}' as long_col".format(base_string)).to_csv(fp, index=False)
+#         sql.csv_to_table(input_file=fp, table=create_table_name, schema=sql_schema, long_varchar_check=True)
+#
+#         # Check to see if table is in database
+#         assert sql.table_exists(table=create_table_name, schema=sql_schema)
+#         sql_df = sql.dfquery("select * from dbo.{}".format(create_table_name))
+#
+#         # Get csv df via pd.read_csv
+#         csv_df = pd.read_csv(fp)
+#         csv_df.columns = [c.replace(' ', '_') for c in list(csv_df.columns)]  # TODO: look into this difference
+#
+#         # Confirm long columns are not truncated and are equal with table from long_varchar_check=True
+#         pd.testing.assert_frame_equal(sql_df, csv_df)
+#
+#         # Cleanup
+#         sql.drop_table(schema=sql_schema, table=create_table_name)
+#
+#     @classmethod
+#     def teardown_class(cls):
+#         sql.cleanup_new_tables()
+#
+#
+# class TestBulkCSVToTableMS:
+#     @classmethod
+#     def setup_class(cls):
+#         return
+#
+#     def test_bulk_csv_to_table_basic(self):
+#         # bulk_csv_to_table
+#         if sql.drop_table(schema=sql_schema, table=create_table_name):
+#             sql.query('drop table dbo.{}'.format(create_table_name))
+#
+#         fp = os.path.dirname(os.path.abspath(__file__)) + "\\test_data\\test.csv"
+#         input_schema = sql.dataframe_to_table_schema(df=pd.read_csv(fp), table=create_table_name, schema=sql_schema)
+#         sql._bulk_csv_to_table(input_file=fp, table=create_table_name, schema=sql_schema, table_schema=input_schema)
+#
+#         # Check to see if table is in database
+#         assert sql.table_exists(table=create_table_name, schema=sql_schema)
+#         sql_df = sql.dfquery("select * from dbo.{}".format(create_table_name))
+#
+#         # Get csv df via pd.read_csv
+#         csv_df = pd.read_csv(fp)
+#         csv_df.columns = [c.replace(' ', '_') for c in list(csv_df.columns)]  # TODO: look into this difference
+#
+#         # Assert df equality, including dtypes and columns
+#         pd.testing.assert_frame_equal(sql_df, csv_df)
+#
+#         # Cleanup
+#         sql.drop_table(schema=sql_schema, table=create_table_name)
+#
+#     def test_bulk_csv_to_table_default_schema(self):
+#         # bulk_csv_to_table
+#         if sql.table_exists(table=create_table_name):
+#             sql.query('drop table {}'.format(create_table_name))
+#
+#         fp = os.path.dirname(os.path.abspath(__file__)) + "\\test_data\\test.csv"
+#         input_schema = sql.dataframe_to_table_schema(df=pd.read_csv(fp), table=create_table_name)
+#         sql._bulk_csv_to_table(input_file=fp, table=create_table_name, table_schema=input_schema)
+#
+#         # Check to see if table is in database
+#         # This example is linked to the mssql default server bug
+#         assert sql.table_exists(table=create_table_name)
+#         sql_df = sql.dfquery("select * from {}".format(create_table_name))
+#
+#         # Get csv df via pd.read_csv
+#         csv_df = pd.read_csv(fp)
+#         csv_df.columns = [c.replace(' ', '_') for c in list(csv_df.columns)]  # TODO: look into this difference
+#
+#         # Assert df equality, including dtypes and columns
+#         pd.testing.assert_frame_equal(sql_df, csv_df)
+#
+#         # Cleanup
+#         sql.drop_table(schema=sql.default_schema, table=create_table_name)
+#
+#     def test_bulk_csv_to_table_long_column(self):
+#         # csv_to_table
+#         if sql.table_exists(schema=sql_schema, table=create_table_name):
+#             sql.drop_table(schema=sql_schema, table=create_table_name)
+#
+#         fp = os.path.dirname(os.path.abspath(__file__)) + "\\test_data\\varchar.csv"
+#         pd.DataFrame(['text'*150]*10000, columns=['long_column']).to_csv(fp)
+#         sql.csv_to_table(input_file=fp, table=create_table_name, schema=sql_schema, long_varchar_check=True)
+#
+#         # Check to see if table is in database
+#         assert sql.table_exists(table=create_table_name, schema=sql_schema)
+#         sql_df = sql.dfquery("select * from dbo.{}".format(create_table_name))
+#
+#         # Get csv df via pd.read_csv
+#         csv_df = pd.read_csv(fp)
+#         csv_df.columns = [c.replace(' ', '_') for c in list(csv_df.columns)]  # TODO: look into this difference
+#
+#         # Confirm long columns are not truncated and are equal with table from long_varchar_check=True
+#         pd.testing.assert_frame_equal(sql_df[['long_column']], csv_df[['long_column']])
+#
+#         # Cleanup
+#         sql.drop_table(schema=sql_schema, table=create_table_name)
+#
+#     def test_bulk_csv_to_table_input_schema(self):
+#         # Test input schema
+#         return
+#
+#     # Temp test is in logging tests
+#
+#     @classmethod
+#     def teardown_class(cls):
+#         sql.cleanup_new_tables()

--- a/pysqldb3/tests/test_csv_to_table.py
+++ b/pysqldb3/tests/test_csv_to_table.py
@@ -23,7 +23,8 @@ sql = pysqldb.DbConnect(type=config.get('SQL_DB', 'TYPE'),
 
 pg_table_name = 'pg_test_table_{}'.format(db.user)
 create_table_name = 'sample_acs_test_csv_to_table_{}'.format(db.user)
-
+pg_schema = 'working'
+sql_schema = sql_schema
 
 class TestCsvToTablePG:
     @classmethod
@@ -36,10 +37,10 @@ class TestCsvToTablePG:
         db.query('drop table if exists working.{}'.format(create_table_name))
 
         fp = os.path.dirname(os.path.abspath(__file__)) + "\\test_data\\test.csv"
-        db.csv_to_table(input_file=fp, table=create_table_name, schema='working')
+        db.csv_to_table(input_file=fp, table=create_table_name, schema=pg_schema)
 
         # Check to see if table is in database
-        assert db.table_exists(table=create_table_name, schema='working')
+        assert db.table_exists(table=create_table_name, schema=pg_schema)
         db_df = db.dfquery("select * from working.{}".format(create_table_name))
 
         # Get csv df via pd.read_csv
@@ -50,17 +51,17 @@ class TestCsvToTablePG:
         pd.testing.assert_frame_equal(db_df, csv_df)
 
         # Cleanup
-        db.drop_table(schema='working', table=create_table_name)
+        db.drop_table(schema=pg_schema, table=create_table_name)
 
     def test_csv_to_table_column_override(self):
-        db.drop_table(schema='working', table=create_table_name)
+        db.drop_table(schema=pg_schema, table=create_table_name)
         fp = os.path.dirname(os.path.abspath(__file__)) + "\\test_data\\csv_override_ex.csv"
         test_df = pd.DataFrame([{'a': 1, 'b': 2, 'c': 3, 'd': 'text'}, {'a': 4, 'b': 5, 'c': 6, 'd': 'another'}])
         test_df.to_csv(fp)
-        db.csv_to_table(input_file=fp, table=create_table_name, schema='working', column_type_overrides={'a': 'varchar'})
+        db.csv_to_table(input_file=fp, table=create_table_name, schema=pg_schema, column_type_overrides={'a': 'varchar'})
 
         # Check to see if table is in database
-        assert db.table_exists(table=create_table_name, schema='working')
+        assert db.table_exists(table=create_table_name, schema=pg_schema)
         db_df = db.dfquery("select * from working.{}".format(create_table_name))
 
         # Modify to make column types altered
@@ -81,7 +82,7 @@ class TestCsvToTablePG:
         )
 
         # Cleanup
-        db.drop_table(schema='working', table=create_table_name)
+        db.drop_table(schema=pg_schema, table=create_table_name)
         os.remove(fp)
 
     def test_csv_to_table_separator(self):
@@ -91,12 +92,12 @@ class TestCsvToTablePG:
         fp = os.path.dirname(os.path.abspath(__file__)) + "\\test_data\\test2.csv"
         db.csv_to_table(
             input_file=fp,
-            table=create_table_name, schema='working',
+            table=create_table_name, schema=pg_schema,
             sep="|"
         )
 
         # Check to see if table is in database
-        assert db.table_exists(table=create_table_name, schema='working')
+        assert db.table_exists(table=create_table_name, schema=pg_schema)
         db_df = db.dfquery("select * from working.{}".format(create_table_name))
 
         # Get csv df via pd.read_csv
@@ -107,7 +108,7 @@ class TestCsvToTablePG:
         pd.testing.assert_frame_equal(db_df, csv_df)
 
         # Cleanup
-        db.drop_table(schema='working', table=create_table_name)
+        db.drop_table(schema=pg_schema, table=create_table_name)
 
     # what if the table has no header?
     def test_csv_to_table_no_header(self):
@@ -117,10 +118,10 @@ class TestCsvToTablePG:
         fp = os.path.dirname(os.path.abspath(__file__)) + "\\test_data\\test3.csv"
         db.csv_to_table(
             input_file=fp,
-            table=create_table_name, schema='working', sep="|")
+            table=create_table_name, schema=pg_schema, sep="|")
 
         # did it enter the db correctly?
-        assert db.table_exists(table=create_table_name, schema='working')
+        assert db.table_exists(table=create_table_name, schema=pg_schema)
         db_df = db.dfquery("select * from working.{}".format(create_table_name))
 
         # Get csv df via pd.read_csv
@@ -133,19 +134,19 @@ class TestCsvToTablePG:
         pd.testing.assert_frame_equal(db_df, csv_df)
 
         # Cleanup
-        db.drop_table(schema='working', table=create_table_name)
+        db.drop_table(schema=pg_schema, table=create_table_name)
 
     def test_csv_to_table_overwrite(self):
         # Make a table to fill the eventual table location and confirm it exists
         db.query('create table working.{} as select 10'.format(create_table_name))
-        assert db.table_exists(table=create_table_name, schema='working')
+        assert db.table_exists(table=create_table_name, schema=pg_schema)
 
         # csv_to_table
         fp = os.path.dirname(os.path.abspath(__file__)) + "\\test_data\\test.csv"
-        db.csv_to_table(input_file=fp, table=create_table_name, schema='working', overwrite=True)
+        db.csv_to_table(input_file=fp, table=create_table_name, schema=pg_schema, overwrite=True)
 
         # Check to see if table is in database
-        assert db.table_exists(table=create_table_name, schema='working')
+        assert db.table_exists(table=create_table_name, schema=pg_schema)
         db_df = db.dfquery("select * from working.{}".format(create_table_name))
 
         # Get csv df via pd.read_csv
@@ -156,7 +157,7 @@ class TestCsvToTablePG:
         pd.testing.assert_frame_equal(db_df, csv_df)
 
         # Cleanup
-        db.drop_table(schema='working', table=create_table_name)
+        db.drop_table(schema=pg_schema, table=create_table_name)
 
     def test_csv_to_table_long_column(self):
         # csv_to_table
@@ -165,10 +166,10 @@ class TestCsvToTablePG:
         base_string = 'text'*150
         fp = os.path.dirname(os.path.abspath(__file__)) + "\\test_data\\varchar.csv"
         db.dfquery("select '{}' as long_col".format(base_string)).to_csv(fp, index=False)
-        db.csv_to_table(input_file=fp, table=create_table_name, schema='working', long_varchar_check=True)
+        db.csv_to_table(input_file=fp, table=create_table_name, schema=pg_schema, long_varchar_check=True)
 
         # Check to see if table is in database
-        assert db.table_exists(table=create_table_name, schema='working')
+        assert db.table_exists(table=create_table_name, schema=pg_schema)
         db_df = db.dfquery("select * from working.{}".format(create_table_name))
 
         # Get csv df via pd.read_csv
@@ -179,7 +180,7 @@ class TestCsvToTablePG:
         pd.testing.assert_frame_equal(db_df, csv_df)
 
         # Cleanup
-        db.drop_table(schema='working', table=create_table_name)
+        db.drop_table(schema=pg_schema, table=create_table_name)
 
     # Temp test is in logging tests
 
@@ -199,11 +200,11 @@ class TestBulkCSVToTablePG:
         db.query('drop table if exists working.{}'.format(create_table_name))
 
         fp = os.path.dirname(os.path.abspath(__file__)) + "\\test_data\\test.csv"
-        input_schema = db.dataframe_to_table_schema(df=pd.read_csv(fp), table=create_table_name, schema='working')
-        db._bulk_csv_to_table(input_file=fp, table=create_table_name, schema='working', table_schema=input_schema)
+        input_schema = db.dataframe_to_table_schema(df=pd.read_csv(fp), table=create_table_name, schema=pg_schema)
+        db._bulk_csv_to_table(input_file=fp, table=create_table_name, schema=pg_schema, table_schema=input_schema)
 
         # Check to see if table is in database
-        assert db.table_exists(table=create_table_name, schema='working')
+        assert db.table_exists(table=create_table_name, schema=pg_schema)
         db_df = db.dfquery("select * from working.{}".format(create_table_name))
 
         # Get csv df via pd.read_csv
@@ -214,7 +215,7 @@ class TestBulkCSVToTablePG:
         pd.testing.assert_frame_equal(db_df, csv_df)
 
         # Cleanup
-        db.drop_table(schema='working', table=create_table_name)
+        db.drop_table(schema=pg_schema, table=create_table_name)
 
     def test_bulk_csv_to_table_default_schema(self):
         # bulk_csv_to_table
@@ -240,16 +241,16 @@ class TestBulkCSVToTablePG:
 
     def test_bulk_csv_to_table_long_column(self):
         # csv_to_table
-        if sql.table_exists(schema='dbo', table=create_table_name):
-            sql.drop_table(schema='dbo', table=create_table_name)
+        if db.table_exists(schema=pg_schema, table=create_table_name):
+            db.drop_table(schema=pg_schema, table=create_table_name)
 
         fp = os.path.dirname(os.path.abspath(__file__)) + "\\test_data\\varchar.csv"
         pd.DataFrame(['text'*150]*10000, columns=['long_column']).to_csv(fp)
-        sql.csv_to_table(input_file=fp, table=create_table_name, schema='dbo', long_varchar_check=True)
+        db.csv_to_table(input_file=fp, table=create_table_name, schema=pg_schema, long_varchar_check=True)
 
         # Check to see if table is in database
-        assert sql.table_exists(table=create_table_name, schema='dbo')
-        sql_df = sql.dfquery("select * from dbo.{}".format(create_table_name))
+        assert db.table_exists(table=create_table_name, schema=pg_schema)
+        sql_df = db.dfquery("select * from {}.{}".format(pg_schema, create_table_name))
 
         # Get csv df via pd.read_csv
         csv_df = pd.read_csv(fp)
@@ -259,7 +260,7 @@ class TestBulkCSVToTablePG:
         pd.testing.assert_frame_equal(sql_df[['long_column']], csv_df[['long_column']])
 
         # Cleanup
-        sql.drop_table(schema='dbo', table=create_table_name)
+        db.drop_table(schema=pg_schema, table=create_table_name)
 
     def test_bulk_csv_to_table_input_schema(self):
         # Test input schema
@@ -279,14 +280,14 @@ class TestCsvToTableMS:
 
     def test_csv_to_table_basic(self):
         # csv_to_table
-        if sql.table_exists(schema='dbo', table=create_table_name):
+        if sql.table_exists(schema=sql_schema, table=create_table_name):
             sql.query('drop table dbo.{}'.format(create_table_name))
 
         fp = os.path.dirname(os.path.abspath(__file__)) + "\\test_data\\test.csv"
-        sql.csv_to_table(input_file=fp, table=create_table_name, schema='dbo')
+        sql.csv_to_table(input_file=fp, table=create_table_name, schema=sql_schema)
 
         # Check to see if table is in database
-        assert sql.table_exists(table=create_table_name, schema='dbo')
+        assert sql.table_exists(table=create_table_name, schema=sql_schema)
         sql_df = sql.dfquery("select * from dbo.{}".format(create_table_name))
 
         # Get csv df via pd.read_csv
@@ -297,19 +298,19 @@ class TestCsvToTableMS:
         pd.testing.assert_frame_equal(sql_df, csv_df)
 
         # Cleanup
-        sql.drop_table(schema='dbo', table=create_table_name)
+        sql.drop_table(schema=sql_schema, table=create_table_name)
 
     def test_csv_to_table_column_override(self):
-        sql.drop_table(schema='dbo', table=create_table_name)
+        sql.drop_table(schema=sql_schema, table=create_table_name)
 
         fp = os.path.dirname(os.path.abspath(__file__)) + "\\test_data\\csv_override_ex.csv"
         test_df = pd.DataFrame([{'a': 1, 'b': 2, 'c': 3, 'd': 'text'}, {'a': 4, 'b': 5, 'c': 6, 'd': 'another'}])
         test_df.to_csv(fp)
-        sql.csv_to_table(input_file=fp, table=create_table_name, schema='dbo',
+        sql.csv_to_table(input_file=fp, table=create_table_name, schema=sql_schema,
                          column_type_overrides={'a': 'numeric'})
 
         # Check to see if table is in database
-        assert sql.table_exists(table=create_table_name, schema='dbo')
+        assert sql.table_exists(table=create_table_name, schema=sql_schema)
 
         # Assert df column types match override
         pd.testing.assert_frame_equal(pd.DataFrame(
@@ -323,23 +324,23 @@ class TestCsvToTableMS:
                                       )
 
         # Cleanup
-        sql.drop_table(schema='dbo', table=create_table_name)
+        sql.drop_table(schema=sql_schema, table=create_table_name)
         os.remove(fp)
 
     def test_csv_to_table_separator(self):
         # csv_to_table
-        if sql.table_exists(schema='dbo', table=create_table_name):
+        if sql.table_exists(schema=sql_schema, table=create_table_name):
             sql.query('drop table dbo.{}'.format(create_table_name))
 
         fp = os.path.dirname(os.path.abspath(__file__)) + "\\test_data\\test2.csv"
         sql.csv_to_table(
             input_file=fp,
-            table=create_table_name, schema='dbo',
+            table=create_table_name, schema=sql_schema,
             sep="|"
         )
 
         # Check to see if table is in database
-        assert sql.table_exists(table=create_table_name, schema='dbo')
+        assert sql.table_exists(table=create_table_name, schema=sql_schema)
         sql_df = sql.dfquery("select * from dbo.{}".format(create_table_name))
 
         # Get csv df via pd.read_csv
@@ -350,21 +351,21 @@ class TestCsvToTableMS:
         pd.testing.assert_frame_equal(sql_df, csv_df)
 
         # Cleanup
-        sql.drop_table(schema='dbo', table=create_table_name)
+        sql.drop_table(schema=sql_schema, table=create_table_name)
 
     # what if the table has no header?
     def test_csv_to_table_no_header(self):
         # csv_to_table
-        if sql.table_exists(schema='dbo', table=create_table_name):
+        if sql.table_exists(schema=sql_schema, table=create_table_name):
             sql.query('drop table dbo.{}'.format(create_table_name))
 
         fp = os.path.dirname(os.path.abspath(__file__)) + "\\test_data\\test3.csv"
         sql.csv_to_table(
             input_file=fp,
-            table=create_table_name, schema='dbo', sep="|")
+            table=create_table_name, schema=sql_schema, sep="|")
 
         # did it enter the db correctly?
-        assert sql.table_exists(table=create_table_name, schema='dbo')
+        assert sql.table_exists(table=create_table_name, schema=sql_schema)
         sql_df = sql.dfquery("select * from dbo.{}".format(create_table_name))
 
         # Get csv df via pd.read_csv
@@ -377,10 +378,10 @@ class TestCsvToTableMS:
         pd.testing.assert_frame_equal(sql_df, csv_df)
 
         # Cleanup
-        sql.drop_table(schema='dbo', table=create_table_name)
+        sql.drop_table(schema=sql_schema, table=create_table_name)
 
     def test_csv_to_table_overwrite(self):
-        if sql.table_exists(schema='dbo', table=create_table_name):
+        if sql.table_exists(schema=sql_schema, table=create_table_name):
             sql.query('drop table dbo.{}'.format(create_table_name))
 
         # Make a table to fill the eventual table location and confirm it exists
@@ -390,14 +391,14 @@ class TestCsvToTableMS:
         insert into dbo.{} VALUES(1, 2, geometry::Point(985831.79200444, 203371.60461367, 2263));
         insert into dbo.{} VALUES(3, 4, geometry::Point(985831.79200444, 203371.60461367, 2263));
         """.format(create_table_name, create_table_name, create_table_name))
-        assert sql.table_exists(table=create_table_name, schema='dbo')
+        assert sql.table_exists(table=create_table_name, schema=sql_schema)
 
         # csv_to_table
         fp = os.path.dirname(os.path.abspath(__file__)) + "\\test_data\\test.csv"
-        sql.csv_to_table(input_file=fp, table=create_table_name, schema='dbo', overwrite=True)
+        sql.csv_to_table(input_file=fp, table=create_table_name, schema=sql_schema, overwrite=True)
 
         # Check to see if table is in database
-        assert sql.table_exists(table=create_table_name, schema='dbo')
+        assert sql.table_exists(table=create_table_name, schema=sql_schema)
         sql_df = sql.dfquery("select * from dbo.{}".format(create_table_name))
 
         # Get csv df via pd.read_csv
@@ -410,22 +411,22 @@ class TestCsvToTableMS:
         pd.testing.assert_frame_equal(sql_df, csv_df)
 
         # Cleanup
-        sql.drop_table(schema='dbo', table=create_table_name)
+        sql.drop_table(schema=sql_schema, table=create_table_name)
 
     # Temp test is in logging tests
 
     def test_csv_to_table_long_column(self):
         # csv_to_table
-        if sql.table_exists(schema='dbo', table=create_table_name):
-            sql.drop_table(schema='dbo', table=create_table_name)
+        if sql.table_exists(schema=sql_schema, table=create_table_name):
+            sql.drop_table(schema=sql_schema, table=create_table_name)
 
         base_string = 'text'*150
         fp = os.path.dirname(os.path.abspath(__file__)) + "\\test_data\\varchar.csv"
         sql.dfquery("select '{}' as long_col".format(base_string)).to_csv(fp, index=False)
-        sql.csv_to_table(input_file=fp, table=create_table_name, schema='dbo', long_varchar_check=True)
+        sql.csv_to_table(input_file=fp, table=create_table_name, schema=sql_schema, long_varchar_check=True)
 
         # Check to see if table is in database
-        assert sql.table_exists(table=create_table_name, schema='dbo')
+        assert sql.table_exists(table=create_table_name, schema=sql_schema)
         sql_df = sql.dfquery("select * from dbo.{}".format(create_table_name))
 
         # Get csv df via pd.read_csv
@@ -436,7 +437,7 @@ class TestCsvToTableMS:
         pd.testing.assert_frame_equal(sql_df, csv_df)
 
         # Cleanup
-        sql.drop_table(schema='dbo', table=create_table_name)
+        sql.drop_table(schema=sql_schema, table=create_table_name)
 
     @classmethod
     def teardown_class(cls):
@@ -450,15 +451,15 @@ class TestBulkCSVToTableMS:
 
     def test_bulk_csv_to_table_basic(self):
         # bulk_csv_to_table
-        if sql.drop_table(schema='dbo', table=create_table_name):
+        if sql.drop_table(schema=sql_schema, table=create_table_name):
             sql.query('drop table dbo.{}'.format(create_table_name))
 
         fp = os.path.dirname(os.path.abspath(__file__)) + "\\test_data\\test.csv"
-        input_schema = sql.dataframe_to_table_schema(df=pd.read_csv(fp), table=create_table_name, schema='dbo')
-        sql._bulk_csv_to_table(input_file=fp, table=create_table_name, schema='dbo', table_schema=input_schema)
+        input_schema = sql.dataframe_to_table_schema(df=pd.read_csv(fp), table=create_table_name, schema=sql_schema)
+        sql._bulk_csv_to_table(input_file=fp, table=create_table_name, schema=sql_schema, table_schema=input_schema)
 
         # Check to see if table is in database
-        assert sql.table_exists(table=create_table_name, schema='dbo')
+        assert sql.table_exists(table=create_table_name, schema=sql_schema)
         sql_df = sql.dfquery("select * from dbo.{}".format(create_table_name))
 
         # Get csv df via pd.read_csv
@@ -469,7 +470,7 @@ class TestBulkCSVToTableMS:
         pd.testing.assert_frame_equal(sql_df, csv_df)
 
         # Cleanup
-        sql.drop_table(schema='dbo', table=create_table_name)
+        sql.drop_table(schema=sql_schema, table=create_table_name)
 
     def test_bulk_csv_to_table_default_schema(self):
         # bulk_csv_to_table
@@ -497,15 +498,15 @@ class TestBulkCSVToTableMS:
 
     def test_bulk_csv_to_table_long_column(self):
         # csv_to_table
-        if sql.table_exists(schema='dbo', table=create_table_name):
-            sql.drop_table(schema='dbo', table=create_table_name)
+        if sql.table_exists(schema=sql_schema, table=create_table_name):
+            sql.drop_table(schema=sql_schema, table=create_table_name)
 
         fp = os.path.dirname(os.path.abspath(__file__)) + "\\test_data\\varchar.csv"
         pd.DataFrame(['text'*150]*10000, columns=['long_column']).to_csv(fp)
-        sql.csv_to_table(input_file=fp, table=create_table_name, schema='dbo', long_varchar_check=True)
+        sql.csv_to_table(input_file=fp, table=create_table_name, schema=sql_schema, long_varchar_check=True)
 
         # Check to see if table is in database
-        assert sql.table_exists(table=create_table_name, schema='dbo')
+        assert sql.table_exists(table=create_table_name, schema=sql_schema)
         sql_df = sql.dfquery("select * from dbo.{}".format(create_table_name))
 
         # Get csv df via pd.read_csv
@@ -516,7 +517,7 @@ class TestBulkCSVToTableMS:
         pd.testing.assert_frame_equal(sql_df[['long_column']], csv_df[['long_column']])
 
         # Cleanup
-        sql.drop_table(schema='dbo', table=create_table_name)
+        sql.drop_table(schema=sql_schema, table=create_table_name)
 
     def test_bulk_csv_to_table_input_schema(self):
         # Test input schema

--- a/pysqldb3/tests/test_csv_to_table.py
+++ b/pysqldb3/tests/test_csv_to_table.py
@@ -24,7 +24,7 @@ sql = pysqldb.DbConnect(type=config.get('SQL_DB', 'TYPE'),
 pg_table_name = 'pg_test_table_{}'.format(db.user)
 create_table_name = 'sample_acs_test_csv_to_table_{}'.format(db.user)
 pg_schema = 'working'
-sql_schema = sql_schema
+sql_schema = 'dbo'
 
 class TestCsvToTablePG:
     @classmethod

--- a/pysqldb3/tests/test_query_to_csv.py
+++ b/pysqldb3/tests/test_query_to_csv.py
@@ -65,6 +65,34 @@ class TestQueryToCSVPG:
         db.drop_table(schema='working', table=test_csv_name)
         os.remove(output)
 
+    def test_query_to_csv_basic_spec_char_columns(self):
+        output = os.path.dirname(os.path.abspath(__file__)) + 'test_query_to_csv.csv'
+        db.drop_table(schema='working', table=test_csv_name)
+
+        # Setup table
+        db.query("""
+            create table working.{} ("col 1" varchar, "col 2" varchar, "col 3" varchar);
+
+            insert into working.{} values ('a', 'b', 'c');
+        """.format(test_csv_name, test_csv_name))
+
+        # Query_to_csv
+        db.query_to_csv(query='select "col 1", "col 2", "col 3" from working.{}'.format(test_csv_name),
+                        output_file=output)
+
+        # Get result from query_to_csv as df
+        result_df = pd.read_csv(output)
+
+        # Get result from dfquery
+        query_df = db.dfquery('select "col 1", "col 2", "col 3" from working.{}'.format(test_csv_name))
+
+        # Assert equality
+        pd.testing.assert_frame_equal(result_df, query_df)
+
+        # Cleanup
+        db.drop_table(schema='working', table=test_csv_name)
+        os.remove(output)
+
     def test_query_to_csv_special_char(self):
         output = os.path.dirname(os.path.abspath(__file__)) + 'test_query_to_csv.csv'
         db.drop_table(schema='working', table=test_csv_name)
@@ -248,6 +276,34 @@ class TestQueryToCSVMS:
 
         # Get result from dfquery
         query_df = sql.dfquery('select * from dbo.{}'.format(test_csv_name))
+
+        # Assert equality
+        pd.testing.assert_frame_equal(result_df.drop(columns=['WKT']), query_df)
+
+        # Cleanup
+        sql.drop_table(schema='dbo', table=test_csv_name)
+        os.remove(output)
+
+    def test_query_to_csv_basic_spec_char_columns(self):
+        output = os.path.dirname(os.path.abspath(__file__)) + 'test_query_to_csv.csv'
+        sql.drop_table(schema='dbo', table=test_csv_name)
+
+        # Setup table
+        sql.query("""
+            create table dbo.{} ([col 1] varchar, [col 2] varchar, [col 3] varchar);
+
+            insert into dbo.{} values ('a', 'b', 'c');
+        """.format(test_csv_name, test_csv_name))
+
+        # Query_to_csv
+        sql.query_to_csv(query='select [col 1], [col 2], [col 3] from dbo.{}'.format(test_csv_name),
+                         output_file=output)
+
+        # Get result from query_to_csv as df
+        result_df = pd.read_csv(output)
+
+        # Get result from dfquery
+        query_df = sql.dfquery('select [col 1], [col 2], [col 3] from dbo.{}'.format(test_csv_name))
 
         # Assert equality
         pd.testing.assert_frame_equal(result_df.drop(columns=['WKT']), query_df)

--- a/pysqldb3/util.py
+++ b/pysqldb3/util.py
@@ -3,6 +3,7 @@ import decimal
 import re
 import os
 import configparser
+import pyarrow
 
 import numpy as np
 import pandas as pd
@@ -210,6 +211,27 @@ def type_decoder(typ, varchar_length=500):
     else:
         return 'varchar ({})'.format(varchar_length)
 
+def type_decoder_pyarrow(typ, varchar_length=500):
+    """
+    Lazy type decoding from pandas to SQL. There are problems assoicated with NaN values for numeric types when
+    stored as Object dtypes.
+
+    This does not try to optimize for smallest size datatype.
+
+    :param typ: Numpy dtype for column
+    :param varchar_length: Length for varchar columns
+    :return: String representing data type
+    """
+    if typ in (pyarrow.int8(), pyarrow.int16(), pyarrow.int32(), pyarrow.int64()):
+        return 'bigint'
+    if typ in (pyarrow.float16(), pyarrow.float32(), pyarrow.float64()):
+        return 'float'
+    elif pyarrow.types.is_timestamp(typ):
+        return 'timestamp'
+    elif pyarrow.types.is_date(typ):
+        return 'date'
+    else:
+        return 'varchar ({})'.format(varchar_length)
 
 def clean_cell(x):
     """
@@ -221,7 +243,7 @@ def clean_cell(x):
     if pd.isnull(x):
         return "None"
     elif type(x) == int:
-        return str(float(x))
+        return str(int(x))
     elif type(x) == decimal.Decimal:
         return str(float(x))
     elif type(x) == str:


### PR DESCRIPTION
- Allows you to pass pandas keyword arguments for csv/xls to table to take advantage of skiprows etc.
- Allows query_to_csv to work with `"` encapsulated column names in PG, needed for columns with special characters 