### PR TITLE
Sample tests for sql_to_sql functions

### DIFF
--- a/pysqldb3/data_io.py
+++ b/pysqldb3/data_io.py
@@ -433,7 +433,7 @@ def sql_to_sql(from_sql, to_sql, org_table, LDAP_from=False, LDAP_to=False, spat
     # enforce column data types in dest match the source
     for c in cols.keys():
         if '-' in c:
-            # GDAL sanitizes `'` out of column names this will put them back so the start/end tables match
+            # GDAL sanitizes `-` out of column names this will put them back so the start/end tables match
             to_sql.query(f"""EXEC sp_rename '{dest_schema}.{dest_table}.{c.replace('-', '_')}', '{c}', 'COLUMN';""")
             cols_to = to_sql.get_table_columns(dest_table, schema=dest_schema)
             cols_to = {_[0]: _[1] for _ in cols_to}

--- a/pysqldb3/data_io.py
+++ b/pysqldb3/data_io.py
@@ -421,9 +421,31 @@ def sql_to_sql(from_sql, to_sql, org_table, LDAP_from=False, LDAP_to=False, spat
     if not dest_table:
         dest_table = org_table
 
+    sql_to_sql_qry(from_sql, to_sql,
+           f'select * from [{org_schema}].[{org_table}]', LDAP_from, LDAP_to, spatial, org_schema, dest_schema, print_cmd, dest_table, temp,
+           gdal_data_loc, pg_encoding, permission)
 
-    sql_to_sql_qry(from_sql, to_sql, f'select * from [{org_schema}].[{org_table}]', LDAP_from, LDAP_to, spatial, org_schema, dest_schema, print_cmd, dest_table, temp,
-                   gdal_data_loc, pg_encoding, permission)
+    cols = from_sql.get_table_columns(org_table, schema=org_schema)
+    cols = {c[0]:c[1] for c in cols}
+    cols_to = to_sql.get_table_columns(dest_table, schema=dest_schema)
+    cols_to = {c[0]: c[1] for c in cols_to}
+
+    # enforce column data types in dest match the source
+    for c in cols.keys():
+        if '-' in c:
+            # GDAL sanitizes `'` out of column names this will put them back so the start/end tables match
+            to_sql.query(f"""EXEC sp_rename '{dest_schema}.{dest_table}.{c.replace('-', '_')}', '{c}', 'COLUMN';""")
+            cols_to = to_sql.get_table_columns(dest_table, schema=dest_schema)
+            cols_to = {_[0]: _[1] for _ in cols_to}
+        if cols[c] != cols_to[c]:
+            if 'varchar' in cols[c] and 'nvarchar' in cols_to[c]:
+                # allow upgrade to nvarchar
+                pass
+            else:
+                to_sql.query(f"ALTER TABLE [{dest_schema}].[{dest_table}] ALTER COLUMN [{c}] {cols[c]}",
+                         timeme=False, internal=True, strict=False)
+
+
 
 
 

--- a/pysqldb3/pysqldb3.py
+++ b/pysqldb3/pysqldb3.py
@@ -720,7 +720,11 @@ class DbConnect:
         if full:
             columns = '*'
         else:
-            columns = "column_name, data_type"
+            if self.type == PG:
+                columns = "column_name, data_type"
+            else:
+                columns = "column_name, case when CHARACTER_MAXIMUM_LENGTH is not null then " \
+                          "DATA_TYPE + ' ('+ cast(CHARACTER_MAXIMUM_LENGTH as varchar)+')' else DATA_TYPE end as DATA_TYPE"
 
         if self.type == PG:
             self.query("""


### PR DESCRIPTION
- This branch is built off `dev` and therefore doesn't have the `sql_to_sql` functions in the branch yet, as you had requested.
- Several of the tests were failing when I had tried the tests in your `84-data-io-needs-sql-to-sql` branch. The issues were that that geometry columns get renamed when they are copied from one server/db to another (not sure if you want to change the way the function works so that it doesn't change the column name from `geom` to `ogr_geometry`, datetime column in one of the test tables seemed to have an issue, and there were dtypes that seemed to have gotten changed when copying the table.