### PR TITLE
Add 2 lines about tds_version to the parameters for MSS connectivity

### DIFF
--- a/pysqldb3/pysqldb3.py
+++ b/pysqldb3/pysqldb3.py
@@ -208,7 +208,8 @@ class DbConnect:
                 'database': self.database,
                 'host': self.server,
                 'user': self.user,
-                'password': self.password            }
+                'password': self.password,
+                'tds_version': r'7.0'}
 
         try:
             self.conn = pymssql.connect(**self.params)
@@ -1563,6 +1564,7 @@ class DbConnect:
                 output_file=output_file,
                 host=self.server,
                 username=self.user,
+                tds_version=r'7.0', # cindy add 09272023
                 db=self.database,
                 password=self.password,
                 ms_sql_select=query,


### PR DESCRIPTION
Since I encountered a problem connecting to the MS SQL Server, I had to add an extra parameter where tds_version = r'7.0' in order for pymssql to work. In turn (since pysqldb3 is based on pymssql), I have to add this parameter to pysqldb3 for the Microsoft Server connection.