### PR TITLE
Call pysqldb3 to change permissions to public on pg_to_pg tables

### DIFF
--- a/pysqldb3/cmds.py
+++ b/pysqldb3/cmds.py
@@ -135,7 +135,7 @@ dbname={from_pg_database}  user={from_pg_user} password={from_pg_pass}" {from_pg
 -lco OVERWRITE=yes -nln {to_pg_schema}.{to_pg_name} {nlt_spatial} -progress
 """.replace('\n', ' ')
 
-PG_TO_PG_QRY_CMD = """
+PG_TO_PG_QRY_CMD = r"""
 ogr2ogr --config GDAL_DATA "{gdal_data}" -overwrite -f "PostgreSQL" PG:"host={to_pg_host} port={to_pg_port} 
 dbname={to_pg_database} user={to_pg_user} password={to_pg_pass}" PG:"host={from_pg_host} port={from_pg_port} 
 dbname={from_pg_database}  user={from_pg_user} password={from_pg_pass}"  -sql "{sql_select}"

--- a/pysqldb3/data_io.py
+++ b/pysqldb3/data_io.py
@@ -1,5 +1,6 @@
 import subprocess
 import shlex
+import pysqldb3
 
 from .cmds import *
 from .util import *
@@ -346,6 +347,7 @@ def pg_to_pg(from_pg, to_pg, org_table, org_schema=None, dest_schema=None, print
 
     try:
         ogr_response = subprocess.check_output(shlex.split(cmd.replace('\n', ' ')), stderr=subprocess.STDOUT)
+        to_pg.query(f"GRANT SELECT ON {dest_schema}.{dest_table} TO PUBLIC;")
         print(ogr_response)
     except subprocess.CalledProcessError as e:
         print("Ogr2ogr Output:\n", e.output)

--- a/pysqldb3/data_io.py
+++ b/pysqldb3/data_io.py
@@ -96,7 +96,7 @@ def pg_to_sql(pg, ms, org_table, LDAP=False, spatial=True, org_schema=None, dest
 
 
 def sql_to_pg_qry(ms, pg, query, LDAP=False, spatial=True, dest_schema=None, print_cmd=False, temp=True,
-                  dest_table=None, pg_encoding='UTF8'):
+                  dest_table=None, pg_encoding='UTF8', permission = True):
     """
     Migrates the result of a query from SQL Server database to PostgreSQL database, and generates spatial tables in
     PG if spatial in MS.
@@ -111,6 +111,7 @@ def sql_to_pg_qry(ms, pg, query, LDAP=False, spatial=True, dest_schema=None, pri
     :param temp: flag, defaults to true, for temporary tables
     :param dest_table: destination table name
     :param pg_encoding: encoding to use for PG client (defaults to UTF-8)
+    :param permission: set permission to Public on destination table
     :return:
     """
     if not dest_schema:
@@ -179,6 +180,8 @@ def sql_to_pg_qry(ms, pg, query, LDAP=False, spatial=True, dest_schema=None, pri
     try:
         ogr_response = subprocess.check_output(shlex.split(cmd.replace('\n', ' ')), stderr=subprocess.STDOUT,
                                                env=cmd_env)
+        if permission == True:
+            pg.query(f"GRANT SELECT ON {dest_schema}.{dest_table} TO PUBLIC;") 
         print(ogr_response)
     except subprocess.CalledProcessError as e:
         print("Ogr2ogr Output:\n", e.output)
@@ -194,7 +197,7 @@ def sql_to_pg_qry(ms, pg, query, LDAP=False, spatial=True, dest_schema=None, pri
 
 
 def sql_to_pg(ms, pg, org_table, LDAP=False, spatial=True, org_schema=None, dest_schema=None, print_cmd=False,
-              dest_table=None, temp=True, gdal_data_loc=GDAL_DATA_LOC, pg_encoding='UTF8'):
+              dest_table=None, temp=True, gdal_data_loc=GDAL_DATA_LOC, pg_encoding='UTF8', permission = True):
     """
     Migrates tables from SQL Server to PostgreSQL, generates spatial tables in PG if spatial in MS.
 
@@ -210,6 +213,7 @@ def sql_to_pg(ms, pg, org_table, LDAP=False, spatial=True, org_schema=None, dest
     :param temp: flag, defaults to true, for temporary tables
     :param gdal_data_loc: location of GDAL data
     :param pg_encoding: encoding to use for PG client (defaults to UTF-8)
+    :param permission: set permission to Public on destination table
     :return:
     """
     if not org_schema:
@@ -280,6 +284,8 @@ def sql_to_pg(ms, pg, org_table, LDAP=False, spatial=True, org_schema=None, dest
     try:
         ogr_response = subprocess.check_output(shlex.split(cmd.replace('\n', ' ')), stderr=subprocess.STDOUT,
                                                env=cmd_env)
+        if permission == True:
+            pg.query(f"GRANT SELECT ON {dest_schema}.{dest_table} TO PUBLIC;") 
         print(ogr_response)
     except subprocess.CalledProcessError as e:
         print("Ogr2ogr Output:\n", e.output)
@@ -295,7 +301,7 @@ def sql_to_pg(ms, pg, org_table, LDAP=False, spatial=True, org_schema=None, dest
 
 
 def pg_to_pg(from_pg, to_pg, org_table, org_schema=None, dest_schema=None, print_cmd=False, dest_table=None,
-             spatial=True, temp=True):
+             spatial=True, temp=True, permission = True):
     """
     Migrates tables from one PostgreSQL database to another PostgreSQL.
     :param from_pg: Source database DbConnect object
@@ -307,6 +313,7 @@ def pg_to_pg(from_pg, to_pg, org_table, org_schema=None, dest_schema=None, print
     :param print_cmd: Option to print he ogr2ogr command line statement (defaults to False) - used for debugging
     :param spatial: Flag for spatial table (defaults to True)
     :param temp: temporary table, defaults to true
+    :param permission: set permission to Public on destination table
     :return:
     """
     if not org_schema:
@@ -347,7 +354,10 @@ def pg_to_pg(from_pg, to_pg, org_table, org_schema=None, dest_schema=None, print
 
     try:
         ogr_response = subprocess.check_output(shlex.split(cmd.replace('\n', ' ')), stderr=subprocess.STDOUT)
-        to_pg.query(f"GRANT SELECT ON {dest_schema}.{dest_table} TO PUBLIC;")
+        
+        if permission == True:
+            to_pg.query(f"GRANT SELECT ON {dest_schema}.{dest_table} TO PUBLIC;")
+        
         print(ogr_response)
     except subprocess.CalledProcessError as e:
         print("Ogr2ogr Output:\n", e.output)
@@ -363,7 +373,7 @@ def pg_to_pg(from_pg, to_pg, org_table, org_schema=None, dest_schema=None, print
 
 
 def pg_to_pg_qry(from_pg, to_pg, query, dest_schema=None, print_cmd=False, dest_table=None,
-             spatial=True, temp=True):
+             spatial=True, temp=True, permission = True):
     """
     Migrates query results  from one PostgreSQL database to another PostgreSQL.
     :param from_pg: Source database DbConnect object
@@ -374,6 +384,7 @@ def pg_to_pg_qry(from_pg, to_pg, query, dest_schema=None, print_cmd=False, dest_
     :param print_cmd: Option to print he ogr2ogr command line statement (defaults to False) - used for debugging
     :param spatial: Flag for spatial table (defaults to True)
     :param temp: temporary table, defaults to true
+    :param permission: set permission to Public on destination table
     :return:
     """
 
@@ -418,6 +429,10 @@ def pg_to_pg_qry(from_pg, to_pg, query, dest_schema=None, print_cmd=False, dest_
 
     try:
         ogr_response = subprocess.check_output(shlex.split(cmd.replace('\n', ' ')), stderr=subprocess.STDOUT)
+        
+        if permission:
+            to_pg.query(f"GRANT SELECT ON {dest_schema}.{dest_table} TO PUBLIC;")
+        
         print(ogr_response)
     except subprocess.CalledProcessError as e:
         print ("Ogr2ogr Output:\n", e.output)

--- a/pysqldb3/tests/test_io.py
+++ b/pysqldb3/tests/test_io.py
@@ -601,6 +601,11 @@ class TestPgToPg:
                                       check_exact=False
                                       )
 
+        # Assert that the permissions is in PUBLIC
+        assert ris.dfquery(f"""SELECT bool_or(CASE WHEN GRANTEE IN ('PUBLIC') THEN True ELSE False END)
+                            FROM information_schema.role_table_grants 
+                            WHERE table_schema = '{pg_schema}' and table_name = '{test_pg_to_pg_tbl}'""").values[0][0]  == True, "Dest table permissions not set to PUBLIC"
+
         # Cleanup
         db.drop_table(schema=pg_schema, table=test_pg_to_pg_tbl)
         ris.drop_table(schema=pg_schema, table=test_pg_to_pg_tbl)
@@ -652,6 +657,11 @@ class TestPgToPg:
         # Assert
         pd.testing.assert_frame_equal(risdf.drop(['geom', 'ogc_fid'], axis=1), dbdf.drop(['geom'], axis=1),
                                       check_exact=False)
+
+        # Assert that the permissions is in PUBLIC
+        assert ris.dfquery(f"""SELECT bool_or(CASE WHEN GRANTEE IN ('PUBLIC') THEN True ELSE False END)
+                            FROM information_schema.role_table_grants 
+                            WHERE table_schema = '{pg_schema}' and table_name = '{test_pg_to_pg_tbl_other}'""").values[0][0]  == True, "Dest table permissions not set to PUBLIC"
 
         # Cleanup
         ris.drop_table(schema=pg_schema, table=test_pg_to_pg_tbl_other)

--- a/pysqldb3/tests/test_io.py
+++ b/pysqldb3/tests/test_io.py
@@ -285,6 +285,10 @@ class TestSqlToPgQry:
         pd.testing.assert_frame_equal(sql_df, pg_df.drop(['geom', 'ogc_fid'], axis = 1),
                                     check_dtype=False,
                                       check_column_type=False)
+        
+        assert db.dfquery(f"""SELECT bool_or(CASE WHEN GRANTEE IN ('PUBLIC') THEN True ELSE False END)
+                            FROM information_schema.role_table_grants 
+                            WHERE table_schema = '{pg_schema}' and table_name = '{test_sql_to_pg_qry_table}'""").values[0][0]  == True, "Dest table permissions not set to PUBLIC"
 
         # Cleanup
         db.drop_table(schema=pg_schema, table=test_sql_to_pg_qry_table)
@@ -328,6 +332,10 @@ class TestSqlToPgQry:
         pd.testing.assert_frame_equal(sql_df, pg_df.drop(['geom', 'ogc_fid'], axis = 1),
                                     check_dtype=False,
                                       check_column_type=False)
+        
+        assert db.dfquery(f"""SELECT bool_or(CASE WHEN GRANTEE IN ('PUBLIC') THEN True ELSE False END)
+                            FROM information_schema.role_table_grants 
+                            WHERE table_schema = '{pg_schema}' and table_name = '{test_sql_to_pg_qry_table}'""").values[0][0]  == True, "Dest table permissions not set to PUBLIC"
 
         # Cleanup
         db.drop_table(schema=pg_schema, table=test_sql_to_pg_qry_table)
@@ -389,6 +397,10 @@ class TestSqlToPgQry:
     
         assert len(spatial_df) == len(not_spatial_df) and len(joined_df) == len(
              joined_df[joined_df['geom_x'] != joined_df['geom_y']])
+        
+        assert db.dfquery(f"""SELECT bool_or(CASE WHEN GRANTEE IN ('PUBLIC') THEN True ELSE False END)
+                            FROM information_schema.role_table_grants 
+                            WHERE table_schema = '{pg_schema}' and table_name = '{test_sql_to_pg_qry_spatial_table}'""").values[0][0]  == True, "Dest table permissions not set to PUBLIC"
     
         db.drop_table(schema=pg_schema, table=test_sql_to_pg_qry_table)
         db.drop_table(schema=pg_schema, table=test_sql_to_pg_qry_spatial_table)
@@ -430,6 +442,10 @@ class TestSqlToPgQry:
         # Assert
         pd.testing.assert_frame_equal(sql_df, pg_df.drop(['ogc_fid', 'geom'], axis = 1), check_column_type=False,
                                       check_dtype=False)
+        
+        assert db.dfquery(f"""SELECT bool_or(CASE WHEN GRANTEE IN ('PUBLIC') THEN True ELSE False END)
+                            FROM information_schema.role_table_grants 
+                            WHERE table_schema = '{pg_schema}' and table_name = '{test_sql_to_pg_qry_table}'""").values[0][0]  == True, "Dest table permissions not set to PUBLIC"
 
         # Cleanup
         db.drop_table(schema=pg_schema, table=test_sql_to_pg_qry_table)
@@ -487,6 +503,10 @@ class TestSqlToPg:
         pd.testing.assert_frame_equal(sql_df, pg_df.drop(['geom', 'ogc_fid'], axis=1),
                                       check_dtype=False, check_column_type=False)
 
+        assert db.dfquery(f"""SELECT bool_or(CASE WHEN GRANTEE IN ('PUBLIC') THEN True ELSE False END)
+                            FROM information_schema.role_table_grants 
+                            WHERE table_schema = '{pg_schema}' and table_name = '{test_sql_to_pg_table}'""").values[0][0]  == True, "Dest table permissions not set to PUBLIC"
+
         # Cleanup
         db.drop_table(schema=pg_schema, table=test_sql_to_pg_table)
         sql.drop_table(schema=sql_schema, table=test_sql_to_pg_table)
@@ -526,6 +546,10 @@ class TestSqlToPg:
         pd.testing.assert_frame_equal(sql_df, pg_df.drop(['geom', 'ogc_fid'], axis=1),
                                       check_dtype=False,
                                       check_column_type=False)
+        
+        assert db.dfquery(f"""SELECT bool_or(CASE WHEN GRANTEE IN ('PUBLIC') THEN True ELSE False END)
+                            FROM information_schema.role_table_grants 
+                            WHERE table_schema = '{pg_schema}' and table_name = '{test_sql_to_pg_table}'""").values[0][0]  == True, "Dest table permissions not set to PUBLIC"
 
         # Cleanup
         db.drop_table(schema=pg_schema, table=test_sql_to_pg_table)
@@ -662,7 +686,6 @@ class TestPgToPg:
         assert ris.dfquery(f"""SELECT bool_or(CASE WHEN GRANTEE IN ('PUBLIC') THEN True ELSE False END)
                             FROM information_schema.role_table_grants 
                             WHERE table_schema = '{pg_schema}' and table_name = '{test_pg_to_pg_tbl_other}'""").values[0][0]  == True, "Dest table permissions not set to PUBLIC"
-
         # Cleanup
         ris.drop_table(schema=pg_schema, table=test_pg_to_pg_tbl_other)
         db.drop_table(schema=pg_schema, table=test_pg_to_pg_tbl)
@@ -725,6 +748,10 @@ class TestPgToPgQry:
         pd.testing.assert_frame_equal(org_pg_df, pg_df.drop(['ogc_fid'], axis=1), check_dtype=False,
                                       check_column_type=False)
 
+        assert db.dfquery(f"""SELECT bool_or(CASE WHEN GRANTEE IN ('PUBLIC') THEN True ELSE False END)
+                            FROM information_schema.role_table_grants 
+                            WHERE table_schema = '{pg_schema}' and table_name = '{test_pg_to_pg_qry_table}'""").values[0][0]  == True, "Dest table permissions not set to PUBLIC"
+
         # Cleanup
         db.drop_table(schema=pg_schema, table=test_pg_to_pg_qry_table)
         org_pg.drop_table(schema=pg_schema, table=test_pg_to_pg_qry_table)
@@ -779,6 +806,10 @@ class TestPgToPgQry:
         pd.testing.assert_frame_equal(org_pg_df, pg_df.drop(['ogc_fid'], axis=1), check_dtype=False,
                                       check_column_type=False)
 
+        assert db.dfquery(f"""SELECT bool_or(CASE WHEN GRANTEE IN ('PUBLIC') THEN True ELSE False END)
+                            FROM information_schema.role_table_grants 
+                            WHERE table_schema = '{pg_schema}' and table_name = '{test_pg_to_pg_qry_table}'""").values[0][0]  == True, "Dest table permissions not set to PUBLIC"
+
         # Cleanup
         db.drop_table(schema=pg_schema, table=test_pg_to_pg_qry_table)
         org_pg.drop_table(schema=pg_schema, table=test_pg_to_pg_qry_table)
@@ -827,6 +858,10 @@ class TestPgToPgQry:
         # Assert
         pd.testing.assert_frame_equal(org_pg_df, pg_df.drop(['ogc_fid'], axis=1), check_column_type=False,
                                       check_dtype=False)
+        
+        assert db.dfquery(f"""SELECT bool_or(CASE WHEN GRANTEE IN ('PUBLIC') THEN True ELSE False END)
+                            FROM information_schema.role_table_grants 
+                            WHERE table_schema = '{pg_schema}' and table_name = '{test_pg_to_pg_qry_table}'""").values[0][0]  == True, "Dest table permissions not set to PUBLIC"
 
         # Cleanup
         db.drop_table(schema=pg_schema, table=test_pg_to_pg_qry_table)


### PR DESCRIPTION
This is related to the Issue #53.
Importing pysqldb3 was the only way that I could change permissions. Looked for a solution in ogr2ogr but couldn't find one.