### PR TITLE
FIX - empty column datatype in csv import 

### DIFF
--- a/pysqldb3/pysqldb3.py
+++ b/pysqldb3/pysqldb3.py
@@ -1303,6 +1303,16 @@ class DbConnect:
 
                 column_names = self.queries[-1].data_columns
 
+                # check for null columns
+                for c in column_names:
+                    self.query("select count(case when {c} is not null then 1 else null end) nnulls from {s}.stg_{t}".format(s=schema, t=table, c=c),
+                               strict=False, timeme=False, internal=True)
+                    if self.internal_data[0][0] > 0:
+                        self.query(
+                            "alter table {s}.stg_{t} alter {c} type varchar".format(
+                                s=schema, t=table, c=c),
+                            strict=False, timeme=False, internal=True)
+
                 # Drop ogc_fid
                 if "ogc_fid" in column_names and "ogc_fid" not in [col_name for i, (col_name, col_type) in
                                                                    enumerate(table_schema)]:

--- a/pysqldb3/pysqldb3.py
+++ b/pysqldb3/pysqldb3.py
@@ -1305,11 +1305,12 @@ class DbConnect:
 
                 # check for null columns
                 for c in column_names:
-                    self.query("select count(case when {c} is not null then 1 else null end) nnulls from {s}.stg_{t}".format(s=schema, t=table, c=c),
+                    self.query('select count(case when "{c}" is not null then 1 else null end) nnulls from {s}.stg_{t}'.
+                               format(s=schema, t=table, c=c),
                                strict=False, timeme=False, internal=True)
                     if self.internal_data[0][0] > 0:
                         self.query(
-                            "alter table {s}.stg_{t} alter {c} type varchar".format(
+                            'alter table {s}.stg_{t} alter "{c}" type varchar'.format(
                                 s=schema, t=table, c=c),
                             strict=False, timeme=False, internal=True)
 

--- a/pysqldb3/pysqldb3.py
+++ b/pysqldb3/pysqldb3.py
@@ -864,6 +864,11 @@ class DbConnect:
         for col in df.dtypes.items():
             col_name, col_type = col[0], type_decoder(col[1], varchar_length=allowed_length)
 
+            # check if column is empty - if so force string
+            s = df[col_name].value_counts()
+            if s.empty:
+                col_type = 'varchar ({})'.format(allowed_length)
+
             # autodetect date and force to text (common error)
             if 'date' in col_name.lower() and col_type in ('int', 'bigint', 'float'):
                 col_type = 'varchar(500)'

--- a/pysqldb3/tests/helpers.py
+++ b/pysqldb3/tests/helpers.py
@@ -51,12 +51,13 @@ def set_up_test_csv():
 
     # bulk csv with empty column
     data3 = [
-        ["id",  "col1", "col3"],
-        [1,2,None],
-        [2, 3,None]
+        ["id",  "col1", "col3", 'col2'],
+        [1,2,None,100],
+        [2, 3,None, 9],
+        [35,36,None, 37]
     ]
     for i in range(1000):
-        data3.append([2+i, 2, None])
+        data3.append([2+i, 2, None, 0])
 
     with open(DIR+"\\test7.csv", 'w', newline='') as csvfile:
         w = csv.writer(csvfile, delimiter=',')

--- a/pysqldb3/tests/helpers.py
+++ b/pysqldb3/tests/helpers.py
@@ -26,12 +26,12 @@ def set_up_test_csv():
             'neighborhood': {0: 'Corona', 1: 'Kensington', 2: 'Morris Heights', 3: 'Bayside', 4: 'Inwood'},
             'sale date': {0: '1/1/2015', 1: '2/25/2012', 2: '7/9/2018', 3: '12/2/2021', 4: '11/13/1995'}}
     df = pd.DataFrame(data)
-    df.to_csv(os.path.dirname(os.path.abspath(__file__)) + "\\test_data\\test.csv", index=False)
-    df.to_csv(os.path.dirname(os.path.abspath(__file__)) + "\\test_data\\test2.csv", index=False, sep='|')
-    df.to_csv(os.path.dirname(os.path.abspath(__file__)) + "\\test_data\\test3.csv", index=False, header=False)
+    df.to_csv(DIR+"\\test.csv", index=False)
+    df.to_csv(DIR+"\\test2.csv", index=False, sep='|')
+    df.to_csv(DIR+"\\test3.csv", index=False, header=False)
 
     data['neighborhood'][0] = data['neighborhood'][0] * 500
-    df.to_csv(os.path.dirname(os.path.abspath(__file__)) + "\\test_data\\varchar.csv", index=False, header=False)
+    df.to_csv(DIR+"\\varchar.csv", index=False, header=False)
 
     # add csv with extra header line
     data2 = [
@@ -41,7 +41,29 @@ def set_up_test_csv():
         [9, 9, 9]
     ]
 
-    with open(os.path.dirname(os.path.abspath(__file__)) + "\\test_data\\test4.csv", 'w', newline='') as csvfile:
+    # simple csv with empty column
+    df = pd.DataFrame({"id": {1: 1, 2: 2, 3: 3},
+                       "col1": {1: 'a', 2: 'b'},
+                       "col3": {1: None, 2: None},
+                       "col2": {1: 35, 2: 0},
+                       })
+    df.to_csv(DIR + "\\test6.csv", index=False)
+
+    # bulk csv with empty column
+    data3 = [
+        ["id",  "col1", "col3"],
+        [1,2,None],
+        [2, 3,None]
+    ]
+    for i in range(1000):
+        data3.append([2+i, 2, None])
+
+    with open(DIR+"\\test7.csv", 'w', newline='') as csvfile:
+        w = csv.writer(csvfile, delimiter=',')
+        for row in data3:
+            w.writerow(row)
+
+    with open(DIR+"\\test4.csv", 'w', newline='') as csvfile:
         w = csv.writer(csvfile, delimiter=',')
         for row in data2:
             w.writerow(row)
@@ -50,7 +72,7 @@ def set_up_test_csv():
     for i in range(1000):
         data2.append([1, 2, 3])
 
-    with open(os.path.dirname(os.path.abspath(__file__)) + "\\test_data\\test5.csv", 'w', newline='') as csvfile:
+    with open(DIR+"\\test5.csv", 'w', newline='') as csvfile:
         w = csv.writer(csvfile, delimiter=',')
         for row in data2:
             w.writerow(row)

--- a/pysqldb3/tests/helpers.py
+++ b/pysqldb3/tests/helpers.py
@@ -59,9 +59,24 @@ def set_up_test_csv():
     for i in range(1000):
         data3.append([2+i, 2, None, 0])
 
-    with open(DIR+"\\test7.csv", 'w', newline='') as csvfile:
+    # bulk csv with sparse column - int column with 1 text value
+    data4 = [
+        ["id", "col1", "col3", 'col2'],
+        [1, 2, None, 100],
+        [2, 3, None, 9],
+        [35, 36, None, 37]
+    ]
+    for i in range(100000):
+        data4.append([2 + i, 2, None, 0])
+        i+=1
+    data4.append([2 + i, 'U', None, 0])
+    for j in range(1000):
+        data4.append([2 + i, 2, None, 0])
+        i += 1
+
+    with open(DIR+"\\test8.csv", 'w', newline='') as csvfile:
         w = csv.writer(csvfile, delimiter=',')
-        for row in data3:
+        for row in data4:
             w.writerow(row)
 
     with open(DIR+"\\test4.csv", 'w', newline='') as csvfile:

--- a/pysqldb3/tests/test_csv_to_table.py
+++ b/pysqldb3/tests/test_csv_to_table.py
@@ -53,7 +53,6 @@ class TestCsvToTablePG:
         # Cleanup
         db.drop_table(schema=pg_schema, table=create_table_name)
 
-
     def test_csv_to_table_basic_blank_col(self):
         # csv_to_table
         db.query('drop table if exists {}.{}'.format(pg_schema, create_table_name))
@@ -422,7 +421,7 @@ class TestBulkCSVToTablePG:
         # bulk_csv_to_table
         db.query('drop table if exists {}.{}'.format(pg_schema, create_table_name))
 
-        fp = os.path.dirname(os.path.abspath(__file__)) + "\\test_data\\test7.csv"
+        fp = os.path.dirname(os.path.abspath(__file__)) + "\\test_data\\test8.csv"
         input_schema = db.dataframe_to_table_schema(df=pd.read_csv(fp), table=create_table_name, schema=pg_schema)
         db._bulk_csv_to_table(input_file=fp, table=create_table_name, schema=pg_schema, table_schema=input_schema)
 
@@ -434,6 +433,7 @@ class TestBulkCSVToTablePG:
         csv_df = pd.read_csv(fp)
         csv_df.columns = [c.replace(' ', '_') for c in list(csv_df.columns)]  # TODO: look into this difference
 
+
         # Assert df equality, including dtypes and columns - non-null columns
         pd.testing.assert_frame_equal(db_df[['id', 'col1', 'col2']], csv_df[['id', 'col1', 'col2']])
 
@@ -443,6 +443,32 @@ class TestBulkCSVToTablePG:
 
         # Cleanup
         db.drop_table(schema=pg_schema, table=create_table_name)
+
+    def test_bulk_csv_to_table_basic_sparse_data(self):
+        # bulk_csv_to_table
+        db.query('drop table if exists {}.{}'.format(pg_schema, pg_table_name))
+
+        fp = os.path.dirname(os.path.abspath(__file__)) + "\\test_data\\test8.csv"
+        input_schema = db.dataframe_to_table_schema(df=pd.read_csv(fp), table=pg_table_name, schema=pg_schema)
+        db._bulk_csv_to_table(input_file=fp, table=pg_table_name, schema=pg_schema, table_schema=input_schema)
+
+        # Check to see if table is in database
+        assert db.table_exists(table=pg_table_name, schema=pg_schema)
+        db_df = db.dfquery("select * from {}.{}".format(pg_schema, pg_table_name))
+
+        # Get csv df via pd.read_csv
+        csv_df = pd.read_csv(fp)
+        csv_df.columns = [c.replace(' ', '_') for c in list(csv_df.columns)]  # TODO: look into this difference
+
+        # Assert df equality, including dtypes and columns - non-null columns
+        pd.testing.assert_frame_equal(db_df[['id', 'col1', 'col2']], csv_df[['id', 'col1', 'col2']])
+
+        # assert null column in db is varchar
+        assert [_ for _ in db.get_table_columns(pg_table_name, schema=pg_schema) if _[0] == 'col3'][0][
+                   1] == 'character varying'
+
+        # Cleanup
+        db.drop_table(schema=pg_schema, table=pg_table_name)
 
     def test_bulk_csv_to_table_basic_kwargs(self):
         # csv_to_table
@@ -917,7 +943,7 @@ class TestBulkCSVToTableMS:
 
     def test_bulk_csv_to_table_basic_blank_col(self):
         # bulk_csv_to_table
-        db.query('drop table if exists {}.{}'.format(sql_schema, create_table_name))
+        sql.query('drop table if exists {}.{}'.format(sql_schema, create_table_name))
 
         fp = os.path.dirname(os.path.abspath(__file__)) + "\\test_data\\test7.csv"
         input_schema = sql.dataframe_to_table_schema(df=pd.read_csv(fp), table=create_table_name, schema=sql_schema)
@@ -930,6 +956,33 @@ class TestBulkCSVToTableMS:
         # Get csv df via pd.read_csv
         csv_df = pd.read_csv(fp)
         csv_df.columns = [c.replace(' ', '_') for c in list(csv_df.columns)]  # TODO: look into this difference
+
+        # Assert df equality, including dtypes and columns - non-null columns
+        pd.testing.assert_frame_equal(db_df[['id', 'col1', 'col2']], csv_df[['id', 'col1', 'col2']])
+
+        # assert null column in db is varchar
+        assert [_ for _ in sql.get_table_columns(create_table_name, schema=sql_schema) if _[0] == 'col3'][0][
+                   1] == 'varchar'
+
+        # Cleanup
+        sql.drop_table(schema=sql_schema, table=create_table_name)
+
+    def test_bulk_csv_to_table_basic_sparse_data(self):
+        # bulk_csv_to_table
+        sql.query('drop table if exists {}.{}'.format(sql_schema, create_table_name))
+
+        fp = os.path.dirname(os.path.abspath(__file__)) + "\\test_data\\test8.csv"
+        input_schema = sql.dataframe_to_table_schema(df=pd.read_csv(fp), table=create_table_name, schema=sql_schema)
+        sql._bulk_csv_to_table(input_file=fp, table=create_table_name, schema=sql_schema, table_schema=input_schema)
+
+        # Check to see if table is in database
+        assert sql.table_exists(table=create_table_name, schema=sql_schema)
+        db_df = sql.dfquery("select * from {}.{}".format(sql_schema, create_table_name))
+
+        # Get csv df via pd.read_csv
+        csv_df = pd.read_csv(fp)
+        csv_df.columns = [c.replace(' ', '_') for c in list(csv_df.columns)]  # TODO: look into this difference
+
 
         # Assert df equality, including dtypes and columns - non-null columns
         pd.testing.assert_frame_equal(db_df[['id', 'col1', 'col2']], csv_df[['id', 'col1', 'col2']])

--- a/pysqldb3/tests/test_csv_to_table.py
+++ b/pysqldb3/tests/test_csv_to_table.py
@@ -36,7 +36,7 @@ class TestCsvToTablePG:
         # csv_to_table
         db.query('drop table if exists {}.{}'.format(pg_schema, create_table_name))
 
-        fp = os.path.dirname(os.path.abspath(__file__)) + "\\test_data\\test.csv"
+        fp = helpers.DIR + "\\test.csv"
         db.csv_to_table(input_file=fp, table=create_table_name, schema=pg_schema)
 
         # Check to see if table is in database
@@ -57,7 +57,7 @@ class TestCsvToTablePG:
         # csv_to_table
         db.query('drop table if exists {}.{}'.format(pg_schema, create_table_name))
 
-        fp = os.path.dirname(os.path.abspath(__file__)) + "\\test_data\\test6.csv"
+        fp = helpers.DIR + "\\test6.csv"
         db.csv_to_table(input_file=fp, table=create_table_name, schema=pg_schema)
 
         # Check to see if table is in database
@@ -81,7 +81,7 @@ class TestCsvToTablePG:
         # csv_to_table
         db.query('drop table if exists {}.{}'.format(pg_schema, create_table_name))
 
-        fp = os.path.dirname(os.path.abspath(__file__)) + "\\test_data\\test.csv"
+        fp = helpers.DIR + "\\test.csv"
         db.csv_to_table_pyarrow(input_file=fp, table=create_table_name, schema=pg_schema)
 
         # Check to see if table is in database
@@ -176,7 +176,7 @@ class TestCsvToTablePG:
         # csv_to_table
         db.query('drop table if exists {}.{}'.format(pg_schema, create_table_name))
 
-        fp = os.path.dirname(os.path.abspath(__file__)) + "\\test_data\\test4.csv"
+        fp = helpers.DIR + "\\test4.csv"
         db.csv_to_table(input_file=fp, table=create_table_name, schema=pg_schema,
                         skiprows=1, skipfooter=1)
 
@@ -198,7 +198,7 @@ class TestCsvToTablePG:
         # csv_to_table
         db.query('drop table if exists {}.{}'.format(pg_schema, create_table_name))
 
-        fp = os.path.dirname(os.path.abspath(__file__)) + "\\test_data\\test4.csv"
+        fp = helpers.DIR + "\\test4.csv"
         db.csv_to_table_pyarrow(input_file=fp, table=create_table_name, schema=pg_schema,
                         skip_rows=1)
 
@@ -218,7 +218,7 @@ class TestCsvToTablePG:
 
     def test_csv_to_table_column_override(self):
         db.drop_table(schema=pg_schema, table=create_table_name)
-        fp = os.path.dirname(os.path.abspath(__file__)) + "\\test_data\\csv_override_ex.csv"
+        fp = helpers.DIR + "\\csv_override_ex.csv"
         test_df = pd.DataFrame([{'a': 1, 'b': 2, 'c': 3, 'd': 'text'}, {'a': 4, 'b': 5, 'c': 6, 'd': 'another'}])
         test_df.to_csv(fp)
         db.csv_to_table(input_file=fp, table=create_table_name, schema=pg_schema, column_type_overrides={'a': 'varchar'})
@@ -250,7 +250,7 @@ class TestCsvToTablePG:
 
     def test_csv_to_table_column_override_pyarrow(self):
         db.drop_table(schema=pg_schema, table=create_table_name)
-        fp = os.path.dirname(os.path.abspath(__file__)) + "\\test_data\\csv_override_ex.csv"
+        fp = helpers.DIR + "\\csv_override_ex.csv"
         test_df = pd.DataFrame([{'a': 1, 'b': 2, 'c': 3, 'd': 'text'}, {'a': 4, 'b': 5, 'c': 6, 'd': 'another'}])
         test_df.to_csv(fp)
         db.csv_to_table_pyarrow(
@@ -289,7 +289,7 @@ class TestCsvToTablePG:
         # csv_to_table
         db.query('drop table if exists {}.{}'.format(pg_schema, create_table_name))
 
-        fp = os.path.dirname(os.path.abspath(__file__)) + "\\test_data\\test2.csv"
+        fp = helpers.DIR + "\\test2.csv"
         db.csv_to_table(
             input_file=fp,
             table=create_table_name, schema=pg_schema,
@@ -315,7 +315,7 @@ class TestCsvToTablePG:
         # csv_to_table
         db.query('drop table if exists {}.{}'.format(pg_schema,create_table_name))
 
-        fp = os.path.dirname(os.path.abspath(__file__)) + "\\test_data\\test3.csv"
+        fp = helpers.DIR + "\\test3.csv"
         db.csv_to_table(
             input_file=fp,
             table=create_table_name, schema=pg_schema, sep="|")
@@ -342,7 +342,7 @@ class TestCsvToTablePG:
         assert db.table_exists(table=create_table_name, schema=pg_schema)
 
         # csv_to_table
-        fp = os.path.dirname(os.path.abspath(__file__)) + "\\test_data\\test.csv"
+        fp = helpers.DIR + "\\test.csv"
         db.csv_to_table(input_file=fp, table=create_table_name, schema=pg_schema, overwrite=True)
 
         # Check to see if table is in database
@@ -364,7 +364,7 @@ class TestCsvToTablePG:
         db.query('drop table if exists {}.{}'.format(pg_schema, create_table_name))
 
         base_string = 'text'*150
-        fp = os.path.dirname(os.path.abspath(__file__)) + "\\test_data\\varchar.csv"
+        fp = helpers.DIR + "\\varchar.csv"
         db.dfquery("select '{}' as long_col".format(base_string)).to_csv(fp, index=False)
         db.csv_to_table(input_file=fp, table=create_table_name, schema=pg_schema, long_varchar_check=True)
 
@@ -399,7 +399,7 @@ class TestBulkCSVToTablePG:
         # bulk_csv_to_table
         db.query('drop table if exists {}.{}'.format(pg_schema, create_table_name))
 
-        fp = os.path.dirname(os.path.abspath(__file__)) + "\\test_data\\test.csv"
+        fp = helpers.DIR + "\\test.csv"
         input_schema = db.dataframe_to_table_schema(df=pd.read_csv(fp), table=create_table_name, schema=pg_schema)
         db._bulk_csv_to_table(input_file=fp, table=create_table_name, schema=pg_schema, table_schema=input_schema)
 
@@ -421,7 +421,7 @@ class TestBulkCSVToTablePG:
         # bulk_csv_to_table
         db.query('drop table if exists {}.{}'.format(pg_schema, create_table_name))
 
-        fp = os.path.dirname(os.path.abspath(__file__)) + "\\test_data\\test8.csv"
+        fp = helpers.DIR + "\\test8.csv"
         input_schema = db.dataframe_to_table_schema(df=pd.read_csv(fp), table=create_table_name, schema=pg_schema)
         db._bulk_csv_to_table(input_file=fp, table=create_table_name, schema=pg_schema, table_schema=input_schema)
 
@@ -448,7 +448,7 @@ class TestBulkCSVToTablePG:
         # bulk_csv_to_table
         db.query('drop table if exists {}.{}'.format(pg_schema, pg_table_name))
 
-        fp = os.path.dirname(os.path.abspath(__file__)) + "\\test_data\\test8.csv"
+        fp = helpers.DIR + "\\test8.csv"
         input_schema = db.dataframe_to_table_schema(df=pd.read_csv(fp), table=pg_table_name, schema=pg_schema)
         db._bulk_csv_to_table(input_file=fp, table=pg_table_name, schema=pg_schema, table_schema=input_schema)
 
@@ -474,7 +474,7 @@ class TestBulkCSVToTablePG:
         # csv_to_table
         db.query('drop table if exists {}.{}'.format(pg_schema, create_table_name))
 
-        fp = os.path.dirname(os.path.abspath(__file__)) + "\\test_data\\test5.csv"
+        fp = helpers.DIR + "\\test5.csv"
         db.csv_to_table(input_file=fp, table=create_table_name, schema=pg_schema,
                         skiprows=1)
 
@@ -493,7 +493,7 @@ class TestBulkCSVToTablePG:
         # bulk_csv_to_table
         db.query('drop table if exists {}'.format(create_table_name))
 
-        fp = os.path.dirname(os.path.abspath(__file__)) + "\\test_data\\test.csv"
+        fp = helpers.DIR + "\\test.csv"
         input_schema = db.dataframe_to_table_schema(df=pd.read_csv(fp), table=create_table_name)
         db._bulk_csv_to_table(input_file=fp, table=create_table_name, table_schema=input_schema)
 
@@ -516,7 +516,7 @@ class TestBulkCSVToTablePG:
         if db.table_exists(schema=pg_schema, table=create_table_name):
             db.drop_table(schema=pg_schema, table=create_table_name)
 
-        fp = os.path.dirname(os.path.abspath(__file__)) + "\\test_data\\varchar.csv"
+        fp = helpers.DIR + "\\varchar.csv"
         pd.DataFrame(['text'*150]*10000, columns=['long_column']).to_csv(fp)
         db.csv_to_table(input_file=fp, table=create_table_name, schema=pg_schema, long_varchar_check=True)
 
@@ -555,7 +555,7 @@ class TestCsvToTableMS:
         if sql.table_exists(schema=sql_schema, table=create_table_name):
             sql.query('drop table {}.{}'.format(sql_schema, create_table_name))
 
-        fp = os.path.dirname(os.path.abspath(__file__)) + "\\test_data\\test.csv"
+        fp = helpers.DIR + "\\test.csv"
         sql.csv_to_table(input_file=fp, table=create_table_name, schema=sql_schema)
 
         # Check to see if table is in database
@@ -576,7 +576,7 @@ class TestCsvToTableMS:
         # csv_to_table
         sql.query('drop table if exists {}.{}'.format(sql_schema, create_table_name))
 
-        fp = os.path.dirname(os.path.abspath(__file__)) + "\\test_data\\test6.csv"
+        fp = helpers.DIR + "\\test6.csv"
         sql.csv_to_table(input_file=fp, table=create_table_name, schema=sql_schema)
 
         # Check to see if table is in database
@@ -600,7 +600,7 @@ class TestCsvToTableMS:
         # csv_to_table
         sql.query('drop table if exists {}.{}'.format(sql_schema, create_table_name))
 
-        fp = os.path.dirname(os.path.abspath(__file__)) + "\\test_data\\test.csv"
+        fp = helpers.DIR + "\\test.csv"
         sql.csv_to_table_pyarrow(input_file=fp, table=create_table_name, schema=sql_schema)
 
         # Check to see if table is in database
@@ -694,7 +694,7 @@ class TestCsvToTableMS:
         # csv_to_table
         sql.query('drop table if exists {}.{}'.format(sql_schema, create_table_name))
 
-        fp = os.path.dirname(os.path.abspath(__file__)) + "\\test_data\\test4.csv"
+        fp = helpers.DIR + "\\test4.csv"
         sql.csv_to_table(input_file=fp, table=create_table_name, schema=sql_schema,
                         skiprows=1, skipfooter=1)
 
@@ -716,7 +716,7 @@ class TestCsvToTableMS:
         # csv_to_table
         sql.query('drop table if exists {}.{}'.format(sql_schema, create_table_name))
 
-        fp = os.path.dirname(os.path.abspath(__file__)) + "\\test_data\\test4.csv"
+        fp = helpers.DIR + "\\test4.csv"
         sql.csv_to_table_pyarrow(input_file=fp, table=create_table_name, schema=sql_schema,
                         skip_rows=1)
 
@@ -737,7 +737,7 @@ class TestCsvToTableMS:
     def test_csv_to_table_column_override(self):
         sql.drop_table(schema=sql_schema, table=create_table_name)
 
-        fp = os.path.dirname(os.path.abspath(__file__)) + "\\test_data\\csv_override_ex.csv"
+        fp = helpers.DIR + "\\csv_override_ex.csv"
         test_df = pd.DataFrame([{'a': 1, 'b': 2, 'c': 3, 'd': 'text'}, {'a': 4, 'b': 5, 'c': 6, 'd': 'another'}])
         test_df.to_csv(fp)
         sql.csv_to_table(input_file=fp, table=create_table_name, schema=sql_schema,
@@ -763,7 +763,7 @@ class TestCsvToTableMS:
 
     def test_csv_to_table_column_override_pyarrow(self):
         sql.drop_table(schema=sql_schema, table=create_table_name)
-        fp = os.path.dirname(os.path.abspath(__file__)) + "\\test_data\\csv_override_ex.csv"
+        fp = helpers.DIR + "\\csv_override_ex.csv"
         test_df = pd.DataFrame([{'a': 1, 'b': 2, 'c': 3, 'd': 'text'}, {'a': 4, 'b': 5, 'c': 6, 'd': 'another'}])
         test_df.to_csv(fp)
         sql.csv_to_table_pyarrow(
@@ -801,7 +801,7 @@ class TestCsvToTableMS:
         if sql.table_exists(schema=sql_schema, table=create_table_name):
             sql.query('drop table {}.{}'.format(sql_schema, create_table_name))
 
-        fp = os.path.dirname(os.path.abspath(__file__)) + "\\test_data\\test2.csv"
+        fp = helpers.DIR + "\\test2.csv"
         sql.csv_to_table(
             input_file=fp,
             table=create_table_name, schema=sql_schema,
@@ -828,7 +828,7 @@ class TestCsvToTableMS:
         if sql.table_exists(schema=sql_schema, table=create_table_name):
             sql.query('drop table {}.{}'.format(sql_schema, create_table_name))
 
-        fp = os.path.dirname(os.path.abspath(__file__)) + "\\test_data\\test3.csv"
+        fp = helpers.DIR + "\\test3.csv"
         sql.csv_to_table(
             input_file=fp,
             table=create_table_name, schema=sql_schema, sep="|")
@@ -863,7 +863,7 @@ class TestCsvToTableMS:
         assert sql.table_exists(table=create_table_name, schema=sql_schema)
 
         # csv_to_table
-        fp = os.path.dirname(os.path.abspath(__file__)) + "\\test_data\\test.csv"
+        fp = helpers.DIR + "\\test.csv"
         sql.csv_to_table(input_file=fp, table=create_table_name, schema=sql_schema, overwrite=True)
 
         # Check to see if table is in database
@@ -890,7 +890,7 @@ class TestCsvToTableMS:
             sql.drop_table(schema=sql_schema, table=create_table_name)
 
         base_string = 'text'*150
-        fp = os.path.dirname(os.path.abspath(__file__)) + "\\test_data\\varchar.csv"
+        fp = helpers.DIR + "\\varchar.csv"
         sql.dfquery("select '{}' as long_col".format(base_string)).to_csv(fp, index=False)
         sql.csv_to_table(input_file=fp, table=create_table_name, schema=sql_schema, long_varchar_check=True)
 
@@ -923,7 +923,7 @@ class TestBulkCSVToTableMS:
         if sql.drop_table(schema=sql_schema, table=create_table_name):
             sql.query('drop table {}.{}'.format(sql_schema, create_table_name))
 
-        fp = os.path.dirname(os.path.abspath(__file__)) + "\\test_data\\test.csv"
+        fp = helpers.DIR + "\\test.csv"
         input_schema = sql.dataframe_to_table_schema(df=pd.read_csv(fp), table=create_table_name, schema=sql_schema)
         sql._bulk_csv_to_table(input_file=fp, table=create_table_name, schema=sql_schema, table_schema=input_schema)
 
@@ -945,7 +945,7 @@ class TestBulkCSVToTableMS:
         # bulk_csv_to_table
         sql.query('drop table if exists {}.{}'.format(sql_schema, create_table_name))
 
-        fp = os.path.dirname(os.path.abspath(__file__)) + "\\test_data\\test7.csv"
+        fp = helpers.DIR + "\\test7.csv"
         input_schema = sql.dataframe_to_table_schema(df=pd.read_csv(fp), table=create_table_name, schema=sql_schema)
         sql._bulk_csv_to_table(input_file=fp, table=create_table_name, schema=sql_schema, table_schema=input_schema)
 
@@ -971,7 +971,7 @@ class TestBulkCSVToTableMS:
         # bulk_csv_to_table
         sql.query('drop table if exists {}.{}'.format(sql_schema, create_table_name))
 
-        fp = os.path.dirname(os.path.abspath(__file__)) + "\\test_data\\test8.csv"
+        fp = helpers.DIR + "\\test8.csv"
         input_schema = sql.dataframe_to_table_schema(df=pd.read_csv(fp), table=create_table_name, schema=sql_schema)
         sql._bulk_csv_to_table(input_file=fp, table=create_table_name, schema=sql_schema, table_schema=input_schema)
 
@@ -998,7 +998,7 @@ class TestBulkCSVToTableMS:
         # csv_to_table
         sql.query('drop table if exists {}.{}'.format(sql_schema, create_table_name))
 
-        fp = os.path.dirname(os.path.abspath(__file__)) + "\\test_data\\test5.csv"
+        fp = helpers.DIR + "\\test5.csv"
         sql.csv_to_table(input_file=fp, table=create_table_name, schema=sql_schema,
                         skiprows=1)
 
@@ -1018,7 +1018,7 @@ class TestBulkCSVToTableMS:
         if sql.table_exists(table=create_table_name):
             sql.query('drop table {}'.format(create_table_name))
 
-        fp = os.path.dirname(os.path.abspath(__file__)) + "\\test_data\\test.csv"
+        fp = helpers.DIR + "\\test.csv"
         input_schema = sql.dataframe_to_table_schema(df=pd.read_csv(fp), table=create_table_name)
         sql._bulk_csv_to_table(input_file=fp, table=create_table_name, table_schema=input_schema)
 
@@ -1042,7 +1042,7 @@ class TestBulkCSVToTableMS:
         if sql.table_exists(schema=sql_schema, table=create_table_name):
             sql.drop_table(schema=sql_schema, table=create_table_name)
 
-        fp = os.path.dirname(os.path.abspath(__file__)) + "\\test_data\\varchar.csv"
+        fp = helpers.DIR + "\\varchar.csv"
         pd.DataFrame(['text'*150]*10000, columns=['long_column']).to_csv(fp)
         sql.csv_to_table(input_file=fp, table=create_table_name, schema=sql_schema, long_varchar_check=True)
 

--- a/pysqldb3/tests/test_data_no_folder/_testing_table_to_csv_2024_04_12_shostetter_.csv
+++ b/pysqldb3/tests/test_data_no_folder/_testing_table_to_csv_2024_04_12_shostetter_.csv
@@ -1,0 +1,4 @@
+WKT,objectid,nd,street1
+,"1","2",Mulberry
+,"2","3",Canal
+,"3","4",Fifth Ave.


### PR DESCRIPTION
When importing data from csv (csv_to_table/bulk) if there are empty columns pandas defaults them to Int datatype, but often this creates issues when merging or updating if the field isnt really always null, but really just very sparsely populated. This identifies fields with this condition and sets the database datatype to varchar. 

Notes:
* Tests are included 
* pyarrow functions are not modified for this behavior 