### PR TITLE
Pyarrow and integer fixes for pandas imports 

### DIFF
--- a/pysqldb3/pysqldb3.py
+++ b/pysqldb3/pysqldb3.py
@@ -807,6 +807,10 @@ class DbConnect:
         for col in df.dtypes.items():
             col_name, col_type = col[0], type_decoder(col[1], varchar_length=allowed_length)
 
+            # autodetect date and force to text (common error)
+            if 'date' in col_name.lower() and col_type in ('int', 'bigint', 'float'):
+                col_type = 'varchar(500)'
+
             if column_type_overrides and col_name in column_type_overrides.keys():
                 input_schema.append([clean_column(col_name), column_type_overrides[col_name]])
             else:
@@ -1097,6 +1101,14 @@ class DbConnect:
 
                 # Cast all fields to new type to move from stg to final table
                 # take staging field name from stg table
+                # def __double_cast_for_ints(i, column_name, column_type):
+                #     if column_type == 'bigint':
+                #         return 'CAST(CAST("' + column_names[i] + '"as float) as bigint)'
+                #     else:
+                #         return 'CAST("' + column_names[i] + '" as ' + column_type + ')'
+                #
+                # cols = [__double_cast_for_ints(i, col_name, col_type) for i, (col_name, col_type) in
+                #         enumerate(table_schema)]
                 cols = ['CAST("' + column_names[i] + '" as ' + col_type + ')' for i, (col_name, col_type) in
                         enumerate(table_schema)]
                 # cols = [c.encode('utf-8') for c in cols]

--- a/pysqldb3/pysqldb3.py
+++ b/pysqldb3/pysqldb3.py
@@ -1101,16 +1101,16 @@ class DbConnect:
 
                 # Cast all fields to new type to move from stg to final table
                 # take staging field name from stg table
-                # def __double_cast_for_ints(i, column_name, column_type):
-                #     if column_type == 'bigint':
-                #         return 'CAST(CAST("' + column_names[i] + '"as float) as bigint)'
-                #     else:
-                #         return 'CAST("' + column_names[i] + '" as ' + column_type + ')'
-                #
-                # cols = [__double_cast_for_ints(i, col_name, col_type) for i, (col_name, col_type) in
-                #         enumerate(table_schema)]
-                cols = ['CAST("' + column_names[i] + '" as ' + col_type + ')' for i, (col_name, col_type) in
+                def __double_cast_for_ints(i, column_name, column_type):
+                    if column_type == 'bigint':
+                        return 'CAST(CAST("' + column_names[i] + '"as float) as bigint)'
+                    else:
+                        return 'CAST("' + column_names[i] + '" as ' + column_type + ')'
+
+                cols = [__double_cast_for_ints(i, col_name, col_type) for i, (col_name, col_type) in
                         enumerate(table_schema)]
+                # cols = ['CAST("' + column_names[i] + '" as ' + col_type + ')' for i, (col_name, col_type) in
+                #         enumerate(table_schema)]
                 # cols = [c.encode('utf-8') for c in cols]
                 cols = str(cols).replace("'", "")[1:-1]
             else:

--- a/pysqldb3/pysqldb3.py
+++ b/pysqldb3/pysqldb3.py
@@ -1008,6 +1008,19 @@ class DbConnect:
         """
         return self._bulk_file_to_table(input_file=input_file, schema=schema, table=table,
                                         table_schema=table_schema, print_cmd=print_cmd, excel_header=header, days=days)
+    @staticmethod
+    def __double_cast_for_ints(i, column_names, column_type):
+        """
+        This will create the cast statements for insert query which is used by _bulk_file_to_table
+        :param i: index position
+        :param column_names: column name list
+        :param column_type: column datatype
+        :return: castting string for insert query
+        """
+        if column_type == 'bigint':
+            return 'CAST(CAST("' + column_names[i] + '"as float) as bigint)'
+        else:
+            return 'CAST("' + column_names[i] + '" as ' + column_type + ')'
 
     def _bulk_file_to_table(self, input_file=None, schema=None, table=None, table_schema=None, print_cmd=False,
                             excel_header=True, days=7):
@@ -1101,13 +1114,9 @@ class DbConnect:
 
                 # Cast all fields to new type to move from stg to final table
                 # take staging field name from stg table
-                def __double_cast_for_ints(i, column_name, column_type):
-                    if column_type == 'bigint':
-                        return 'CAST(CAST("' + column_names[i] + '"as float) as bigint)'
-                    else:
-                        return 'CAST("' + column_names[i] + '" as ' + column_type + ')'
 
-                cols = [__double_cast_for_ints(i, col_name, col_type) for i, (col_name, col_type) in
+
+                cols = [self.__double_cast_for_ints(i, column_names, col_type) for i, (col_name, col_type) in
                         enumerate(table_schema)]
                 # cols = ['CAST("' + column_names[i] + '" as ' + col_type + ')' for i, (col_name, col_type) in
                 #         enumerate(table_schema)]

--- a/pysqldb3/util.py
+++ b/pysqldb3/util.py
@@ -221,7 +221,7 @@ def clean_cell(x):
     if pd.isnull(x):
         return "None"
     elif type(x) == int:
-        return str(float(x))
+        return str(int(x))
     elif type(x) == decimal.Decimal:
         return str(float(x))
     elif type(x) == str:


### PR DESCRIPTION
This is a fix for an issue when bulk importing csv files. Some field will be typed as integers but when bulk importing gdal includes a decimal place which then breaks the casting to int on the insert into the final table. This resolves that, though I'm sure there is a more elegant way to resolve this 