### PR TITLE
Move rename_geom function out of Shapefile.py

### DIFF
--- a/pysqldb3/tests/test_query_to_shp.py
+++ b/pysqldb3/tests/test_query_to_shp.py
@@ -30,10 +30,10 @@ sql = pysqldb.DbConnect(type=config.get('SQL_DB', 'TYPE'),
 #                              server='DOTGISSQL01',
 #                              ldap=True)
 
-test_table = '__testing_query_to_shp_{}__'.format(db.user)
+test_table = f'__testing_query_to_shp_{db.user}__'
 
 ms_schema = 'risadmin'
-pg_schmma = 'working'
+pg_schema = 'working'
 
 
 class TestQueryToShpPg:
@@ -41,18 +41,18 @@ class TestQueryToShpPg:
         fldr = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'test_data')
         shp = 'test.shp'
 
+        db.drop_table(schema = pg_schema, table = test_table)
         # create table
-        db.query("""
-            DROP TABLE IF EXISTS {s}.{t};
-            CREATE TABLE {s}.{t} (id int, txt text, dte timestamp, geom geometry(Point));
+        db.query(f"""
+            CREATE TABLE {pg_schema}.{test_table} (id int, txt text, dte timestamp, geom geometry(Point));
 
-            INSERT INTO {s}.{t}
+            INSERT INTO {pg_schema}.{test_table}
              VALUES (1, 'test text', now(), st_setsrid(st_makepoint(1015329.1, 213793.1), 2263))
-        """.format(s=pg_schmma, t=test_table))
-        assert db.table_exists(test_table, schema=pg_schmma)
+        """)
+        assert db.table_exists(test_table, schema=pg_schema)
 
         # table to shp
-        db.query_to_shp("select * from {}.{}".format(pg_schmma, test_table), shp_name=shp, path=fldr, print_cmd=True, srid=2263)
+        db.query_to_shp(f"select * from {pg_schema}.{test_table}", shp_name=shp, path=fldr, print_cmd=True, srid=2263)
 
         # check table in folder
         assert os.path.isfile(os.path.join(fldr, shp))
@@ -63,7 +63,7 @@ class TestQueryToShpPg:
         assert b'"EPSG",2263' in ogr_response or b'"EPSG","2263"' in ogr_response
 
         # clean up
-        db.drop_table(pg_schmma, test_table)
+        db.drop_table(pg_schema, test_table)
         for ext in ('dbf', 'prj', 'shx', 'shp'):
             os.remove(os.path.join(fldr, shp.replace('shp', ext)))
 
@@ -71,24 +71,24 @@ class TestQueryToShpPg:
         fldr = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'test_data')
         shp = 'test.shp'
 
+        db.drop_table(schema = pg_schema, table = test_table)
         # create table
-        db.query("""
-            DROP TABLE IF EXISTS {s}.{t};
-            CREATE TABLE {s}.{t} (id int, txt text, dte timestamp, geom geometry(Point));
+        db.query(f"""
+            CREATE TABLE {pg_schema}.{test_table} (id int, txt text, dte timestamp, geom geometry(Point));
 
-            INSERT INTO {s}.{t}
+            INSERT INTO {pg_schema}.{test_table}
              VALUES (1, 'test text', now(), st_setsrid(st_makepoint(1015329.1, 213793.1), 2263))
-        """.format(s=pg_schmma, t=test_table))
-        assert db.table_exists(test_table, schema=pg_schmma)
+        """)
+        assert db.table_exists(test_table, schema=pg_schema)
 
         # table to shp
-        db.query_to_shp("select * from {}.{}".format(pg_schmma, test_table), path=fldr+'\\'+shp, print_cmd=True)
+        db.query_to_shp(f"select * from {pg_schema}.{test_table}", path=fldr+'\\'+shp, print_cmd=True)
 
         # check table in folder
         assert os.path.isfile(os.path.join(fldr, shp))
 
         # clean up
-        db.drop_table(pg_schmma, test_table)
+        db.drop_table(pg_schema, test_table)
         for ext in ('dbf', 'prj', 'shx', 'shp'):
             os.remove(os.path.join(fldr, shp.replace('shp', ext)))
 
@@ -96,18 +96,18 @@ class TestQueryToShpPg:
         fldr = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'test_data')
         shp = 'test.shp'
 
+        db.drop_table(schema = pg_schema, table = test_table)
         # create table
-        db.query("""
-            DROP TABLE IF EXISTS {s}.{t};
-            CREATE TABLE {s}.{t} (id int, txt text, dte timestamp, geom geometry(Point));
+        db.query(f"""
+            CREATE TABLE {pg_schema}.{test_table} (id int, txt text, dte timestamp, geom geometry(Point));
 
-            INSERT INTO {s}.{t}
+            INSERT INTO {pg_schema}.{test_table}
              VALUES (1, 'test text', now(), st_setsrid(st_makepoint(1015329.1, 213793.1), 2263))
-        """.format(s=pg_schmma, t=test_table))
-        assert db.table_exists(test_table, schema=pg_schmma)
+        """)
+        assert db.table_exists(test_table, schema=pg_schema)
 
         # table to shp - make sure shp_name overwrites any shp in the path
-        db.query_to_shp("select * from {}.{}".format(pg_schmma, test_table), shp_name=shp,
+        db.query_to_shp(f"select * from {pg_schema}.{test_table}", shp_name=shp,
                         path=fldr+'\\'+'test_'+shp, print_cmd=True)
 
         # check table in folder
@@ -119,7 +119,7 @@ class TestQueryToShpPg:
         assert b'"EPSG",2263' in ogr_response
 
         # clean up
-        db.drop_table(pg_schmma, test_table)
+        db.drop_table(pg_schema, test_table)
         for ext in ('dbf', 'prj', 'shx', 'shp'):
             os.remove(os.path.join(fldr, shp.replace('shp', ext)))
 
@@ -127,24 +127,24 @@ class TestQueryToShpPg:
         fldr = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'test_data')
         shp = 'test.shp'
 
+        db.drop_table(schema = pg_schema, table = test_table)
         # create table
-        db.query("""
-            DROP TABLE IF EXISTS {s}.{t};
-            CREATE TABLE {s}.{t} (id int, txt text, dte timestamp, geom geometry(Point));
+        db.query(f"""
+            CREATE TABLE {pg_schema}.{test_table} (id int, txt text, dte timestamp, geom geometry(Point));
 
-            INSERT INTO {s}.{t}
+            INSERT INTO {pg_schema}.{test_table}
              VALUES (1, 'test text', now(), st_setsrid(st_makepoint(1015329.1, 213793.1), 2263))
-        """.format(s=pg_schmma, t=test_table))
-        assert db.table_exists(test_table, schema=pg_schmma)
+        """)
+        assert db.table_exists(test_table, schema=pg_schema)
 
         # table to shp
-        db.query_to_shp("select * from {}.{}".format(pg_schmma, test_table), path=fldr+'\\'+shp, print_cmd=True)
+        db.query_to_shp(f"select * from {pg_schema}.{test_table}", path=fldr+'\\'+shp, print_cmd=True)
 
         # check table in folder
         assert os.path.isfile(os.path.join(fldr, shp))
 
         # clean up
-        db.drop_table(pg_schmma, test_table)
+        db.drop_table(pg_schema, test_table)
         for ext in ('dbf', 'prj', 'shx', 'shp'):
             os.remove(os.path.join(fldr, shp.replace('shp', ext)))
 
@@ -153,25 +153,25 @@ class TestQueryToShpPg:
         fldr = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'test_data')
         shp = 'test.shp'
 
+        db.drop_table(schema = pg_schema, table = test_table)
         # create table
-        db.query("""
-            DROP TABLE IF EXISTS {s}.{t};
-            CREATE TABLE {s}.{t} (id int, txt text, dte timestamp, geom geometry(Point));
+        db.query(f"""
+            CREATE TABLE {pg_schema}.{test_table} (id int, txt text, dte timestamp, geom geometry(Point));
 
-            INSERT INTO {s}.{t}
+            INSERT INTO {pg_schema}.{test_table}
              VALUES (1, 'test text', now(), st_setsrid(st_makepoint(1015329.1, 213793.1), 2263))
-        """.format(s=pg_schmma, t=test_table))
-        assert db.table_exists(test_table, schema=pg_schmma)
+        """)
+        assert db.table_exists(test_table, schema=pg_schema)
 
         # table to shp - make sure shp_name overwrites any shp in the path
-        db.query_to_shp("select * from {}.{}".format(pg_schmma, test_table), shp_name=shp,
+        db.query_to_shp(f"select * from {pg_schema}.{test_table}", shp_name=shp,
                         path=fldr+'\\'+'test_'+shp, print_cmd=True)
 
         # check table in folder
         assert os.path.isfile(os.path.join(fldr, shp))
 
         # clean up
-        db.drop_table(pg_schmma, test_table)
+        db.drop_table(pg_schema, test_table)
         for ext in ('dbf', 'prj', 'shx', 'shp'):
             os.remove(os.path.join(fldr, shp.replace('shp', ext)))
 
@@ -179,24 +179,24 @@ class TestQueryToShpPg:
         fldr = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'test_data')
         shp = 'test.shp'
 
+        db.drop_table(schema = pg_schema, table = test_table)
         # create table
-        db.query("""
-            DROP TABLE IF EXISTS {s}.{t};
-            CREATE TABLE {s}.{t} (id int, "txt" text, dte timestamp, geom geometry(Point));
+        db.query(f"""
+            CREATE TABLE {pg_schema}.{test_table} (id int, "txt" text, dte timestamp, geom geometry(Point));
 
-            INSERT INTO {s}.{t}
+            INSERT INTO {pg_schema}.{test_table}
              VALUES (1, 'test text', now(), st_setsrid(st_makepoint(1015329.1, 213793.1), 2263))
-        """.format(s=pg_schmma, t=test_table))
-        assert db.table_exists(test_table, schema=pg_schmma)
+        """)
+        assert db.table_exists(test_table, schema=pg_schema)
 
         # table to shp
-        db.query_to_shp("select * from {}.{}".format(pg_schmma, test_table), shp_name=shp, path=fldr, print_cmd=True)
+        db.query_to_shp(f"select * from {pg_schema}.{test_table}", shp_name=shp, path=fldr, print_cmd=True)
 
         # check table in folder
         assert os.path.isfile(os.path.join(fldr, shp))
 
         # clean up
-        db.drop_table(schema=pg_schmma, table=test_table)
+        db.drop_table(schema=pg_schema, table=test_table)
         for ext in ('dbf', 'prj', 'shx', 'shp'):
             os.remove(os.path.join(fldr, shp.replace('shp', ext)))
 
@@ -204,24 +204,24 @@ class TestQueryToShpPg:
         fldr = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'test_data')
         shp = 'test.shp'
 
+        db.drop_table(schema = pg_schema, table = test_table)
         # create table
-        db.query("""
-            DROP TABLE IF EXISTS {s}.{t};
-            CREATE TABLE {s}.{t} (id int, "t.txt" text, "1t txt" text, "t txt" text, dte timestamp, geom geometry(Point));
+        db.query(f"""
+            CREATE TABLE {pg_schema}.{test_table} (id int, "t.txt" text, "1t txt" text, "t txt" text, dte timestamp, geom geometry(Point));
 
-            INSERT INTO {s}.{t}
+            INSERT INTO {pg_schema}.{test_table}
              VALUES (1, 'test text','test text','test text', now(), st_setsrid(st_makepoint(1015329.1, 213793.1), 2263))
-        """.format(s=pg_schmma, t=test_table))
-        assert db.table_exists(test_table, schema=pg_schmma)
+        """)
+        assert db.table_exists(test_table, schema=pg_schema)
 
         # table to shp
-        db.query_to_shp("select * from {}.{}".format(pg_schmma, test_table), shp_name=shp, path=fldr, print_cmd=True)
+        db.query_to_shp(f"select * from {pg_schema}.{test_table}", shp_name=shp, path=fldr, print_cmd=True)
 
         # check table in folder
         assert os.path.isfile(os.path.join(fldr, shp))
 
         # clean up
-        db.drop_table(schema=pg_schmma, table=test_table)
+        db.drop_table(schema=pg_schema, table=test_table)
         for ext in ('dbf', 'prj', 'shx', 'shp'):
             os.remove(os.path.join(fldr, shp.replace('shp', ext)))
 
@@ -229,28 +229,28 @@ class TestQueryToShpPg:
         fldr = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'test_data')
         shp = 'test.shp'
 
+        db.drop_table(schema = pg_schema, table = test_table)
         # create table
-        db.query("""
-            DROP TABLE IF EXISTS {s}.{t};
-            CREATE TABLE {s}.{t} (id_name_one int, "123text name one" text,
+        db.query(f"""
+            CREATE TABLE {pg_schema}.{test_table} (id_name_one int, "123text name one" text,
             "text@name-two~three four five six seven" text,
             current_date_time timestamp,
             "x-coord" float,
             geom geometry(Point));
 
-            INSERT INTO {s}.{t}
+            INSERT INTO {pg_schema}.{test_table}
              VALUES (1, 'test text', 'test text', now(), 123.456, st_setsrid(st_makepoint(1015329.1, 213793.1), 2263))
-        """.format(s=pg_schmma, t=test_table))
-        assert db.table_exists(test_table, schema=pg_schmma)
+        """)
+        assert db.table_exists(test_table, schema=pg_schema)
 
         # table to shp
-        db.query_to_shp("select * from {}.{}".format(pg_schmma, test_table), shp_name=shp, path=fldr, print_cmd=True)
+        db.query_to_shp(f"select * from {pg_schema}.{test_table}", shp_name=shp, path=fldr, print_cmd=True)
 
         # check table in folder
         assert os.path.isfile(os.path.join(fldr, shp))
 
         # clean up
-        db.drop_table(schema=pg_schmma, table=test_table)
+        db.drop_table(schema=pg_schema, table=test_table)
         for ext in ('dbf', 'prj', 'shx', 'shp'):
             os.remove(os.path.join(fldr, shp.replace('shp', ext)))
 
@@ -259,25 +259,25 @@ class TestQueryToShpPg:
         fldr = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'test_data')
         shp = 'test.shp'
 
+        db.drop_table(schema = pg_schema, table = test_table)
         # create table
-        db.query("""
-            DROP TABLE IF EXISTS {s}.{t};
-            CREATE TABLE {s}.{t} (id int, txt text, dte timestamp, geom geometry(Point));
+        db.query(f"""
+            CREATE TABLE {pg_schema}.{test_table} (id int, txt text, dte timestamp, geom geometry(Point));
 
-            INSERT INTO {s}.{t}
+            INSERT INTO {pg_schema}.{test_table}
              VALUES (1, 'test text', now(), st_setsrid(st_makepoint(1015329.1, 213793.1), 2263))
-        """.format(s=pg_schmma, t=test_table))
-        assert db.table_exists(test_table, schema=pg_schmma)
+        """)
+        assert db.table_exists(test_table, schema=pg_schema)
 
         # table to shp
-        db.query_to_shp("select * from {}.{} limit 0".format(pg_schmma, test_table),
+        db.query_to_shp(f"select * from {pg_schema}.{test_table} limit 0",
                         shp_name=shp, path=fldr, print_cmd=True)
 
         # check table in folder
         assert os.path.isfile(os.path.join(fldr, shp))
 
         # clean up
-        db.drop_table(schema=pg_schmma, table=test_table)
+        db.drop_table(schema=pg_schema, table=test_table)
         for ext in ('dbf', 'prj', 'shx', 'shp'):
             try:
                 os.remove(os.path.join(fldr, shp.replace('shp', ext)))
@@ -288,32 +288,32 @@ class TestQueryToShpPg:
         fldr = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'test_data')
         shp = 'test.shp'
 
+        db.drop_table(schema = pg_schema, table = test_table)
         # create table
-        db.query("""
-            DROP TABLE IF EXISTS {s}.{t};
-            CREATE TABLE {s}.{t} (fld1 int,
+        db.query(f"""
+            CREATE TABLE {pg_schema}.{test_table} (fld1 int,
             fld2 text,
             fld3 text,
             fld4 timestamp,
             fld5 float,
             fld6 geometry(Point));
 
-            INSERT INTO {s}.{t}
+            INSERT INTO {pg_schema}.{test_table}
              VALUES (1,
              'test text',
-             '{lt}',
+             '{'test ' * 51}',
              now(), 123.456, st_setsrid(st_makepoint(1015329.1, 213793.1), 2263))
-        """.format(s=pg_schmma, t=test_table, lt='test ' * 51))  # The shapefile maximum field width is 254 lt set to 255
-        assert db.table_exists(test_table, schema=pg_schmma)
+        """)  # The shapefile maximum field width is 254 lt set to 255
+        assert db.table_exists(test_table, schema=pg_schema)
 
         # table to shp
-        db.query_to_shp("select * from {}.{}".format(pg_schmma, test_table), shp_name=shp, path=fldr, print_cmd=True)
+        db.query_to_shp(f"select * from {pg_schema}.{test_table}", shp_name=shp, path=fldr, print_cmd=True)
 
         # check table in folder
         assert os.path.isfile(os.path.join(fldr, shp))
 
         # import shp to db to compare
-        db.shp_to_table(path=fldr, table=test_table + 'QA', schema=pg_schmma,
+        db.shp_to_table(path=fldr, table=test_table + 'QA', schema=pg_schema,
                         shp_name=shp, print_cmd=True)
 
         db.query(f"""
@@ -324,15 +324,15 @@ class TestQueryToShpPg:
             t1.fld4::time = t2.fld4_tm::time, -- shapefiles cannot store datetimes
             t1.fld5 = t2.fld5,
             st_distance(t1.fld6, t2.geom) < 1 -- deafult name from pysqldb
-        from {pg_schmma}.{test_table} t1
-        join {pg_schmma}.{test_table}qa t2
+        from {pg_schema}.{test_table} t1
+        join {pg_schema}.{test_table}qa t2
         on t1.fld1=t2.fld1
         """)
         assert set(db.data[0]) == {True}
 
         # clean up
-        db.drop_table(schema=pg_schmma, table=test_table)
-        db.drop_table(schema=pg_schmma, table=test_table + 'qa')
+        db.drop_table(schema=pg_schema, table=test_table)
+        db.drop_table(schema=pg_schema, table=test_table + 'qa')
 
         for ext in ('dbf', 'prj', 'shx', 'shp'):
             try:
@@ -344,32 +344,32 @@ class TestQueryToShpPg:
         fldr = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'test_data')
         shp = 'test.shp'
 
+        db.drop_table(schema = pg_schema, table = test_table)
         # create table
-        db.query("""
-            DROP TABLE IF EXISTS {s}.{t};
-            CREATE TABLE {s}.{t} (fld1 int,
+        db.query(f"""
+            CREATE TABLE {pg_schema}.{test_table} (fld1 int,
             fld2 text,
             fld3 text,
             longfld4 timestamp,
             fld5 float,
             fld6 geometry(Point));
 
-            INSERT INTO {s}.{t}
+            INSERT INTO {pg_schema}.{test_table}
              VALUES (1,
              'test text',
-             '{lt}',
+             '{'test ' * 51}',
              now(), 123.456, st_setsrid(st_makepoint(1015329.1, 213793.1), 2263))
-        """.format(s=pg_schmma, t=test_table, lt='test ' * 51))  # The shapefile maximum field width is 254 lt set to 255
-        assert db.table_exists(test_table, schema=pg_schmma)
+        """)  # The shapefile maximum field width is 254 lt set to 255
+        assert db.table_exists(test_table, schema=pg_schema)
 
         # table to shp
-        db.query_to_shp("select * from {}.{}".format(pg_schmma, test_table), shp_name=shp, path=fldr, print_cmd=True)
+        db.query_to_shp(f"select * from {pg_schema}.{test_table}", shp_name=shp, path=fldr, print_cmd=True)
 
         # check table in folder
         assert os.path.isfile(os.path.join(fldr, shp))
 
         # import shp to db to compare
-        db.shp_to_table(path=fldr, table=test_table + 'QA', schema=pg_schmma,
+        db.shp_to_table(path=fldr, table=test_table + 'QA', schema=pg_schema,
                         shp_name=shp, print_cmd=True)
 
         db.query(f"""
@@ -380,15 +380,15 @@ class TestQueryToShpPg:
             t1.longfld4::time = t2.longfld_tm::time, -- shapefiles cannot store datetimes
             t1.fld5 = t2.fld5,
             st_distance(t1.fld6, t2.geom) < 1 -- deafult name from pysqldb
-        from {pg_schmma}.{test_table} t1
-        join {pg_schmma}.{test_table}qa t2
+        from {pg_schema}.{test_table} t1
+        join {pg_schema}.{test_table}qa t2
         on t1.fld1=t2.fld1
         """)
         assert set(db.data[0]) == {True}
 
         # clean up
-        db.drop_table(schema=pg_schmma, table=test_table)
-        db.drop_table(schema=pg_schmma, table=test_table + 'qa')
+        db.drop_table(schema=pg_schema, table=test_table)
+        db.drop_table(schema=pg_schema, table=test_table + 'qa')
 
         for ext in ('dbf', 'prj', 'shx', 'shp'):
             try:
@@ -407,14 +407,14 @@ class TestQueryToShpPg:
         assert os.path.isfile(os.path.join(fldr, shp + '.dbf'))
 
         # Upload shp (with special character)
-        db.shp_to_table(path=fldr, shp_name=shp + '.dbf', schema=pg_schmma, table=test_table)
+        db.shp_to_table(path=fldr, shp_name=shp + '.dbf', schema=pg_schema, table=test_table)
 
         # This will only work if ENCODED/DECODED properly; otherwise, it will be scrambled.
         # Though ogr uses LATIN1, our PG server stores things using UTF8; this is decoded and then encoded as LATIN1 to get the initial character.
-        assert list(db.dfquery("""select sc from {}.{}""".format(pg_schmma, test_table))['sc'])[0].encode('latin1') == '©'.encode('latin1')
+        assert list(db.dfquery(f"""select sc from {pg_schema}.{test_table}""")['sc'])[0].encode('latin1') == '©'.encode('latin1')
 
         # clean up
-        db.drop_table(pg_schmma, test_table)
+        db.drop_table(pg_schema, test_table)
         os.remove(os.path.join(fldr, shp + '.dbf'))
 
     def test_query_to_shp_bad_query(self):
@@ -442,18 +442,18 @@ class TestQueryToShpMs:
         sql.drop_table(schema=ms_schema, table=test_table)
 
         # create table
-        sql.query("""
-            CREATE TABLE {s}.{t} (id int, txt text, dte datetime, geom geometry);
+        sql.query(f"""
+            CREATE TABLE {ms_schema}.{test_table} (id int, txt text, dte datetime, geom geometry);
 
-            INSERT INTO {s}.{t}
+            INSERT INTO {ms_schema}.{test_table}
             (id, txt, dte, geom)
              VALUES (1, 'test text', CURRENT_TIMESTAMP,
              geometry::Point(1015329.1, 213793.1, 2263 ))
-        """.format(s=ms_schema, t=test_table))
+        """)
         assert sql.table_exists(test_table, schema=ms_schema)
 
         # table to shp
-        sql.query_to_shp("select * from {}.{}".format(ms_schema, test_table), shp_name=shp, path=fldr, print_cmd=True, srid=2263)
+        sql.query_to_shp(f"select * from {ms_schema}.{test_table}", shp_name=shp, path=fldr, print_cmd=True, srid=2263)
 
         # check table in folder
         assert os.path.isfile(os.path.join(fldr, shp))
@@ -477,18 +477,18 @@ class TestQueryToShpMs:
         sql.drop_table(schema=ms_schema, table=test_table)
 
         # create table
-        sql.query("""
-            CREATE TABLE {s}.{t} (id int, txt text, dte datetime, geom geometry);
+        sql.query(f"""
+            CREATE TABLE {ms_schema}.{test_table} (id int, txt text, dte datetime, geom geometry);
 
-            INSERT INTO {s}.{t}
+            INSERT INTO {ms_schema}.{test_table}
             (id, txt, dte, geom)
              VALUES (1, 'test text', CURRENT_TIMESTAMP,
              geometry::Point(1015329.1, 213793.1, 2263 ))
-        """.format(s=ms_schema, t=test_table))
+        """)
         assert sql.table_exists(test_table, schema=ms_schema)
 
         # table to shp
-        sql.query_to_shp("select * from {}.{}".format(ms_schema, test_table), path=fldr + '\\' + shp, print_cmd=True)
+        sql.query_to_shp(f"select * from {ms_schema}.{test_table}", path=fldr + '\\' + shp, print_cmd=True)
 
         # check table in folder
         assert os.path.isfile(os.path.join(fldr, shp))
@@ -507,18 +507,18 @@ class TestQueryToShpMs:
         sql.drop_table(schema=ms_schema, table=test_table)
 
         # create table
-        sql.query("""
-            CREATE TABLE {s}.{t} (id int, txt text, dte datetime, geom geometry);
+        sql.query(f"""
+            CREATE TABLE {ms_schema}.{test_table} (id int, txt text, dte datetime, geom geometry);
 
-            INSERT INTO {s}.{t}
+            INSERT INTO {ms_schema}.{test_table}
             (id, txt, dte, geom)
              VALUES (1, 'test text', CURRENT_TIMESTAMP,
              geometry::Point(1015329.1, 213793.1, 2263 ))
-        """.format(s=ms_schema, t=test_table))
+        """)
         assert sql.table_exists(test_table, schema=ms_schema)
 
         # table to shp - make sure shp_name overwrites any shp in the path
-        sql.query_to_shp("select * from {}.{}".format(ms_schema, test_table), shp_name=shp,
+        sql.query_to_shp(f"select * from {ms_schema}.{test_table}", shp_name=shp,
                         path=fldr + '\\' + 'test_' + shp, print_cmd=True)
 
         # check table in folder
@@ -543,18 +543,18 @@ class TestQueryToShpMs:
         sql.drop_table(schema=ms_schema, table=test_table)
 
         # create table
-        sql.query("""
-            CREATE TABLE {s}.{t} (id int, txt text, dte datetime, geom geometry);
+        sql.query(f"""
+            CREATE TABLE {ms_schema}.{test_table} (id int, txt text, dte datetime, geom geometry);
 
-            INSERT INTO {s}.{t}
+            INSERT INTO {ms_schema}.{test_table}
             (id, txt, dte, geom)
              VALUES (1, 'test text', CURRENT_TIMESTAMP,
              geometry::Point(1015329.1, 213793.1, 2263 ))
-        """.format(s=ms_schema, t=test_table))
+        """)
         assert sql.table_exists(test_table, schema=ms_schema)
 
         # table to shp
-        sql.query_to_shp("select * from {}.{}".format(ms_schema, test_table), path=fldr + '\\' + shp, print_cmd=True)
+        sql.query_to_shp(f"select * from {ms_schema}.{test_table}", path=fldr + '\\' + shp, print_cmd=True)
 
         # check table in folder
         assert os.path.isfile(os.path.join(fldr, shp))
@@ -573,18 +573,18 @@ class TestQueryToShpMs:
         sql.drop_table(schema=ms_schema, table=test_table)
 
         # create table
-        sql.query("""
-            CREATE TABLE {s}.{t} (id int, txt text, dte datetime, geom geometry);
+        sql.query(f"""
+            CREATE TABLE {ms_schema}.{test_table} (id int, txt text, dte datetime, geom geometry);
 
-            INSERT INTO {s}.{t}
+            INSERT INTO {ms_schema}.{test_table}
             (id, txt, dte, geom)
              VALUES (1, 'test text', CURRENT_TIMESTAMP,
              geometry::Point(1015329.1, 213793.1, 2263 ))
-        """.format(s=ms_schema, t=test_table))
+        """)
         assert sql.table_exists(test_table, schema=ms_schema)
 
         # table to shp - make sure shp_name overwrites any shp in the path
-        sql.query_to_shp("select * from {}.{}".format(ms_schema, test_table), shp_name=shp,
+        sql.query_to_shp(f"select * from {ms_schema}.{test_table}", shp_name=shp,
                         path=fldr + '\\' + 'test_' + shp, print_cmd=True)
 
         # check table in folder
@@ -625,18 +625,18 @@ class TestQueryToShpMs:
         sql.drop_table(schema=schema, table=test_table)
 
         # create table
-        sql.query("""
-                    CREATE TABLE {s}.{t} (id int, [txt] text, dte datetime, geom geometry);
+        sql.query(f"""
+                    CREATE TABLE {schema}.{test_table} (id int, [txt] text, dte datetime, geom geometry);
 
-                    INSERT INTO {s}.{t}
+                    INSERT INTO {schema}.{test_table}
                     (id, txt, dte, geom)
                      VALUES (1, 'test text', CURRENT_TIMESTAMP,
                      geometry::Point(1015329.1, 213793.1, 2263))
-                """.format(s=schema, t=test_table))
+                """)
         assert sql.table_exists(test_table, schema=schema)
 
         # table to shp
-        sql.query_to_shp("select * from {}.{}".format(schema, test_table), shp_name=shp, path=fldr, print_cmd=True)
+        sql.query_to_shp(f"select * from {schema}.{test_table}", shp_name=shp, path=fldr, print_cmd=True)
 
         # check table in folder
         assert os.path.isfile(os.path.join(fldr, shp))
@@ -654,18 +654,18 @@ class TestQueryToShpMs:
         shp = 'test.shp'
 
         # create table
-        sql.query("""
-            CREATE TABLE {s}.{t} (id int, [t.txt] text, [1t txt] text, [t_txt] text, dte datetime, geom geometry);
+        sql.query(f"""
+            CREATE TABLE {ms_schema}.{test_table} (id int, [t.txt] text, [1t txt] text, [t_txt] text, dte datetime, geom geometry);
 
-            INSERT INTO {s}.{t}
+            INSERT INTO {ms_schema}.{test_table}
             (id, [t.txt], [1t txt], [t_txt], dte, geom)
             VALUES (1, 'test text','test text','test text', CURRENT_TIMESTAMP,
             geometry::Point(1015329.1, 213793.1, 2263 ))
-        """.format(s=ms_schema, t=test_table))
+        """)
         assert sql.table_exists(test_table, schema=ms_schema)
 
         # table to shp
-        sql.query_to_shp("select * from {}.{}".format(ms_schema, test_table), shp_name=shp, path=fldr, print_cmd=True)
+        sql.query_to_shp(f"select * from {ms_schema}.{test_table}", shp_name=shp, path=fldr, print_cmd=True)
 
         # check table in folder
         assert os.path.isfile(os.path.join(fldr, shp))
@@ -685,22 +685,22 @@ class TestQueryToShpMs:
         sql.drop_table(schema=schema, table=test_table)
 
         # create table
-        sql.query("""
-            CREATE TABLE {s}.{t} (id_name_one int,
+        sql.query(f"""
+            CREATE TABLE {schema}.{test_table} (id_name_one int,
             [123text name one] text,
             [text@name-two~three four five six seven] text,
             current_date_time datetime,
             [x-coord] float,
             geom geometry);
 
-            INSERT INTO {s}.{t}
+            INSERT INTO {schema}.{test_table}
             VALUES (1, 'test text', 'test text', CURRENT_TIMESTAMP,
             123.456, geometry::Point(1015329.1, 213793.1, 2263 ))
-        """.format(s=schema, t=test_table))
+        """)
         assert sql.table_exists(test_table, schema=schema)
 
         # table to shp
-        sql.query_to_shp("select * from {}.{}".format(schema, test_table), shp_name=shp, path=fldr, print_cmd=True)
+        sql.query_to_shp(f"select * from {schema}.{test_table}", shp_name=shp, path=fldr, print_cmd=True)
 
         # check table in folder
         assert os.path.isfile(os.path.join(fldr, shp))
@@ -721,17 +721,17 @@ class TestQueryToShpMs:
         assert not sql.table_exists(table=test_table, schema=schema)
 
         # create table
-        sql.query("""
-            CREATE TABLE {s}.{t} (id int, txt text, dte datetime, geom geometry);
+        sql.query(f"""
+            CREATE TABLE {schema}.{test_table} (id int, txt text, dte datetime, geom geometry);
 
-            INSERT INTO {s}.{t}
+            INSERT INTO {schema}.{test_table}
                  VALUES (1, 'test text', cast(CURRENT_TIMESTAMP as datetime), geometry::Point(1015329.1, 213793.1, 2263 ))
-        """.format(s=schema, t=test_table))
+        """)
 
         assert sql.table_exists(test_table, schema=schema)
 
         # table to shp
-        sql.query_to_shp("select top 0 * from {}.{}".format(schema, test_table), shp_name=shp, path=fldr, print_cmd=True)
+        sql.query_to_shp(f"select top 0 * from {schema}.{test_table}", shp_name=shp, path=fldr, print_cmd=True)
 
         # check table in folder
         assert os.path.isfile(os.path.join(fldr, shp))
@@ -753,24 +753,24 @@ class TestQueryToShpMs:
         sql.drop_table(schema, test_table + 'qa')
 
         # create table
-        sql.query("""
-            CREATE TABLE {s}.{t} (fld1 int,
+        sql.query(f"""
+            CREATE TABLE {schema}.{test_table} (fld1 int,
             fld2 varchar(MAX),
             fld3 varchar(MAX),
             fld4 datetime,
             fld5 float,
             fld6 geometry);
 
-            INSERT INTO {s}.{t}
+            INSERT INTO {schema}.{test_table}
              VALUES (1,
              'test text',
-             '{lt}',
+             '{'test ' * 51}',
              CURRENT_TIMESTAMP, 123.456, geometry::Point(1015329.1, 213793.1, 2263 ))
-        """.format(s=schema, t=test_table, lt='test ' * 51))  # The shapefile maximum field width is 254 lt set to 255
+        """)  # The shapefile maximum field width is 254 lt set to 255
         assert sql.table_exists(test_table, schema=schema)
 
         # table to shp
-        sql.query_to_shp("select * from {}.{}".format(schema, test_table), shp_name=shp, path=fldr, print_cmd=True)
+        sql.query_to_shp(f"select * from {schema}.{test_table}", shp_name=shp, path=fldr, print_cmd=True)
 
         # check table in folder
         assert os.path.isfile(os.path.join(fldr, shp))
@@ -778,7 +778,7 @@ class TestQueryToShpMs:
         # import shp to db to compare
         sql.shp_to_table(path=fldr, table=test_table + 'QA', schema=schema, shp_name=shp, print_cmd=True)
 
-        sql.query("""
+        sql.query(f"""
         select
             case when t1.fld2 = t2.fld2 then 1 else 0 end,
             case when left(t1.fld3, 254) = t2.fld3 then 1 else 0 end,
@@ -786,10 +786,10 @@ class TestQueryToShpMs:
             case when cast(t1.fld4 as time)=t2.fld4_tm then 1 else 0 end, -- shapefiles cannot store datetimes
             case when t1.fld5 = t2.fld5 then 1 else 0 end,
             case when t1.fld6.STDistance(t2.geom) < 1  then 1 else 0 end-- default name from pysqldb
-        from {s}.{t} t1
-        join {s}.{t}QA t2
+        from {schema}.{test_table} t1
+        join {schema}.{test_table}QA t2
         on t1.fld1=t2.fld1
-        """.format(s=schema, t=test_table))
+        """)
         assert set(sql.data[0]) == {1}
 
         # clean up
@@ -811,24 +811,24 @@ class TestQueryToShpMs:
         sql.drop_table(schema, test_table + 'qa')
 
         # create table
-        sql.query("""
-            CREATE TABLE {s}.{t} (fld1 int,
+        sql.query(f"""
+            CREATE TABLE {schema}.{test_table} (fld1 int,
             fld2 varchar(MAX),
             fld3 varchar(MAX),
             longfld4 datetime,
             fld5 float,
             fld6 geometry);
 
-            INSERT INTO {s}.{t}
+            INSERT INTO {schema}.{test_table}
              VALUES (1,
              'test text',
-             '{lt}',
+             '{'test ' * 51}',
              CURRENT_TIMESTAMP, 123.456, geometry::Point(1015329.1, 213793.1, 2263 ))
-        """.format(s=schema, t=test_table, lt='test ' * 51))  # The shapefile maximum field width is 254 lt set to 255
+        """)  # The shapefile maximum field width is 254 lt set to 255
         assert sql.table_exists(test_table, schema=schema)
 
         # table to shp
-        sql.query_to_shp("select * from {}.{}".format(schema, test_table), shp_name=shp, path=fldr, print_cmd=True)
+        sql.query_to_shp(f"select * from {schema}.{test_table}", shp_name=shp, path=fldr, print_cmd=True)
 
         # check table in folder
         assert os.path.isfile(os.path.join(fldr, shp))
@@ -836,7 +836,7 @@ class TestQueryToShpMs:
         # import shp to db to compare
         sql.shp_to_table(path=fldr, table=test_table + 'QA', schema=schema, shp_name=shp, print_cmd=True)
 
-        sql.query("""
+        sql.query(f"""
         select
             case when t1.fld2 = t2.fld2 then 1 else 0 end,
             case when left(t1.fld3, 254) = t2.fld3 then 1 else 0 end,
@@ -844,10 +844,10 @@ class TestQueryToShpMs:
             case when cast(t1.longfld4 as time)=t2.longfld_tm then 1 else 0 end, -- shapefiles cannot store datetimes
             case when t1.fld5 = t2.fld5 then 1 else 0 end,
             case when t1.fld6.STDistance(t2.geom) < 1  then 1 else 0 end-- default name from pysqldb
-        from {s}.{t} t1
-        join {s}.{t}QA t2
+        from {schema}.{test_table} t1
+        join {schema}.{test_table}QA t2
         on t1.fld1=t2.fld1
-        """.format(s=schema, t=test_table))
+        """)
         assert set(sql.data[0]) == {1}
 
         # clean up
@@ -876,7 +876,7 @@ class TestQueryToShpMs:
 
         # This will only work if ENCODED/DECODED properly; otherwise, it will be scrambled.
         # ogr and SQL Server use/default to LATIN1; thus, encoding our string in LATIN1 will result in the correct character
-        assert (list(sql.dfquery("""select sc from {}.{}""".format(schema, test_table))['sc'])[0]).encode('latin1') == '©'.encode('latin1')
+        assert (list(sql.dfquery(f"""select sc from {schema}.{test_table}""")['sc'])[0]).encode('latin1') == '©'.encode('latin1')
 
         # clean up
         sql.drop_table(schema, test_table)
@@ -898,7 +898,7 @@ class TestQueryToShpMs:
     @classmethod
     def teardown_class(cls):
         helpers.clean_up_test_table_sql(sql, schema=ms_schema)
-        sql.query("drop table {}.{}".format(ms_schema, sql.log_table))
+        sql.drop_table(schema = ms_schema, table = sql.log_table)
         sql.cleanup_new_tables()
         # helpers.clean_up_schema(sql, ms_schema)
 

--- a/pysqldb3/tests/test_shapefile.py
+++ b/pysqldb3/tests/test_shapefile.py
@@ -453,7 +453,7 @@ class TestWriteShpPG:
         mutual_columns = set(db_df.columns).intersection(shp_uploaded_df.columns) - {'ogc_fid', 'geom'}
         pd.testing.assert_frame_equal(db_df[list(mutual_columns)], shp_uploaded_df[list(mutual_columns)],
                                       check_like=True, check_names=False, check_dtype=False,
-                                      check_datetimelike_compat=True, check_less_precise=True)
+                                      check_datetimelike_compat=True)
 
         # Assert before/after geom columns are all 0 ft from each other, even if represented differently
         dist_df = db.dfquery(f"""
@@ -507,7 +507,7 @@ class TestWriteShpPG:
         mutual_columns = set(db_df.columns).intersection(shp_uploaded_df.columns) - {'ogc_fid', 'geom'}
         pd.testing.assert_frame_equal(db_df[list(mutual_columns)], shp_uploaded_df[list(mutual_columns)],
                                       check_like=True, check_names=False, check_dtype=False,
-                                      check_datetimelike_compat=True, check_less_precise=True)
+                                      check_datetimelike_compat=True)
 
         # Assert before/after geom columns are all 0 ft from each other, even if represented differently
         dist_df = db.dfquery(f"""
@@ -563,7 +563,7 @@ class TestWriteShpPG:
         mutual_columns = set(db_df.columns).intersection(shp_uploaded_df.columns) - {'ogc_fid', 'geom'}
         pd.testing.assert_frame_equal(db_df[list(mutual_columns)], shp_uploaded_df[list(mutual_columns)],
                                       check_like=True, check_names=False, check_dtype=False,
-                                      check_datetimelike_compat=True, check_less_precise=True)
+                                      check_datetimelike_compat=True)
 
         # Assert before/after geom columns are all 0 ft from each other, even if represented differently
         dist_df = db.dfquery(f"""
@@ -609,7 +609,7 @@ class TestWriteShpPG:
         mutual_columns = set(db_df.columns).intersection(shp_uploaded_df.columns) - {'ogc_fid', 'geom'}
         pd.testing.assert_frame_equal(db_df[list(mutual_columns)], shp_uploaded_df[list(mutual_columns)],
                                       check_like=True, check_names=False, check_dtype=False,
-                                      check_datetimelike_compat=True, check_less_precise=True)
+                                      check_datetimelike_compat=True)
 
         # Assert before/after geom columns are all 0 ft from each other, even if represented differently
         dist_df = db.dfquery(f"""

--- a/pysqldb3/tests/test_shapefile.py
+++ b/pysqldb3/tests/test_shapefile.py
@@ -29,10 +29,10 @@ sql = pysqldb.DbConnect(type=config.get('SQL_DB', 'TYPE'),
                         # use_native_driver=False # this is needed for spatial data types
                         )
 
-pg_table_name = 'pg_test_table_{}'.format(db.user)
-test_read_shp_table_name = 'test_read_shp_table_{}'.format(db.user)
-test_write_shp_table_name = 'test_write_shp_table_{}'.format(db.user)
-test_reuploaded_table_name = 'test_write_reuploaded_{}'.format(db.user)
+pg_table_name = f'pg_test_table_{db.user}'
+test_read_shp_table_name = f'test_read_shp_table_{db.user}'
+test_write_shp_table_name = f'test_write_shp_table_{db.user}'
+test_reuploaded_table_name = f'test_write_reuploaded_{db.user}'
 
 ms_schema = 'dbo'
 pg_schema = 'working'
@@ -58,14 +58,14 @@ class TestReadShpPG:
 
         # Assert read_shp happened successfully and contents are correct
         assert db.table_exists(schema=pg_schema, table=test_read_shp_table_name)
-        table_df = db.dfquery('select * from {}.{}'.format(pg_schema, test_read_shp_table_name))
+        table_df = db.dfquery(f'select * from {pg_schema}.{test_read_shp_table_name}')
 
         assert set(table_df.columns) == {'gid', 'some_value', 'geom', 'ogc_fid'}
         assert len(table_df) == 2
 
         # Assert distance between geometries is 0 when recreating from raw input
         # This method was used because the geometries themselves may be recorded differently but mean the same (after mapping on QGIS)
-        diff_df = db.dfquery("""
+        diff_df = db.dfquery(f"""
         select distinct st_distance(raw_inputs.geom,
         st_transform(st_setsrid(end_table.geom, 4326),2263)
         )::int as distance
@@ -74,9 +74,9 @@ class TestReadShpPG:
             union
             select 2 as id, st_setsrid(st_point(1015428.1, 213086.1), 2263) as geom
         ) raw_inputs
-        join {}.{} end_table
+        join {pg_schema}.{test_read_shp_table_name} end_table
         on raw_inputs.id=end_table.gid::int
-        """.format(pg_schema, test_read_shp_table_name))
+        """)
 
         assert len(diff_df) == 1
         assert int(diff_df.iloc[0]['distance']) == 0
@@ -105,7 +105,7 @@ class TestReadShpPG:
 
         # Assert read_shp happened successfully and contents are correct
         assert db.table_exists(schema=pg_schema, table=test_read_shp_table_name)
-        table_df = db.dfquery('select * from {}.{}'.format(pg_schema, test_read_shp_table_name))
+        table_df = db.dfquery(f'select * from {pg_schema}.{test_read_shp_table_name}')
 
         assert set(table_df.columns) == {'gid', 'some_value', 'geom', 'ogc_fid'}
         assert len(table_df) == 2
@@ -113,7 +113,7 @@ class TestReadShpPG:
         # Assert distance between geometries is 0 when recreating from raw input
         # This method was used because the geometries themselves may be recorded differently
         # but mean the same (after mapping on QGIS)
-        diff_df = db.dfquery("""
+        diff_df = db.dfquery(f"""
         select distinct st_distance(raw_inputs.geom,
         st_transform(st_setsrid(end_table.geom, 4326),2263)
         )::int as distance
@@ -122,9 +122,9 @@ class TestReadShpPG:
             union
             select 2 as id, st_setsrid(st_point(1015428.1, 213086.1), 2263) as geom
         ) raw_inputs
-        join {}.{} end_table
+        join {pg_schema}.{test_read_shp_table_name} end_table
         on raw_inputs.id=end_table.gid::int
-        """.format(pg_schema, test_read_shp_table_name))
+        """)
 
         assert len(diff_df) == 1
         assert int(diff_df.iloc[0]['distance']) == 0
@@ -184,14 +184,14 @@ class TestReadShpPG:
 
         # Assert read_shp happened successfully and contents are correct
         assert db.table_exists(schema=db.default_schema, table=test_read_shp_table_name)
-        table_df = db.dfquery('select * from {}'.format(test_read_shp_table_name))
+        table_df = db.dfquery(f'select * from {test_read_shp_table_name}')
 
         assert set(table_df.columns) == {'some_value', 'ogc_fid', 'gid', 'geom'}
         assert len(table_df) == 2
 
         # Assert distance between geometries is 0 when recreating from raw input
         # This method was used because the geometries themselves may be recorded differently but mean the same (after mapping on QGIS)
-        diff_df = db.dfquery("""
+        diff_df = db.dfquery(f"""
         select distinct
         st_distance(raw_inputs.geom, st_transform(st_setsrid(end_table.geom, 4326),2263))::int distance
         from (
@@ -199,9 +199,9 @@ class TestReadShpPG:
             union
             select 2 as id, st_setsrid(st_point(1015428.1, 213086.1), 2263) as geom
         ) raw_inputs
-        join {} end_table
+        join {test_read_shp_table_name} end_table
         on raw_inputs.id=end_table.gid::int
-        """.format(test_read_shp_table_name))
+        """)
 
         assert len(diff_df) == 1
         assert int(diff_df.iloc[0]['distance']) == 0
@@ -251,23 +251,23 @@ class TestReadShpMS:
         assert sql.table_exists(schema=ms_schema, table=test_read_shp_table_name)
 
         # todo: this fails because odbc 17 driver isnt supporting geometry
-        table_df = sql.dfquery('select * from {}.{}'.format(ms_schema, test_read_shp_table_name))
+        table_df = sql.dfquery(f'select * from {ms_schema}.{test_read_shp_table_name}')
 
         assert set(table_df.columns) == {'ogr_fid', 'gid', 'some_value', 'geom'}
         assert len(table_df) == 2
 
         # Assert distance between geometries is 0 when recreating from raw input
         # This method was used because the geometries themselves may be recorded differently but mean the same (after mapping on QGIS)
-        diff_df = sql.dfquery("""
+        diff_df = sql.dfquery(f"""
         select distinct raw_inputs.geom.STDistance(end_table.geom) as distance
         from (
             (select 1 as id, geometry::Point(-73.88782477721676, 40.75343453961836, 2263) as geom)
             union all
             (select 2 as id, geometry::Point(-73.88747073046778, 40.75149365677327, 2263) as geom)
         ) raw_inputs
-        join {}.{} end_table
+        join {ms_schema}.{test_read_shp_table_name} end_table
         on raw_inputs.id=end_table.gid
-        """.format(ms_schema, test_read_shp_table_name))
+        """)
 
         assert len(diff_df) == 1
         assert int(diff_df.iloc[0]['distance']) == 0
@@ -296,7 +296,7 @@ class TestReadShpMS:
 
         # Assert read_shp happened successfully and contents are correct
         assert sql.table_exists(schema=ms_schema, table=test_read_shp_table_name)
-        table_df = sql.dfquery('select * from {}.{}'.format(ms_schema, test_read_shp_table_name))
+        table_df = sql.dfquery(f'select * from {ms_schema}.{test_read_shp_table_name}')
 
         assert set(table_df.columns) == {'gid', 'some_value', 'geom', 'ogr_fid'}
         assert len(table_df) == 2
@@ -304,16 +304,16 @@ class TestReadShpMS:
         # Assert distance between geometries is 0 when recreating from raw input
         # This method was used because the geometries themselves may be recorded differently
         # but mean the same (after mapping on QGIS)
-        diff_df = sql.dfquery("""
+        diff_df = sql.dfquery(f"""
                 select distinct raw_inputs.geom.STDistance(end_table.geom) as distance
                 from (
                     (select 1 as id, geometry::Point(-73.88782477721676, 40.75343453961836, 2263) as geom)
                     union all
                     (select 2 as id, geometry::Point(-73.88747073046778, 40.75149365677327, 2263) as geom)
                 ) raw_inputs
-                join {}.{} end_table
+                join {ms_schema}.{test_read_shp_table_name} end_table
                 on raw_inputs.id=end_table.gid
-                """.format(ms_schema, test_read_shp_table_name))
+                """)
 
         assert len(diff_df) == 1
         assert int(diff_df.iloc[0]['distance']) == 0
@@ -371,22 +371,22 @@ class TestReadShpMS:
 
         # Assert read_shp happened successfully and contents are correct
         assert sql.table_exists(schema=sql.default_schema, table=test_read_shp_table_name)
-        table_df = sql.dfquery('select * from {}'.format(test_read_shp_table_name))
+        table_df = sql.dfquery(f'select * from {test_read_shp_table_name}')
         assert set(table_df.columns) == {'ogr_fid', 'gid', 'some_value', 'geom'}
         assert len(table_df) == 2
 
         # Assert distance between geometries is 0 when recreating from raw input
         # This method was used because the geometries themselves may be recorded differently but mean the same (after mapping on QGIS)
-        diff_df = sql.dfquery("""
+        diff_df = sql.dfquery(f"""
         select distinct raw_inputs.geom.STDistance(end_table.geom) as distance
         from (
             (select 1 as id, geometry::Point(-73.88782477721676, 40.75343453961836, 2263) as geom)
             union all
             (select 2 as id, geometry::Point(-73.88747073046778, 40.75149365677327, 2263) as geom)
         ) raw_inputs
-        join {} end_table
+        join {test_read_shp_table_name} end_table
         on raw_inputs.id=cast(end_table.gid as int)
-        """.format(test_read_shp_table_name))
+        """)
 
         assert len(diff_df) == 1
         assert int(diff_df.iloc[0]['distance']) == 0
@@ -444,8 +444,8 @@ class TestWriteShpPG:
         db.shp_to_table(path=fp, shp_name=shp_name, schema=pg_schema, table=test_reuploaded_table_name, print_cmd=True)
 
         # Assert equality
-        db_df = db.dfquery("select * from {}.{} order by id limit 100".format(pg_schema, pg_table_name))
-        shp_uploaded_df = db.dfquery("select * from {}.{} order by id".format(pg_schema, test_reuploaded_table_name))
+        db_df = db.dfquery(f"select * from {pg_schema}.{pg_table_name} order by id limit 100")
+        shp_uploaded_df = db.dfquery(f"select * from {pg_schema}.{test_reuploaded_table_name} order by id")
 
         assert len(db_df) == len(shp_uploaded_df)
 
@@ -498,8 +498,8 @@ class TestWriteShpPG:
         db.shp_to_table(path=fp+'\\'+shp_name, schema=pg_schema, table=test_reuploaded_table_name, print_cmd=True)
 
         # Assert equality
-        db_df = db.dfquery("select * from {}.{} order by id limit 100".format(pg_schema, pg_table_name))
-        shp_uploaded_df = db.dfquery("select * from {}.{} order by id".format(pg_schema, test_reuploaded_table_name))
+        db_df = db.dfquery(f"select * from {pg_schema}.{pg_table_name} order by id limit 100")
+        shp_uploaded_df = db.dfquery(f"select * from {pg_schema}.{test_reuploaded_table_name} order by id")
 
         assert len(db_df) == len(shp_uploaded_df)
 
@@ -554,8 +554,8 @@ class TestWriteShpPG:
                         table=test_reuploaded_table_name, print_cmd=True)
 
         # Assert equality
-        db_df = db.dfquery("select * from {}.{} order by id limit 100".format(pg_schema, pg_table_name))
-        shp_uploaded_df = db.dfquery("select * from {}.{} order by id".format(pg_schema, test_reuploaded_table_name))
+        db_df = db.dfquery(f"select * from {pg_schema}.{pg_table_name} order by id limit 100")
+        shp_uploaded_df = db.dfquery(f"select * from {pg_schema}.{test_reuploaded_table_name} order by id")
 
         assert len(db_df) == len(shp_uploaded_df)
 
@@ -590,7 +590,7 @@ class TestWriteShpPG:
 
         # Write shp
         s = Shapefile(dbo=db, path=fp, shp_name=shp_name,
-                      query="""select * from {}.{} order by id limit 100""".format(pg_schema, pg_table_name))
+                      query=f"""select * from {pg_schema}.{pg_table_name} order by id limit 100""")
         s.write_shp(print_cmd=True)
 
         # Check table in folder
@@ -600,8 +600,8 @@ class TestWriteShpPG:
         db.shp_to_table(path=fp, shp_name=shp_name, schema=pg_schema, table=test_reuploaded_table_name, print_cmd=True)
 
         # Assert equality
-        db_df = db.dfquery("select * from {}.{} order by id limit 100".format(pg_schema, pg_table_name))
-        shp_uploaded_df = db.dfquery("select * from {}.{} order by id".format(pg_schema, test_reuploaded_table_name))
+        db_df = db.dfquery(f"select * from {pg_schema}.{pg_table_name} order by id limit 100")
+        shp_uploaded_df = db.dfquery(f"select * from {pg_schema}.{test_reuploaded_table_name} order by id")
 
         assert len(db_df) == len(shp_uploaded_df)
 
@@ -639,11 +639,11 @@ class TestWriteShpMS:
         sql.drop_table(schema=ms_schema, table=test_write_shp_table_name)
 
         # Add test_table
-        sql.query("""
-        create table {s}.{t} (test_col1 int, test_col2 int, geom geometry);
-        insert into {s}.{t} VALUES(1, 2, geometry::Point(985831.79200444, 203371.60461367, 2263));
-        insert into {s}.{t} VALUES(3, 4, geometry::Point(985831.79200444, 203371.60461367, 2263));
-        """.format(s=ms_schema, t=test_write_shp_table_name))
+        sql.query(f"""
+        create table {ms_schema}.{test_write_shp_table_name} (test_col1 int, test_col2 int, geom geometry);
+        insert into {ms_schema}.{test_write_shp_table_name} VALUES(1, 2, geometry::Point(985831.79200444, 203371.60461367, 2263));
+        insert into {ms_schema}.{test_write_shp_table_name} VALUES(3, 4, geometry::Point(985831.79200444, 203371.60461367, 2263));
+        """)
 
         fp = os.path.join(os.path.dirname(os.path.abspath(__file__)))+'/test_data'
         shp_name = 'test_write.shp'
@@ -659,10 +659,8 @@ class TestWriteShpMS:
         sql.shp_to_table(path=fp, shp_name=shp_name, schema=ms_schema, table=test_reuploaded_table_name, print_cmd=True)
 
         # Assert equality
-        db_df = sql.dfquery("select top 10 * from {}.{} order by test_col1".format(ms_schema,
-                                                                                   test_write_shp_table_name))
-        shp_uploaded_df = sql.dfquery("select top 10 * from {}.{} order by test_col1".format(ms_schema,
-                                                                                             test_reuploaded_table_name))
+        db_df = sql.dfquery(f"select top 10 * from {ms_schema}.{test_write_shp_table_name} order by test_col1")
+        shp_uploaded_df = sql.dfquery(f"select top 10 * from {ms_schema}.{test_reuploaded_table_name} order by test_col1")
 
         assert len(db_df) == len(shp_uploaded_df)
 
@@ -673,12 +671,12 @@ class TestWriteShpMS:
                                       check_dtype=False)
 
         # Assert before/after geom columns are all 0 ft from each other, even if represented differently
-        dist_df = sql.dfquery("""
+        dist_df = sql.dfquery(f"""
         select distinct b.geom.STDistance(a.geom) as distance
-        from {s}.{t} b
-        join {s}.{t} a
+        from {ms_schema}.{test_reuploaded_table_name} b
+        join {ms_schema}.{test_reuploaded_table_name} a
         on b.test_col1=a.test_col1
-        """.format(s=ms_schema, t=test_reuploaded_table_name))
+        """)
 
         assert len(dist_df) == 1
         assert dist_df.iloc[0]['distance'] == 0
@@ -718,10 +716,8 @@ class TestWriteShpMS:
         sql.shp_to_table(path=fp+'\\'+shp_name, schema=ms_schema, table=test_reuploaded_table_name, print_cmd=True)
 
         # Assert equality
-        db_df = sql.dfquery("select top 10 * from {}.{} order by test_col1".format(ms_schema,
-                                                                                   test_write_shp_table_name))
-        shp_uploaded_df = sql.dfquery("select top 10 * from {}.{} order by test_col1".format(
-            ms_schema, test_reuploaded_table_name))
+        db_df = sql.dfquery(f"select top 10 * from {ms_schema}.{test_write_shp_table_name} order by test_col1")
+        shp_uploaded_df = sql.dfquery(f"select top 10 * from {ms_schema}.{test_reuploaded_table_name} order by test_col1")
 
         assert len(db_df) == len(shp_uploaded_df)
 

--- a/pysqldb3/tests/test_table_to_shp.py
+++ b/pysqldb3/tests/test_table_to_shp.py
@@ -32,7 +32,7 @@ sql = pysqldb.DbConnect(type=config.get('SQL_DB', 'TYPE'),
 #                              server='DOTGISSQL01',
 #                              ldap=True)
 
-test_table = '__testing_query_to_shp_{}__'.format(db.user)
+test_table = f'__testing_query_to_shp_{db.user}__'
 ms_schema = 'risadmin'
 pg_schema = 'working'
 
@@ -42,14 +42,14 @@ class TestTableToShpPg:
         fldr = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'test_data')
         shp = 'test.shp'
 
+        db.drop_table(schema = pg_schema, table = test_table)
         # create table
-        db.query("""
-            DROP TABLE IF EXISTS {s}.{t};
-            CREATE TABLE {s}.{t} (id int, txt text, dte timestamp, geom geometry(Point));
+        db.query(f"""
+            CREATE TABLE {pg_schema}.{test_table} (id int, txt text, dte timestamp, geom geometry(Point));
 
-            INSERT INTO {s}.{t}
+            INSERT INTO {pg_schema}.{test_table}
              VALUES (1, 'test text', now(), st_setsrid(st_makepoint(1015329.1, 213793.1), 2263))
-        """.format(s=pg_schema, t=test_table))
+        """)
         assert db.table_exists(test_table, schema=pg_schema)
 
         # table to shp
@@ -67,14 +67,14 @@ class TestTableToShpPg:
         fldr = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'test_data')
         shp = 'test.shp'
 
+        db.drop_table(schema = pg_schema, table = test_table)
         # create table
-        db.query("""
-            DROP TABLE IF EXISTS {s}.{t};
-            CREATE TABLE {s}.{t} (id int, txt text, dte timestamp, geom geometry(Point));
+        db.query(f"""
+            CREATE TABLE {pg_schema}.{test_table} (id int, txt text, dte timestamp, geom geometry(Point));
 
-            INSERT INTO {s}.{t}
+            INSERT INTO {pg_schema}.{test_table}
              VALUES (1, 'test text', now(), st_setsrid(st_makepoint(1015329.1, 213793.1), 2263))
-        """.format(s=pg_schema, t=test_table))
+        """)
         assert db.table_exists(test_table, schema=pg_schema)
 
         # table to shp
@@ -92,14 +92,14 @@ class TestTableToShpPg:
         fldr = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'test_data')
         shp = 'test.shp'
 
+        db.drop_table(schema = pg_schema, table = test_table)
         # create table
-        db.query("""
-            DROP TABLE IF EXISTS {s}.{t};
-            CREATE TABLE {s}.{t} (id int, txt text, dte timestamp, geom geometry(Point));
+        db.query(f"""
+            CREATE TABLE {pg_schema}.{test_table} (id int, txt text, dte timestamp, geom geometry(Point));
 
-            INSERT INTO {s}.{t}
+            INSERT INTO {pg_schema}.{test_table}
              VALUES (1, 'test text', now(), st_setsrid(st_makepoint(1015329.1, 213793.1), 2263))
-        """.format(s=pg_schema, t=test_table))
+        """)
         assert db.table_exists(test_table, schema=pg_schema)
 
         # table to shp
@@ -117,14 +117,14 @@ class TestTableToShpPg:
         fldr = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'test_data')
         shp = test_table+'.shp'
 
+        db.drop_table(schema = pg_schema, table = test_table)
         # create table
-        db.query("""
-            DROP TABLE IF EXISTS {s}.{t};
-            CREATE TABLE {s}.{t} (id int, "txt" text, dte timestamp, geom geometry(Point));
+        db.query(f"""
+            CREATE TABLE {pg_schema}.{test_table} (id int, "txt" text, dte timestamp, geom geometry(Point));
 
-            INSERT INTO {s}.{t}
+            INSERT INTO {pg_schema}.{test_table}
              VALUES (1, 'test text', now(), st_setsrid(st_makepoint(1015329.1, 213793.1), 2263))
-        """.format(s=pg_schema, t=test_table))
+        """)
         assert db.table_exists(test_table, schema=pg_schema)
 
         # table to shp
@@ -151,14 +151,14 @@ class TestTableToShpMs:
         sql.drop_table(schema=ms_schema, table=test_table)
 
         # create table
-        sql.query("""
-            CREATE TABLE {s}.{t} (id int, txt text, dte datetime, geom geometry);
+        sql.query(f"""
+            CREATE TABLE {ms_schema}.{test_table} (id int, txt text, dte datetime, geom geometry);
 
-            INSERT INTO {s}.{t}
+            INSERT INTO {ms_schema}.{test_table}
             (id, txt, dte, geom)
              VALUES (1, 'test text', CURRENT_TIMESTAMP,
              geometry::Point(1015329.1, 213793.1, 2263 ))
-        """.format(s=ms_schema, t=test_table))
+        """)
         assert sql.table_exists(test_table, schema=ms_schema)
 
         # table to shp
@@ -182,14 +182,14 @@ class TestTableToShpMs:
         sql.drop_table(schema=ms_schema, table=test_table)
 
         # create table
-        sql.query("""
-            CREATE TABLE {s}.{t} (id int, txt text, dte datetime, geom geometry);
+        sql.query(f"""
+            CREATE TABLE {ms_schema}.{test_table} (id int, txt text, dte datetime, geom geometry);
 
-            INSERT INTO {s}.{t}
+            INSERT INTO {ms_schema}.{test_table}
             (id, txt, dte, geom)
              VALUES (1, 'test text', CURRENT_TIMESTAMP,
              geometry::Point(1015329.1, 213793.1, 2263 ))
-        """.format(s=ms_schema, t=test_table))
+        """)
         assert sql.table_exists(test_table, schema=ms_schema)
 
         # table to shp
@@ -212,14 +212,14 @@ class TestTableToShpMs:
 
         sql.drop_table(schema=ms_schema, table=test_table)
         # create table
-        sql.query("""
-            CREATE TABLE {s}.{t} (id int, txt text, dte datetime, geom geometry);
+        sql.query(f"""
+            CREATE TABLE {ms_schema}.{test_table} (id int, txt text, dte datetime, geom geometry);
 
-            INSERT INTO {s}.{t}
+            INSERT INTO {ms_schema}.{test_table}
             (id, txt, dte, geom)
              VALUES (1, 'test text', CURRENT_TIMESTAMP,
              geometry::Point(1015329.1, 213793.1, 2263 ))
-        """.format(s=ms_schema, t=test_table))
+        """)
         assert sql.table_exists(test_table, schema=ms_schema)
 
         # table to shp
@@ -242,10 +242,10 @@ class TestTableToShpMs:
         sql.drop_table(table=test_table, schema=ms_schema)
 
         # create table
-        sql.query("""
-                    CREATE TABLE {s}.{t} (id int, [txt] text, dte datetime, geom geometry);
+        sql.query(f"""
+                    CREATE TABLE {ms_schema}.{test_table} (id int, [txt] text, dte datetime, geom geometry);
 
-                    INSERT INTO {s}.{t}
+                    INSERT INTO {ms_schema}.{test_table}
                     (id, txt, dte, geom)
                      VALUES (1, 'test text', CURRENT_TIMESTAMP,
                      geometry::Point(1015329.1, 213793.1, 2263))
@@ -269,6 +269,6 @@ class TestTableToShpMs:
     @classmethod
     def teardown_class(cls):
         helpers.clean_up_test_table_sql(sql, schema=ms_schema)
-        sql.query("drop table {}.{}".format(ms_schema, sql.log_table))
+        sql.drop_tabl(schema = ms_schema, table = sql.log_table)
         sql.cleanup_new_tables()
         # helpers.clean_up_schema(sql, schema=ms_schema)

--- a/pysqldb3/tests/test_table_to_shp.py
+++ b/pysqldb3/tests/test_table_to_shp.py
@@ -269,6 +269,6 @@ class TestTableToShpMs:
     @classmethod
     def teardown_class(cls):
         helpers.clean_up_test_table_sql(sql, schema=ms_schema)
-        sql.drop_tabl(schema = ms_schema, table = sql.log_table)
+        sql.drop_table(schema = ms_schema, table = sql.log_table)
         sql.cleanup_new_tables()
         # helpers.clean_up_schema(sql, schema=ms_schema)


### PR DESCRIPTION
Move `rename_geom` function (which renames geometry columns) out of the Shapefile.py file since I will want to use it for Geopackage as well (and the arguments are formatted differently).  This is based on Issue https://github.com/safety-analytics-mapping/pysqldb3/issues/89 