### PR TITLE
Fix gpkg/shp tests due to change in file dir

### DIFF
--- a/pysqldb3/cmds.py
+++ b/pysqldb3/cmds.py
@@ -101,7 +101,7 @@ READ_GPKG_CMD_MS = r"""ogr2ogr --config GDAL_DATA "{gdal_data}" -nlt PROMOTE_TO_
  "{gpkg_name}" {gpkg_tbl} -nln {schema}.{tbl_name} {perc} --config MSSQLSPATIAL_USE_GEOMETRY_COLUMNS NO
 """.replace('\n', ' ')
 
-WRITE_SHP_CMD_GPKG = r'ogr2ogr -f GPKG {_update} {gpkg_name} "{full_path}\{shp_name}" -nln {gpkg_tbl}'
+WRITE_SHP_CMD_GPKG = r'ogr2ogr -f GPKG {_update} "{full_path}\{gpkg_name}" "{full_path}\{shp_name}" -nln {gpkg_tbl}'
 
 WRITE_GPKG_CMD_SHP = r'ogr2ogr -f "ESRI Shapefile" "{export_path}\{gpkg_tbl}.shp" "{full_path}\{gpkg_name}" {gpkg_tbl}'
 

--- a/pysqldb3/tests/test_geopackage.py
+++ b/pysqldb3/tests/test_geopackage.py
@@ -38,6 +38,7 @@ test_reuploaded_table_name = f'test_write_reuploaded_{db.user}'
 test_layer1 = f'test_layer1_{db.user}'
 test_layer2 = f'test_layer2_{db.user}'
 
+FOLDER_PATH = helpers.DIR
 
 ms_schema = 'dbo'
 pg_schema = 'working'
@@ -49,15 +50,15 @@ class TestReadgpkgPG:
         helpers.set_up_test_table_pg(db)
 
     def test_read_gpkg_basic(self):
-        fp = os.path.join(os.path.dirname(os.path.abspath(__file__)))+'/test_data/'
+
         gpkg_name = "testgpkg.gpkg"
 
         # Assert successful
-        assert gpkg_name in os.listdir(fp)
+        assert gpkg_name in os.listdir(FOLDER_PATH)
         db.drop_table(schema=pg_schema, table=test_read_gpkg_table_name)
 
         # Read gpkg to new, test table
-        s = Geopackage(path=fp, gpkg_name=gpkg_name, gpkg_tbl = test_layer1)
+        s = Geopackage(path=FOLDER_PATH, gpkg_name=gpkg_name, gpkg_tbl = test_layer1)
         s.read_gpkg(dbo=db, table=test_read_gpkg_table_name, schema=pg_schema, print_cmd=True)
 
         # Assert read_gpkg happened successfully and contents are correct
@@ -97,17 +98,16 @@ class TestReadgpkgPG:
         Test for multiple tables within a geopackage
         """
 
-        fp = os.path.join(os.path.dirname(os.path.abspath(__file__)))+'/test_data/'
         gpkg_name = "testgpkg.gpkg"
 
         # Assert successful
         # Assert successful
-        assert gpkg_name in os.listdir(fp)
+        assert gpkg_name in os.listdir(FOLDER_PATH)
         db.drop_table(schema=pg_schema, table=test_layer1)
         db.drop_table(schema=pg_schema, table=test_layer2)
 
         # no gpkg_tbl argument so that it bulk uploads
-        s = Geopackage(path=fp, gpkg_name=gpkg_name)
+        s = Geopackage(path=FOLDER_PATH, gpkg_name=gpkg_name)
         s.read_gpkg_bulk(dbo=db, schema=pg_schema, print_cmd=True)
 
         # Assert read_gpkg happened successfully and contents are correct
@@ -166,25 +166,23 @@ class TestReadgpkgPG:
         db.drop_table(schema=pg_schema, table=test_layer2)
 
     def test_list_all_gpkg_tables(self):
-        
-        fp = os.path.join(os.path.dirname(os.path.abspath(__file__)))+'/test_data/'
+
         gpkg_name = "testgpkg.gpkg"
-        s = Geopackage(path=fp, gpkg_name=gpkg_name)
+        s = Geopackage(path=FOLDER_PATH, gpkg_name=gpkg_name)
         s_list = s.list_gpkg_tables()
 
         assert s_list == [test_layer1, test_layer2]
 
     def test_read_gpkg_no_schema(self):
-        fp = os.path.join(os.path.dirname(os.path.abspath(__file__)))+'/test_data'
         gpkg_name = "testgpkg.gpkg"
 
         # Assert successful
-        assert gpkg_name in os.listdir(fp)
+        assert gpkg_name in os.listdir(FOLDER_PATH)
         db.drop_table(schema=pg_schema, table=test_layer1)
         db.drop_table(schema=pg_schema, table=test_layer2)
 
         # Read gpkg to new, test table
-        s = Geopackage(path=fp, gpkg_name=gpkg_name, gpkg_tbl = test_layer2)
+        s = Geopackage(path=FOLDER_PATH, gpkg_name=gpkg_name, gpkg_tbl = test_layer2)
         s.read_gpkg(dbo=db, table = test_read_gpkg_table_name, print_cmd=True)
 
         # Assert read_gpkg happened successfully and contents are correct
@@ -242,17 +240,16 @@ class TestReadgpkgMS:
         helpers.set_up_geopackage(db.user)
 
     def test_read_gpkg_basic(self):
-        fp = os.path.join(os.path.dirname(os.path.abspath(__file__)))+'\\test_data'
         gpkg_name = "testgpkg.gpkg"
 
         # Assert successful
-        assert gpkg_name in os.listdir(fp)
+        assert gpkg_name in os.listdir(FOLDER_PATH)
 
         # remove temp table from MS SQL Server if it already exists
         sql.query(f"drop table if exists {ms_schema}.{test_read_gpkg_table_name}")
 
         # Read gpkg to new, test table
-        s = Geopackage(path=fp, gpkg_name=gpkg_name, gpkg_tbl = test_layer2)
+        s = Geopackage(path=FOLDER_PATH, gpkg_name=gpkg_name, gpkg_tbl = test_layer2)
         s.read_gpkg(dbo=sql, table=test_read_gpkg_table_name, schema=ms_schema, print_cmd=True)
 
         # Assert read_gpkg happened successfully and contents are correct
@@ -288,16 +285,16 @@ class TestReadgpkgMS:
         """
         Test for multiple tables within a geopackage
         """
-        fp = os.path.join(os.path.dirname(os.path.abspath(__file__)))+'/test_data/'
+
         gpkg_name = "testgpkg.gpkg"
 
         # Assert successful
-        assert gpkg_name in os.listdir(fp)
+        assert gpkg_name in os.listdir(FOLDER_PATH)
         sql.query(f"drop table if exists {ms_schema}.{test_layer1}")
         sql.query(f"drop table if exists {ms_schema}.{test_layer2}")
 
         # no gpkg_tbl argument so that it bulk uploads
-        s = Geopackage(path=fp, gpkg_name=gpkg_name)
+        s = Geopackage(path=FOLDER_PATH, gpkg_name=gpkg_name)
         s.read_gpkg_bulk(dbo=sql, schema=ms_schema, print_cmd=True)
 
         # Assert read_gpkg happened successfully and contents are correct
@@ -316,18 +313,17 @@ class TestReadgpkgMS:
         sql.query(f"drop table if exists {ms_schema}.{test_layer2}")
 
     def test_read_gpkg_no_table(self):
-        fp = os.path.join(os.path.dirname(os.path.abspath(__file__)))+'/test_data'
         gpkg_name = "testgpkg.gpkg"
 
         # Assert successful
-        assert gpkg_name in os.listdir(fp)
+        assert gpkg_name in os.listdir(FOLDER_PATH)
 
         # drop temp table if exists
         sql.query(f"drop table if exists {ms_schema}.{test_layer1}")
         sql.query(f"drop table if exists {ms_schema}.{test_layer2}")
 
         # Read gpkg to new, test table
-        s = Geopackage(path=fp, gpkg_name=gpkg_name)
+        s = Geopackage(path=FOLDER_PATH, gpkg_name=gpkg_name)
         s.read_gpkg_bulk(dbo=sql, schema=ms_schema, print_cmd=True)
 
         # Assert read_gpkg happened successfully and contents are correct
@@ -375,15 +371,14 @@ class TestReadgpkgMS:
 
 
     def test_read_gpkg_no_schema(self):
-        fp = os.path.join(os.path.dirname(os.path.abspath(__file__)))+'/test_data'
         gpkg_name = "testgpkg.gpkg"
 
         # Assert successful
-        assert gpkg_name in os.listdir(fp)
+        assert gpkg_name in os.listdir(FOLDER_PATH)
         sql.drop_table(schema=sql.default_schema, table=test_read_gpkg_table_name)
 
         # Read gpkg to new, test table
-        s = Geopackage(path=fp, gpkg_name=gpkg_name, gpkg_tbl = test_layer1)
+        s = Geopackage(path=FOLDER_PATH, gpkg_name=gpkg_name, gpkg_tbl = test_layer1)
         s.read_gpkg(dbo=sql, table=test_read_gpkg_table_name, print_cmd=True)
 
         # Assert read_gpkg happened successfully and contents are correct
@@ -412,17 +407,16 @@ class TestReadgpkgMS:
         sql.drop_table(schema=sql.default_schema, table=test_read_gpkg_table_name)
 
     def test_read_gpkg_no_output_name(self):
-        fp = os.path.join(os.path.dirname(os.path.abspath(__file__)))+'\\test_data'
         gpkg_name = "testgpkg.gpkg"
 
         # Assert successful
-        assert gpkg_name in os.listdir(fp)
+        assert gpkg_name in os.listdir(FOLDER_PATH)
 
         # remove temp table from MS SQL Server if it already exists
         sql.query(f"drop table if exists {ms_schema}.{test_layer1}")
 
         # Read gpkg to new, test table
-        s = Geopackage(path=fp, gpkg_name=gpkg_name, gpkg_tbl = test_layer1)
+        s = Geopackage(path=FOLDER_PATH, gpkg_name=gpkg_name, gpkg_tbl = test_layer1)
         s.read_gpkg(dbo=sql, schema=ms_schema, print_cmd=True)
 
         # Assert read_gpkg happened successfully and contents are correct
@@ -473,6 +467,7 @@ class TestReadgpkgMS:
         helpers.clean_up_geopackage()
         helpers.clean_up_test_table_pg(db)
 
+
 class TestWritegpkgPG:
     @classmethod
     def setup_class(cls):
@@ -489,18 +484,18 @@ class TestWritegpkgPG:
         limit 100
         """)
 
-        fp = os.path.join(os.path.dirname(os.path.abspath(__file__)))
+
         gpkg_name = 'testgpkg.gpkg'
 
         # Write gpkg
-        s = Geopackage(path=fp, gpkg_name=gpkg_name)
+        s = Geopackage(path=FOLDER_PATH, gpkg_name=gpkg_name)
         s.write_gpkg(dbo=db, schema=pg_schema, table=test_write_gpkg_table_name, print_cmd=True)
 
         # Assert successful
-        assert os.path.isfile(os.path.join(fp, gpkg_name))
+        assert os.path.isfile(os.path.join(FOLDER_PATH, gpkg_name))
 
         # Reupload as table
-        db.gpkg_to_table(path=fp, schema=pg_schema, table = test_reuploaded_table_name, gpkg_name = gpkg_name, gpkg_tbl = test_write_gpkg_table_name, print_cmd=True)
+        db.gpkg_to_table(path=FOLDER_PATH, schema=pg_schema, table = test_reuploaded_table_name, gpkg_name = gpkg_name, gpkg_tbl = test_write_gpkg_table_name, print_cmd=True)
 
         # Assert equality
         db_df = db.dfquery(f"select * from {pg_schema}.{pg_table_name} order by id limit 100")
@@ -528,7 +523,7 @@ class TestWritegpkgPG:
         # clean up
         db.drop_table(schema=pg_schema, table=test_write_gpkg_table_name)
         db.drop_table(schema=pg_schema, table=test_reuploaded_table_name)
-        os.remove(os.path.join(fp, gpkg_name))
+        os.remove(os.path.join(FOLDER_PATH, gpkg_name))
 
     def test_write_gpkg_overwrite(self):
         db.query(f"""
@@ -541,15 +536,15 @@ class TestWritegpkgPG:
         limit 100
         """)
 
-        fp = os.path.join(os.path.dirname(os.path.abspath(__file__)))
+
         gpkg_name = 'testgpkg.gpkg'
 
         # Write gpkg
-        s = Geopackage(path=fp, gpkg_name=gpkg_name)
+        s = Geopackage(path=FOLDER_PATH, gpkg_name=gpkg_name)
         s.write_gpkg(dbo=db, schema=pg_schema, table=test_write_gpkg_table_name, print_cmd=True)
 
         # Assert successful
-        assert os.path.isfile(os.path.join(fp, gpkg_name))
+        assert os.path.isfile(os.path.join(FOLDER_PATH, gpkg_name))
 
         # overwrite the table as a version with 2 rows
         db.query(f"""
@@ -561,11 +556,11 @@ class TestWritegpkgPG:
         order by id
         limit 2
         """)
-        s = Geopackage(path=fp, gpkg_name=gpkg_name)
+        s = Geopackage(path=FOLDER_PATH, gpkg_name=gpkg_name)
         s.write_gpkg(dbo=db, schema=pg_schema, table=test_write_gpkg_table_name, overwrite = True, print_cmd=True) # overwrite to 2 rows
 
         # Reupload as table
-        db.gpkg_to_table(path=fp, schema=pg_schema, gpkg_name=gpkg_name, gpkg_tbl = test_write_gpkg_table_name,
+        db.gpkg_to_table(path=FOLDER_PATH, schema=pg_schema, gpkg_name=gpkg_name, gpkg_tbl = test_write_gpkg_table_name,
                          table = test_reuploaded_table_name, print_cmd=True)
 
         # Assert equality
@@ -594,7 +589,7 @@ class TestWritegpkgPG:
         # clean up
         db.drop_table(schema=pg_schema, table=test_write_gpkg_table_name)
         db.drop_table(schema=pg_schema, table=test_reuploaded_table_name)
-        os.remove(os.path.join(fp, gpkg_name))
+        os.remove(os.path.join(FOLDER_PATH, gpkg_name))
 
     def test_write_gpkg_add_table(self):
 
@@ -608,15 +603,14 @@ class TestWritegpkgPG:
         limit 100
         """)
 
-        fp = os.path.join(os.path.dirname(os.path.abspath(__file__)))
         gpkg_name = 'testgpkg.gpkg'
 
         # Write gpkg
-        s = Geopackage(path=fp, gpkg_name=gpkg_name)
+        s = Geopackage(path=FOLDER_PATH, gpkg_name=gpkg_name)
         s.write_gpkg(dbo=db, schema=pg_schema, gpkg_tbl = test_reuploaded_table_name, table= test_write_gpkg_table_name, print_cmd=True)
 
         # Assert successful
-        assert os.path.isfile(os.path.join(fp, gpkg_name))
+        assert os.path.isfile(os.path.join(FOLDER_PATH, gpkg_name))
 
         # add another (differently-named) table to the same gpkg
         db.query(f"""
@@ -628,13 +622,13 @@ class TestWritegpkgPG:
         order by id
         limit 2
         """)
-        s = Geopackage(path=fp, gpkg_name=gpkg_name)
+        s = Geopackage(path=FOLDER_PATH, gpkg_name=gpkg_name)
         s.write_gpkg(dbo=db, schema=pg_schema, table = test_write_gpkg_table_name + '_2', gpkg_tbl = test_reuploaded_table_name + '_2', overwrite = False, print_cmd=True) # add another table
 
-        assert os.path.isfile(os.path.join(fp, gpkg_name)) # assert that the table is still there
+        assert os.path.isfile(os.path.join(FOLDER_PATH, gpkg_name)) # assert that the table is still there
 
         # Reupload both tables from the same geopackage (since we are uploading under a different name, we can't use bulk upload function here)
-        db.gpkg_to_table_bulk(path=fp, schema=pg_schema, gpkg_name=gpkg_name, print_cmd=True) 
+        db.gpkg_to_table_bulk(path=FOLDER_PATH, schema=pg_schema, gpkg_name=gpkg_name, print_cmd=True)
 
         # Assert equality
         db_df = db.dfquery(f"select * from {pg_schema}.{pg_table_name} order by id limit 100")
@@ -682,7 +676,7 @@ class TestWritegpkgPG:
         db.drop_table(schema=pg_schema, table=test_reuploaded_table_name)
         db.drop_table(schema=pg_schema, table=test_write_gpkg_table_name + '_2')
         db.drop_table(schema=pg_schema, table=test_reuploaded_table_name + '_2')
-        os.remove(os.path.join(fp, gpkg_name))
+        os.remove(os.path.join(FOLDER_PATH, gpkg_name))
 
     def test_write_gpkg_table_pth(self):
         db.drop_table(pg_schema, test_write_gpkg_table_name)
@@ -694,18 +688,17 @@ class TestWritegpkgPG:
         limit 100
         """)
 
-        fp = os.path.join(os.path.dirname(os.path.abspath(__file__)))
         gpkg_name = 'testgpkg.gpkg'
 
         # Write gpkg
-        s = Geopackage(path=fp, gpkg_name=gpkg_name)
+        s = Geopackage(path=FOLDER_PATH, gpkg_name=gpkg_name)
         s.write_gpkg(dbo=db, table=test_write_gpkg_table_name, schema=pg_schema, print_cmd=True)
 
         # Assert successful
-        assert os.path.isfile(os.path.join(fp, gpkg_name))
+        assert os.path.isfile(os.path.join(FOLDER_PATH, gpkg_name))
 
         # Reupload as table
-        db.gpkg_to_table(path=fp+'\\'+gpkg_name, gpkg_name = gpkg_name, schema=pg_schema, table=test_reuploaded_table_name, gpkg_tbl = test_write_gpkg_table_name, print_cmd=True)
+        db.gpkg_to_table(path=os.path.join(FOLDER_PATH, gpkg_name), gpkg_name = gpkg_name, schema=pg_schema, table=test_reuploaded_table_name, gpkg_tbl = test_write_gpkg_table_name, print_cmd=True)
 
         # Assert equality
         db_df = db.dfquery(f"select * from {pg_schema}.{pg_table_name} order by id limit 100")
@@ -735,7 +728,7 @@ class TestWritegpkgPG:
 
         # clean up
         db.drop_table(schema=pg_schema, table=test_write_gpkg_table_name)
-        os.remove(os.path.join(fp, gpkg_name))
+        os.remove(os.path.join(FOLDER_PATH, gpkg_name))
 
     def test_write_gpkg_table_pth_w_name(self):
         db.query(f"""
@@ -748,18 +741,17 @@ class TestWritegpkgPG:
         limit 100
         """)
 
-        fp = os.path.join(os.path.dirname(os.path.abspath(__file__)))
         gpkg_name = 'testgpkg.gpkg'
 
         # Write gpkg
-        s = Geopackage(path=fp, gpkg_name=gpkg_name)
+        s = Geopackage(path=FOLDER_PATH, gpkg_name=gpkg_name)
         s.write_gpkg(dbo=db, table=test_write_gpkg_table_name, schema=pg_schema, print_cmd=True)
 
         # Assert successful
-        assert os.path.isfile(os.path.join(fp, gpkg_name))
+        assert os.path.isfile(os.path.join(FOLDER_PATH, gpkg_name))
 
         # Reupload as table
-        db.gpkg_to_table(path=fp+'\\'+'err_'+gpkg_name, gpkg_name=gpkg_name ,schema=pg_schema,
+        db.gpkg_to_table(path=os.path.join(FOLDER_PATH, 'err_'+gpkg_name), gpkg_name=gpkg_name ,schema=pg_schema,
                         table=test_reuploaded_table_name, gpkg_tbl = test_write_gpkg_table_name, print_cmd=True)
 
         # Assert equality
@@ -790,22 +782,22 @@ class TestWritegpkgPG:
 
         # clean up
         db.drop_table(schema=pg_schema, table=test_write_gpkg_table_name)
-        os.remove(os.path.join(fp, gpkg_name))
+        os.remove(os.path.join(FOLDER_PATH, gpkg_name))
 
     def test_write_gpkg_query(self):
-        fp = os.path.join(os.path.dirname(os.path.abspath(__file__)))
+
         gpkg_name = 'testgpkg.gpkg'
 
         # Write gpkg
-        s = Geopackage(path=fp, gpkg_name=gpkg_name)
+        s = Geopackage(path=FOLDER_PATH, gpkg_name=gpkg_name)
         s.write_gpkg(dbo=db, query=f"""select * from {pg_schema}.{pg_table_name} order by id limit 100""",
                     gpkg_tbl = test_write_gpkg_table_name, print_cmd=True)
 
         # Check table in folder
-        assert os.path.isfile(os.path.join(fp, gpkg_name))
+        assert os.path.isfile(os.path.join(FOLDER_PATH, gpkg_name))
 
         # Reupload as table
-        db.gpkg_to_table(path=fp, gpkg_name=gpkg_name, schema=pg_schema,
+        db.gpkg_to_table(path=FOLDER_PATH, gpkg_name=gpkg_name, schema=pg_schema,
                          table=test_reuploaded_table_name, gpkg_tbl = test_write_gpkg_table_name, print_cmd=True)
 
         # Assert equality
@@ -834,7 +826,7 @@ class TestWritegpkgPG:
                 # clean up
         db.drop_table(schema=pg_schema, table=test_write_gpkg_table_name)
         db.drop_table(schema=pg_schema, table=test_reuploaded_table_name)
-        os.remove(os.path.join(fp, gpkg_name))
+        os.remove(os.path.join(FOLDER_PATH, gpkg_name))
 
     @classmethod
     def teardown_class(cls):
@@ -853,18 +845,17 @@ class TestWritegpkgMS:
         insert into {ms_schema}.{test_write_gpkg_table_name} VALUES(3, 4, geometry::Point(985831.79200444, 203371.60461367, 2263));
         """)
 
-        fp = os.path.join(os.path.dirname(os.path.abspath(__file__)))+'\\test_data'
         gpkg_name = 'test_write.gpkg'
 
         # Write gpkg
-        s = Geopackage(path=fp, gpkg_name=gpkg_name)
+        s = Geopackage(path=FOLDER_PATH, gpkg_name=gpkg_name)
         s.write_gpkg(dbo=sql, schema = ms_schema, table=test_write_gpkg_table_name, print_cmd=True)
 
         # # Assert successful
-        assert os.path.isfile(os.path.join(fp, gpkg_name))
+        assert os.path.isfile(os.path.join(FOLDER_PATH, gpkg_name))
 
         # Reupload as table
-        sql.gpkg_to_table(path=fp, gpkg_name=gpkg_name, schema = ms_schema, table=test_reuploaded_table_name,
+        sql.gpkg_to_table(path=FOLDER_PATH, gpkg_name=gpkg_name, schema = ms_schema, table=test_reuploaded_table_name,
                           gpkg_tbl = test_write_gpkg_table_name, print_cmd=True)
 
         # # Assert equality
@@ -891,7 +882,7 @@ class TestWritegpkgMS:
         assert dist_df.iloc[0]['distance'] == 0
 
         # Clean up
-        os.remove(os.path.join(fp, gpkg_name))
+        os.remove(os.path.join(FOLDER_PATH, gpkg_name))
         sql.query(f"drop table if exists {ms_schema}.{test_write_gpkg_table_name};")
 
     def test_write_gpkg_overwrite(self):
@@ -905,15 +896,15 @@ class TestWritegpkgMS:
         insert into {ms_schema}.{test_write_gpkg_table_name} VALUES(3, 4, geometry::Point(985831.79200444, 203371.60461367, 2263));
         """)
 
-        fp = os.path.join(os.path.dirname(os.path.abspath(__file__)))+'\\test_data'
+
         gpkg_name = 'test_write.gpkg'
 
         # Write gpkg. Gpkg table will be named the same as the query table
-        s = Geopackage(path=fp, gpkg_name=gpkg_name)
+        s = Geopackage(path=FOLDER_PATH, gpkg_name=gpkg_name)
         s.write_gpkg(dbo=sql, schema = ms_schema, table=test_write_gpkg_table_name, print_cmd=True)
 
         # # Assert successful
-        assert os.path.isfile(os.path.join(fp, gpkg_name))
+        assert os.path.isfile(os.path.join(FOLDER_PATH, gpkg_name))
 
         ### ADD THE SECOND TABLE THAT IS SHORTER VERSION ###
         # Add test_table (slightly different values)
@@ -925,16 +916,16 @@ class TestWritegpkgMS:
         """)
 
         # Write gpkg. Gpkg table will be named the same as the previous table to overwrite it
-        s = Geopackage(path=fp,
+        s = Geopackage(path=FOLDER_PATH,
                        gpkg_name=gpkg_name,
                         gpkg_tbl = test_write_gpkg_table_name)
         s.write_gpkg(dbo=sql, schema = ms_schema, table=test_write_gpkg_table_name + '_2', overwrite = True, print_cmd=True)
 
         # Assert successful
-        assert os.path.isfile(os.path.join(fp, gpkg_name))
+        assert os.path.isfile(os.path.join(FOLDER_PATH, gpkg_name))
 
         # Reupload as table
-        sql.gpkg_to_table(path=fp, gpkg_name=gpkg_name, schema = ms_schema, 
+        sql.gpkg_to_table(path=FOLDER_PATH, gpkg_name=gpkg_name, schema = ms_schema,
                           gpkg_tbl = test_write_gpkg_table_name +'_2', table=test_reuploaded_table_name, print_cmd=True)
 
         # # Assert equality
@@ -961,7 +952,7 @@ class TestWritegpkgMS:
         assert dist_df.iloc[0]['distance'] == 0
 
         # Clean up
-        os.remove(os.path.join(fp, gpkg_name))
+        os.remove(os.path.join(FOLDER_PATH, gpkg_name))
         sql.query(f"drop table if exists {ms_schema}.{test_write_gpkg_table_name};")
         sql.query(f"drop table if exists {ms_schema}.{test_write_gpkg_table_name}_2;")
         sql.query(f"drop table if exists {ms_schema}.{test_reuploaded_table_name};")
@@ -977,15 +968,15 @@ class TestWritegpkgMS:
             insert into {ms_schema}.{test_write_gpkg_table_name} VALUES(3, 4, geometry::Point(985831.79200444, 203371.60461367, 2263));
         """)
 
-        fp = os.path.join(os.path.dirname(os.path.abspath(__file__)))+'\\test_data'
+
         gpkg_name = 'test_write.gpkg'
 
         # Write gpkg. Gpkg table will be named the same as the query table
-        s = Geopackage(path=fp, gpkg_name=gpkg_name)
+        s = Geopackage(path=FOLDER_PATH, gpkg_name=gpkg_name)
         s.write_gpkg(dbo=sql, schema = ms_schema, table= test_write_gpkg_table_name, gpkg_tbl = test_reuploaded_table_name, print_cmd=True)
 
         # # Assert successful
-        assert os.path.isfile(os.path.join(fp, gpkg_name))
+        assert os.path.isfile(os.path.join(FOLDER_PATH, gpkg_name))
 
         ### ADD THE SECOND TABLE THAT IS SHORTER VERSION ###
         # Add test_table (slightly different values)
@@ -997,14 +988,14 @@ class TestWritegpkgMS:
         """)
 
         # Write gpkg.
-        s = Geopackage(path=fp, gpkg_name=gpkg_name, )
+        s = Geopackage(path=FOLDER_PATH, gpkg_name=gpkg_name, )
         s.write_gpkg(dbo=sql, schema = ms_schema, gpkg_tbl=test_reuploaded_table_name + '_2', table = test_write_gpkg_table_name + '_2', print_cmd=True) # add second table
 
         # Assert successful
-        assert os.path.isfile(os.path.join(fp, gpkg_name))
+        assert os.path.isfile(os.path.join(FOLDER_PATH, gpkg_name))
 
         # Reupload as tables using bulk upload function
-        sql.gpkg_to_table_bulk(path=fp, gpkg_name=gpkg_name, schema = ms_schema, print_cmd=True)
+        sql.gpkg_to_table_bulk(path=FOLDER_PATH, gpkg_name=gpkg_name, schema = ms_schema, print_cmd=True)
 
         # # Assert equality
         db_df = sql.dfquery(f"select top 10 * from {ms_schema}.{test_write_gpkg_table_name} order by test_col1")
@@ -1037,7 +1028,7 @@ class TestWritegpkgMS:
         assert dist_df.iloc[0]['distance'] == 0
 
         # Clean up
-        os.remove(os.path.join(fp, gpkg_name))
+        os.remove(os.path.join(FOLDER_PATH, gpkg_name))
         sql.query(f"drop table if exists {ms_schema}.{test_write_gpkg_table_name};")
         sql.query(f"drop table if exists {ms_schema}.{test_write_gpkg_table_name}_2;")
     
@@ -1052,18 +1043,18 @@ class TestWritegpkgMS:
         insert into {ms_schema}.{test_write_gpkg_table_name} VALUES(3, 4, geometry::Point(985831.79200444, 203371.60461367, 2263));
         """)
 
-        fp = os.path.join(os.path.dirname(os.path.abspath(__file__)))
+
         gpkg_name = 'test_write.gpkg'
 
         # Write gpkg
-        s = Geopackage(path=fp, gpkg_name=gpkg_name)
+        s = Geopackage(path=FOLDER_PATH, gpkg_name=gpkg_name)
         s.write_gpkg(dbo=sql, table= test_write_gpkg_table_name, gpkg_tbl = test_write_gpkg_table_name, schema=ms_schema, print_cmd=True)
 
         # Assert successful
-        assert os.path.isfile(os.path.join(fp, gpkg_name))
+        assert os.path.isfile(os.path.join(FOLDER_PATH, gpkg_name))
 
         # Reupload as table
-        sql.gpkg_to_table(path=fp+'\\'+gpkg_name, gpkg_name = gpkg_name, gpkg_tbl = test_write_gpkg_table_name,
+        sql.gpkg_to_table(path=os.path.join(FOLDER_PATH, gpkg_name), gpkg_name = gpkg_name, gpkg_tbl = test_write_gpkg_table_name,
                             schema=ms_schema, table=test_reuploaded_table_name, print_cmd=True)
 
         # Assert equality
@@ -1093,10 +1084,10 @@ class TestWritegpkgMS:
         sql.query(f"drop table if exists {ms_schema}.{test_write_gpkg_table_name}")
         sql.query(f"drop table if exists {ms_schema}.{test_reuploaded_table_name}")
 
-        os.remove(os.path.join(fp, gpkg_name))
+        os.remove(os.path.join(FOLDER_PATH, gpkg_name))
 
     def test_write_gpkg_query(self):
-        fp = os.path.join(os.path.dirname(os.path.abspath(__file__)))+'/test_data'
+
         gpkg_name = 'testgpkg.gpkg'
         sql.query(f"drop table if exists {ms_schema}.{test_write_gpkg_table_name}")
 
@@ -1108,15 +1099,15 @@ class TestWritegpkgMS:
         """)
 
         # Write gpkg
-        s = Geopackage(path=fp, gpkg_name=gpkg_name, gpkg_tbl = test_write_gpkg_table_name)
+        s = Geopackage(path=FOLDER_PATH, gpkg_name=gpkg_name, gpkg_tbl = test_write_gpkg_table_name)
         s.write_gpkg(dbo=sql, query=f"""select top 10 * from {ms_schema}.{test_write_gpkg_table_name} order by test_col1""",
                         gpkg_tbl = test_write_gpkg_table_name, print_cmd=True)
 
         # Check table in folder
-        assert os.path.isfile(os.path.join(fp, gpkg_name))
+        assert os.path.isfile(os.path.join(FOLDER_PATH, gpkg_name))
 
         # Reupload as table
-        sql.gpkg_to_table(path=fp, gpkg_name=gpkg_name, gpkg_tbl = test_write_gpkg_table_name,
+        sql.gpkg_to_table(path=FOLDER_PATH, gpkg_name=gpkg_name, gpkg_tbl = test_write_gpkg_table_name,
                             schema=ms_schema, table=test_reuploaded_table_name, print_cmd=True)
 
         # Assert equality
@@ -1146,7 +1137,7 @@ class TestWritegpkgMS:
         sql.query(f"drop table if exists {ms_schema}.{test_reuploaded_table_name}")
         sql.query(f"drop table if exists {ms_schema}.{test_write_gpkg_table_name}")
 
-        os.remove(os.path.join(fp, gpkg_name))
+        os.remove(os.path.join(FOLDER_PATH, gpkg_name))
         
     @classmethod
     def teardown_class(cls):
@@ -1157,7 +1148,6 @@ class TestGpkgShpConversion:
         
     def test_convert_gpkg_to_shp_file(self):
 
-        fp = os.path.join(os.path.dirname(os.path.abspath(__file__)))+'/test_data'
         gpkg_name = 'gpkg_to_shp.gpkg'
 
         # no shape file name needs to be specified because the table(s) within the gpkg are not necessarily named the same thing
@@ -1172,21 +1162,21 @@ class TestGpkgShpConversion:
         assert sql.table_exists(schema = ms_schema, table = test_write_gpkg_table_name)
 
         # write geopackage file
-        s = Geopackage(path = fp, gpkg_name=gpkg_name)
+        s = Geopackage(path = FOLDER_PATH, gpkg_name=gpkg_name)
         s.write_gpkg(dbo=sql, table= test_write_gpkg_table_name, schema=ms_schema, print_cmd=True)
 
         # # Check table in folder
-        assert os.path.isfile(os.path.join(fp, gpkg_name))
+        assert os.path.isfile(os.path.join(FOLDER_PATH, gpkg_name))
         
         # run function to convert geopackage to shape file
-        s.gpkg_to_shp(export_path = fp, gpkg_tbl = test_write_gpkg_table_name, print_cmd = True)
+        s.gpkg_to_shp(export_path = FOLDER_PATH, gpkg_tbl = test_write_gpkg_table_name, print_cmd = True)
 
         # assert that a shape output file exists. It will not match the name of the geopackage because the tables inside the package canbe different
-        assert os.path.isfile(os.path.join(fp, test_write_gpkg_table_name + '.shp'))
+        assert os.path.isfile(os.path.join(FOLDER_PATH, test_write_gpkg_table_name + '.shp'))
 
         # check that the shapefile and gpkg have the same output
-        cmd_gpkg = f'ogrinfo "{fp}/{gpkg_name}" -sql "SELECT test_col1 FROM {test_write_gpkg_table_name} LIMIT 1" -q'
-        cmd_shp = f'ogrinfo "{fp}/{test_write_gpkg_table_name}.shp" -sql "SELECT test_col1 FROM {test_write_gpkg_table_name} LIMIT 1" -q'
+        cmd_gpkg = f'ogrinfo "{FOLDER_PATH}/{gpkg_name}" -sql "SELECT test_col1 FROM {test_write_gpkg_table_name} LIMIT 1" -q'
+        cmd_shp = f'ogrinfo "{FOLDER_PATH}/{test_write_gpkg_table_name}.shp" -sql "SELECT test_col1 FROM {test_write_gpkg_table_name} LIMIT 1" -q'
 
         ogr_response_gpkg = subprocess.check_output(shlex.split(cmd_gpkg), stderr=subprocess.STDOUT)
         ogr_response_shp = subprocess.check_output(shlex.split(cmd_shp), stderr=subprocess.STDOUT)
@@ -1194,15 +1184,14 @@ class TestGpkgShpConversion:
         assert 'test_col1 (Integer) = 1' in str(ogr_response_gpkg) and 'test_col1 (Integer) = 1' in str(ogr_response_shp), "cannot find 'test_col1 (Integer) = 1' statement in both the shapefile and gpkg queries"
 
         # remove geopackage and shape files
-        os.remove(os.path.join(fp, gpkg_name))
+        os.remove(os.path.join(FOLDER_PATH, gpkg_name))
         for ext in ('dbf', 'prj', 'shx', 'shp'):
-            os.remove(os.path.join(fp, test_write_gpkg_table_name + '.' + ext))
+            os.remove(os.path.join(FOLDER_PATH, test_write_gpkg_table_name + '.' + ext))
 
         sql.drop_table(schema = ms_schema, table = test_write_gpkg_table_name)
     
     def test_convert_gpkg_to_shp_custom_path(self):
 
-        fp = os.path.join(os.path.dirname(os.path.abspath(__file__)))+'/test_data'
         gpkg_name = 'gpkg_to_shp.gpkg'
 
         # no shape file name needs to be specified because the table(s) within the gpkg are not necessarily named the same thing
@@ -1215,20 +1204,20 @@ class TestGpkgShpConversion:
                 """)
 
         # write geopackage file
-        s = Geopackage(path = fp, gpkg_name=gpkg_name)
+        s = Geopackage(path = FOLDER_PATH, gpkg_name=gpkg_name)
         s.write_gpkg(dbo=sql, table= test_write_gpkg_table_name, schema=ms_schema, print_cmd=True)
 
         # Check table in folder
-        assert os.path.isfile(os.path.join(fp, gpkg_name))
+        assert os.path.isfile(os.path.join(FOLDER_PATH, gpkg_name))
         # run function to convert geopackage to shape file
-        s.gpkg_to_shp_bulk(export_path = fp)
+        s.gpkg_to_shp_bulk(export_path = FOLDER_PATH)
  
         # assert that a shape output file exists. It will not match the name of the geopackage because the tables inside the package canbe different
-        assert os.path.isfile(os.path.join(fp , test_write_gpkg_table_name + '.shp'))
+        assert os.path.isfile(os.path.join(FOLDER_PATH , test_write_gpkg_table_name + '.shp'))
 
         # check that the shapefile and gpkg have the same output
-        cmd_gpkg = f'ogrinfo "{fp}/{gpkg_name}" -sql "SELECT test_col1 FROM {test_write_gpkg_table_name} LIMIT 1" -q'
-        cmd_shp = f'ogrinfo "{fp}/{test_write_gpkg_table_name}.shp" -sql "SELECT test_col1 FROM {test_write_gpkg_table_name} LIMIT 1" -q'
+        cmd_gpkg = f'ogrinfo "{FOLDER_PATH}/{gpkg_name}" -sql "SELECT test_col1 FROM {test_write_gpkg_table_name} LIMIT 1" -q'
+        cmd_shp = f'ogrinfo "{FOLDER_PATH}/{test_write_gpkg_table_name}.shp" -sql "SELECT test_col1 FROM {test_write_gpkg_table_name} LIMIT 1" -q'
 
         ogr_response_gpkg = subprocess.check_output(shlex.split(cmd_gpkg), stderr=subprocess.STDOUT)
         ogr_response_shp = subprocess.check_output(shlex.split(cmd_shp), stderr=subprocess.STDOUT)
@@ -1236,15 +1225,14 @@ class TestGpkgShpConversion:
         assert 'test_col1 (Integer) = 1' in str(ogr_response_gpkg) and 'test_col1 (Integer) = 1' in str(ogr_response_shp), "cannot find 'test_col1 (Integer) = 1' statement in both the shapefile and gpkg queries"
 
         # remove geopackage and shape files
-        os.remove(os.path.join(fp, gpkg_name))
+        os.remove(os.path.join(FOLDER_PATH, gpkg_name))
         for ext in ('dbf', 'prj', 'shx', 'shp'):
-            os.remove(os.path.join(fp, test_write_gpkg_table_name + '.' + ext))
+            os.remove(os.path.join(FOLDER_PATH, test_write_gpkg_table_name + '.' + ext))
 
         sql.drop_table(schema = ms_schema, table = test_write_gpkg_table_name)
 
     def test_convert_gpkg_to_shp_file_bulk(self):
 
-        fp = os.path.join(os.path.dirname(os.path.abspath(__file__))) + '/test_data'
         gpkg_name = 'gpkg_to_shp.gpkg'
 
         # no shape file name needs to be specified because the table(s) within the gpkg are not necessarily named the same thing
@@ -1257,7 +1245,7 @@ class TestGpkgShpConversion:
                 """)
 
         # write geopackage file
-        s = Geopackage(path = fp, gpkg_name=gpkg_name)
+        s = Geopackage(path = FOLDER_PATH, gpkg_name=gpkg_name)
         s.write_gpkg(dbo=sql, table= test_write_gpkg_table_name, schema=ms_schema, print_cmd=True)
 
         # add an extra table to test multiple
@@ -1270,25 +1258,25 @@ class TestGpkgShpConversion:
         assert sql.table_exists(schema = ms_schema, table = test_write_gpkg_table_name)
         assert sql.table_exists(schema = ms_schema, table = f"{test_write_gpkg_table_name}_2")
 
-        s = Geopackage(path = fp, gpkg_name=gpkg_name)
+        s = Geopackage(path = FOLDER_PATH, gpkg_name=gpkg_name)
         s.write_gpkg(dbo=sql, schema = ms_schema, table = test_write_gpkg_table_name + '_2', print_cmd=True) # this will append 
 
         # Check table in folder
-        assert os.path.isfile(os.path.join(fp, gpkg_name))
+        assert os.path.isfile(os.path.join(FOLDER_PATH, gpkg_name))
         
         # run function to convert geopackage to shape file
-        s = Geopackage(path = fp, gpkg_name=gpkg_name)
+        s = Geopackage(path = FOLDER_PATH, gpkg_name=gpkg_name)
         s.gpkg_to_shp_bulk(print_cmd = True)
 
         # assert that a shape output file exists. It will not match the name of the geopackage because the tables inside the package canbe different
-        assert os.path.isfile(os.path.join(fp, test_write_gpkg_table_name + '.shp'))
-        assert os.path.isfile(os.path.join(fp, test_write_gpkg_table_name + '_2.shp'))
+        assert os.path.isfile(os.path.join(FOLDER_PATH, test_write_gpkg_table_name + '.shp'))
+        assert os.path.isfile(os.path.join(FOLDER_PATH, test_write_gpkg_table_name + '_2.shp'))
 
         # check that the shapefile and gpkg have the same output
-        cmd_gpkg = f'ogrinfo "{fp}/{gpkg_name}" -sql "SELECT test_col1 FROM {test_write_gpkg_table_name} LIMIT 1" -q'
-        cmd_shp = f'ogrinfo "{fp}/{test_write_gpkg_table_name}.shp" -sql "SELECT test_col1 FROM {test_write_gpkg_table_name} LIMIT 1" -q'
-        cmd_gpkg2 = f'ogrinfo "{fp}/{gpkg_name}" -sql "SELECT test_col5 FROM {test_write_gpkg_table_name}_2 LIMIT 1" -q'
-        cmd_shp2 = f'ogrinfo "{fp}/{test_write_gpkg_table_name}_2.shp" -sql "SELECT test_col5 FROM {test_write_gpkg_table_name}_2 LIMIT 1" -q'
+        cmd_gpkg = f'ogrinfo "{FOLDER_PATH}/{gpkg_name}" -sql "SELECT test_col1 FROM {test_write_gpkg_table_name} LIMIT 1" -q'
+        cmd_shp = f'ogrinfo "{FOLDER_PATH}/{test_write_gpkg_table_name}.shp" -sql "SELECT test_col1 FROM {test_write_gpkg_table_name} LIMIT 1" -q'
+        cmd_gpkg2 = f'ogrinfo "{FOLDER_PATH}/{gpkg_name}" -sql "SELECT test_col5 FROM {test_write_gpkg_table_name}_2 LIMIT 1" -q'
+        cmd_shp2 = f'ogrinfo "{FOLDER_PATH}/{test_write_gpkg_table_name}_2.shp" -sql "SELECT test_col5 FROM {test_write_gpkg_table_name}_2 LIMIT 1" -q'
 
         ogr_response_gpkg = subprocess.check_output(shlex.split(cmd_gpkg), stderr=subprocess.STDOUT)
         ogr_response_shp = subprocess.check_output(shlex.split(cmd_shp), stderr=subprocess.STDOUT)
@@ -1301,15 +1289,14 @@ class TestGpkgShpConversion:
             "cannot find 'test_col5 (Integer) = 5' statement in both the shapefile and gpkg queries"
 
         # remove geopackage and shape files
-        os.remove(os.path.join(fp, gpkg_name))
+        os.remove(os.path.join(FOLDER_PATH, gpkg_name))
         sql.query(f"drop table if exists {ms_schema}.{test_write_gpkg_table_name}")
         sql.query(f"drop table if exists {ms_schema}.{test_write_gpkg_table_name}_2")
         for ext in ('dbf', 'prj', 'shx', 'shp'):
-            os.remove(os.path.join(fp, test_write_gpkg_table_name + '.' + ext))
-            os.remove(os.path.join(fp, test_write_gpkg_table_name + '_2.' + ext))
+            os.remove(os.path.join(FOLDER_PATH, test_write_gpkg_table_name + '.' + ext))
+            os.remove(os.path.join(FOLDER_PATH, test_write_gpkg_table_name + '_2.' + ext))
 
     def test_convert_shp_to_gpkg_file(self):
-        fp = os.path.join(os.path.dirname(os.path.abspath(__file__)))+'/test_data'
         gpkg_name = 'gpkg_to_shp.gpkg'
         shp_name = test_write_gpkg_table_name
 
@@ -1321,27 +1308,27 @@ class TestGpkgShpConversion:
                 """)
 
         # write geopackage file
-        s = Geopackage(path = fp, gpkg_name=gpkg_name)
+        s = Geopackage(path = FOLDER_PATH, gpkg_name=gpkg_name)
         s.write_gpkg(dbo=sql, table= test_write_gpkg_table_name, schema=ms_schema, print_cmd=True)
-        s.gpkg_to_shp(export_path = fp, gpkg_tbl = test_write_gpkg_table_name, print_cmd = True)
+        s.gpkg_to_shp(export_path = FOLDER_PATH, gpkg_tbl = test_write_gpkg_table_name, print_cmd = True)
 
         # drop SQL table and GPKG
         sql.query(f"drop table if exists {ms_schema}.{test_write_gpkg_table_name}")
-        os.remove(os.path.join(fp, gpkg_name))
+        os.remove(os.path.join(FOLDER_PATH, gpkg_name))
 
-        assert os.path.exists(os.path.join(fp, gpkg_name)) == False # confirm that the gpkg is removed
-        assert os.path.isfile(os.path.join(fp, shp_name + '.shp')) # confirm that the shp file exists
+        assert os.path.exists(os.path.join(FOLDER_PATH, gpkg_name)) == False # confirm that the gpkg is removed
+        assert os.path.isfile(os.path.join(FOLDER_PATH, shp_name + '.shp')) # confirm that the shp file exists
 
         # run function to convert Shapefile to GPKG
-        s = Geopackage(path=fp, gpkg_name=gpkg_name)
+        s = Geopackage(path=FOLDER_PATH, gpkg_name=gpkg_name)
         s.shp_to_gpkg(gpkg_tbl = test_write_gpkg_table_name, shp_name = shp_name + '.shp', print_cmd = True)
 
         # assert that the output file exists and that it matches the geopackage
-        assert os.path.isfile(os.path.join(fp, gpkg_name))
+        assert os.path.isfile(os.path.join(FOLDER_PATH, gpkg_name))
 
         # assert that the data is the same
-        cmd_gpkg = f'ogrinfo "{fp}/{gpkg_name}" -sql "SELECT test_col1 FROM {test_write_gpkg_table_name} LIMIT 1" -q'
-        cmd_shp = f'ogrinfo "{fp}/{shp_name}.shp" -sql "SELECT test_col1 FROM {test_write_gpkg_table_name} LIMIT 1" -q'
+        cmd_gpkg = f'ogrinfo "{FOLDER_PATH}/{gpkg_name}" -sql "SELECT test_col1 FROM {test_write_gpkg_table_name} LIMIT 1" -q'
+        cmd_shp = f'ogrinfo "{FOLDER_PATH}/{shp_name}.shp" -sql "SELECT test_col1 FROM {test_write_gpkg_table_name} LIMIT 1" -q'
 
         ogr_response_gpkg = subprocess.check_output(shlex.split(cmd_gpkg), stderr=subprocess.STDOUT)
         ogr_response_shp = subprocess.check_output(shlex.split(cmd_shp), stderr=subprocess.STDOUT)
@@ -1356,23 +1343,22 @@ class TestGpkgShpConversion:
         # copy the same shp file as an additional table in the gpkg
         # this test confirms that the update function for the gpkg is working correctly
 
-        fp = os.path.join(os.path.dirname(os.path.abspath(__file__)))+'/test_data'
         gpkg_name = 'gpkg_to_shp.gpkg'
         shp_name = test_write_gpkg_table_name
 
         # Check table in folder
-        assert os.path.isfile(os.path.join(fp, shp_name) + '.shp')
+        assert os.path.isfile(os.path.join(FOLDER_PATH, shp_name) + '.shp')
 
         # run function to convert Shapefile to GPKG
-        s = Geopackage(path=fp, gpkg_name=gpkg_name)
+        s = Geopackage(path=FOLDER_PATH, gpkg_name=gpkg_name)
         s.shp_to_gpkg(shp_name = shp_name + '.shp', gpkg_tbl = f'{test_write_gpkg_table_name}_2')
 
         # assert that the output file exists and that it matches the geopackage
-        assert os.path.isfile(os.path.join(fp, gpkg_name))
+        assert os.path.isfile(os.path.join(FOLDER_PATH, gpkg_name))
 
         # assert that the data is the same
-        cmd_gpkg = f'ogrinfo "{fp}/{gpkg_name}" -sql "SELECT test_col1 FROM {test_write_gpkg_table_name}_2 LIMIT 1" -q'
-        cmd_shp = f'ogrinfo "{fp}/{shp_name}.shp" -sql "SELECT test_col1 FROM {test_write_gpkg_table_name} LIMIT 1" -q'
+        cmd_gpkg = f'ogrinfo "{FOLDER_PATH}/{gpkg_name}" -sql "SELECT test_col1 FROM {test_write_gpkg_table_name}_2 LIMIT 1" -q'
+        cmd_shp = f'ogrinfo "{FOLDER_PATH}/{shp_name}.shp" -sql "SELECT test_col1 FROM {test_write_gpkg_table_name} LIMIT 1" -q'
 
         ogr_response_gpkg_2 = subprocess.check_output(shlex.split(cmd_gpkg), stderr=subprocess.STDOUT)
         ogr_response_shp_2 = subprocess.check_output(shlex.split(cmd_shp), stderr=subprocess.STDOUT)
@@ -1382,12 +1368,12 @@ class TestGpkgShpConversion:
         # remove shape file
         for ext in ('.dbf', '.prj', '.shx', '.shp'):
             try:
-                os.remove(os.path.join(fp, shp_name + ext))
+                os.remove(os.path.join(FOLDER_PATH, shp_name + ext))
             except Exception as e:
                 print(e)
 
         # remove gpkg output
-        os.remove(os.path.join(fp, gpkg_name))
+        os.remove(os.path.join(FOLDER_PATH, gpkg_name))
         
     @classmethod
     def teardown_class(cls):

--- a/pysqldb3/tests/test_geopackage.py
+++ b/pysqldb3/tests/test_geopackage.py
@@ -1157,7 +1157,7 @@ class TestGpkgShpConversion:
         
     def test_convert_gpkg_to_shp_file(self):
 
-        fp = os.path.join(os.path.dirname(os.path.abspath(__file__)))+'\\test_data'
+        fp = os.path.join(os.path.dirname(os.path.abspath(__file__)))+'/test_data'
         gpkg_name = 'gpkg_to_shp.gpkg'
 
         # no shape file name needs to be specified because the table(s) within the gpkg are not necessarily named the same thing
@@ -1168,6 +1168,8 @@ class TestGpkgShpConversion:
                 insert into {ms_schema}.{test_write_gpkg_table_name} VALUES(1, 2, geometry::Point(985831.79200444, 203371.60461367, 2263));
                 insert into {ms_schema}.{test_write_gpkg_table_name} VALUES(3, 4, geometry::Point(985831.79200444, 203371.60461367, 2263));
                 """)
+        
+        assert sql.table_exists(schema = ms_schema, table = test_write_gpkg_table_name)
 
         # write geopackage file
         s = Geopackage(path = fp, gpkg_name=gpkg_name)
@@ -1183,8 +1185,8 @@ class TestGpkgShpConversion:
         assert os.path.isfile(os.path.join(fp, test_write_gpkg_table_name + '.shp'))
 
         # check that the shapefile and gpkg have the same output
-        cmd_gpkg = f'ogrinfo {gpkg_name} -sql "SELECT test_col1 FROM {test_write_gpkg_table_name} LIMIT 1" -q'
-        cmd_shp = f'ogrinfo {test_write_gpkg_table_name + ".shp"} -sql "SELECT test_col1 FROM {test_write_gpkg_table_name} LIMIT 1" -q'
+        cmd_gpkg = f'ogrinfo "{fp}/{gpkg_name}" -sql "SELECT test_col1 FROM {test_write_gpkg_table_name} LIMIT 1" -q'
+        cmd_shp = f'ogrinfo "{fp}/{test_write_gpkg_table_name}.shp" -sql "SELECT test_col1 FROM {test_write_gpkg_table_name} LIMIT 1" -q'
 
         ogr_response_gpkg = subprocess.check_output(shlex.split(cmd_gpkg), stderr=subprocess.STDOUT)
         ogr_response_shp = subprocess.check_output(shlex.split(cmd_shp), stderr=subprocess.STDOUT)
@@ -1195,10 +1197,12 @@ class TestGpkgShpConversion:
         os.remove(os.path.join(fp, gpkg_name))
         for ext in ('dbf', 'prj', 'shx', 'shp'):
             os.remove(os.path.join(fp, test_write_gpkg_table_name + '.' + ext))
+
+        sql.drop_table(schema = ms_schema, table = test_write_gpkg_table_name)
     
     def test_convert_gpkg_to_shp_custom_path(self):
 
-        fp = os.path.join(os.path.dirname(os.path.abspath(__file__)))+'\\test_data'
+        fp = os.path.join(os.path.dirname(os.path.abspath(__file__)))+'/test_data'
         gpkg_name = 'gpkg_to_shp.gpkg'
 
         # no shape file name needs to be specified because the table(s) within the gpkg are not necessarily named the same thing
@@ -1216,16 +1220,15 @@ class TestGpkgShpConversion:
 
         # Check table in folder
         assert os.path.isfile(os.path.join(fp, gpkg_name))
-        
         # run function to convert geopackage to shape file
-        s.gpkg_to_shp_bulk(export_path = fp )
-        
+        s.gpkg_to_shp_bulk(export_path = fp)
+ 
         # assert that a shape output file exists. It will not match the name of the geopackage because the tables inside the package canbe different
         assert os.path.isfile(os.path.join(fp , test_write_gpkg_table_name + '.shp'))
 
         # check that the shapefile and gpkg have the same output
-        cmd_gpkg = f'ogrinfo {gpkg_name} -sql "SELECT test_col1 FROM {test_write_gpkg_table_name} LIMIT 1" -q'
-        cmd_shp = f'ogrinfo { test_write_gpkg_table_name + ".shp"} -sql "SELECT test_col1 FROM {test_write_gpkg_table_name} LIMIT 1" -q'
+        cmd_gpkg = f'ogrinfo "{fp}/{gpkg_name}" -sql "SELECT test_col1 FROM {test_write_gpkg_table_name} LIMIT 1" -q'
+        cmd_shp = f'ogrinfo "{fp}/{test_write_gpkg_table_name}.shp" -sql "SELECT test_col1 FROM {test_write_gpkg_table_name} LIMIT 1" -q'
 
         ogr_response_gpkg = subprocess.check_output(shlex.split(cmd_gpkg), stderr=subprocess.STDOUT)
         ogr_response_shp = subprocess.check_output(shlex.split(cmd_shp), stderr=subprocess.STDOUT)
@@ -1237,9 +1240,11 @@ class TestGpkgShpConversion:
         for ext in ('dbf', 'prj', 'shx', 'shp'):
             os.remove(os.path.join(fp, test_write_gpkg_table_name + '.' + ext))
 
+        sql.drop_table(schema = ms_schema, table = test_write_gpkg_table_name)
+
     def test_convert_gpkg_to_shp_file_bulk(self):
 
-        fp = os.path.join(os.path.dirname(os.path.abspath(__file__))) + '\\test_data'
+        fp = os.path.join(os.path.dirname(os.path.abspath(__file__))) + '/test_data'
         gpkg_name = 'gpkg_to_shp.gpkg'
 
         # no shape file name needs to be specified because the table(s) within the gpkg are not necessarily named the same thing
@@ -1261,6 +1266,10 @@ class TestGpkgShpConversion:
                 insert into {ms_schema}.{test_write_gpkg_table_name}_2 VALUES(5, 6, geometry::Point(985830.79200444, 203371.60461367, 2263));
                 insert into {ms_schema}.{test_write_gpkg_table_name}_2 VALUES(7, 8, geometry::Point(985830.79200444, 203371.60461367, 2263));
                 """)
+        
+        assert sql.table_exists(schema = ms_schema, table = test_write_gpkg_table_name)
+        assert sql.table_exists(schema = ms_schema, table = f"{test_write_gpkg_table_name}_2")
+
         s = Geopackage(path = fp, gpkg_name=gpkg_name)
         s.write_gpkg(dbo=sql, schema = ms_schema, table = test_write_gpkg_table_name + '_2', print_cmd=True) # this will append 
 
@@ -1276,10 +1285,10 @@ class TestGpkgShpConversion:
         assert os.path.isfile(os.path.join(fp, test_write_gpkg_table_name + '_2.shp'))
 
         # check that the shapefile and gpkg have the same output
-        cmd_gpkg = f'ogrinfo {gpkg_name} -sql "SELECT test_col1 FROM {test_write_gpkg_table_name} LIMIT 1" -q'
-        cmd_shp = f'ogrinfo {test_write_gpkg_table_name + ".shp"} -sql "SELECT test_col1 FROM {test_write_gpkg_table_name} LIMIT 1" -q'
-        cmd_gpkg2 = f'ogrinfo {gpkg_name} -sql "SELECT test_col5 FROM {test_write_gpkg_table_name}_2 LIMIT 1" -q'
-        cmd_shp2 = f'ogrinfo {test_write_gpkg_table_name + "_2.shp"} -sql "SELECT test_col5 FROM {test_write_gpkg_table_name}_2 LIMIT 1" -q'
+        cmd_gpkg = f'ogrinfo "{fp}/{gpkg_name}" -sql "SELECT test_col1 FROM {test_write_gpkg_table_name} LIMIT 1" -q'
+        cmd_shp = f'ogrinfo "{fp}/{test_write_gpkg_table_name}.shp" -sql "SELECT test_col1 FROM {test_write_gpkg_table_name} LIMIT 1" -q'
+        cmd_gpkg2 = f'ogrinfo "{fp}/{gpkg_name}" -sql "SELECT test_col5 FROM {test_write_gpkg_table_name}_2 LIMIT 1" -q'
+        cmd_shp2 = f'ogrinfo "{fp}/{test_write_gpkg_table_name}_2.shp" -sql "SELECT test_col5 FROM {test_write_gpkg_table_name}_2 LIMIT 1" -q'
 
         ogr_response_gpkg = subprocess.check_output(shlex.split(cmd_gpkg), stderr=subprocess.STDOUT)
         ogr_response_shp = subprocess.check_output(shlex.split(cmd_shp), stderr=subprocess.STDOUT)
@@ -1296,28 +1305,43 @@ class TestGpkgShpConversion:
         sql.query(f"drop table if exists {ms_schema}.{test_write_gpkg_table_name}")
         sql.query(f"drop table if exists {ms_schema}.{test_write_gpkg_table_name}_2")
         for ext in ('dbf', 'prj', 'shx', 'shp'):
+            os.remove(os.path.join(fp, test_write_gpkg_table_name + '.' + ext))
             os.remove(os.path.join(fp, test_write_gpkg_table_name + '_2.' + ext))
 
-        # don't delete test_write_gpkg_table_name.shp as it will be used in the subsequent test
-
     def test_convert_shp_to_gpkg_file(self):
-        fp = os.path.join(os.path.dirname(os.path.abspath(__file__)))+'\\test_data'
+        fp = os.path.join(os.path.dirname(os.path.abspath(__file__)))+'/test_data'
         gpkg_name = 'gpkg_to_shp.gpkg'
-        shp_name = f'{test_write_gpkg_table_name}.shp'
+        shp_name = test_write_gpkg_table_name
 
-        # Check table in folder
-        assert os.path.isfile(os.path.join(fp, shp_name))
+        # create shapefile (we don't import Shapefile.py so we create a GPKG, convert to SHP, and then delete the GPKG)
+        sql.query(f"""drop table if exists {ms_schema}.{test_write_gpkg_table_name};
+                create table {ms_schema}.{test_write_gpkg_table_name} (test_col1 int, test_col2 int, geom geometry);
+                insert into {ms_schema}.{test_write_gpkg_table_name} VALUES(1, 2, geometry::Point(985831.79200444, 203371.60461367, 2263));
+                insert into {ms_schema}.{test_write_gpkg_table_name} VALUES(3, 4, geometry::Point(985831.79200444, 203371.60461367, 2263));
+                """)
+
+        # write geopackage file
+        s = Geopackage(path = fp, gpkg_name=gpkg_name)
+        s.write_gpkg(dbo=sql, table= test_write_gpkg_table_name, schema=ms_schema, print_cmd=True)
+        s.gpkg_to_shp(export_path = fp, gpkg_tbl = test_write_gpkg_table_name, print_cmd = True)
+
+        # drop SQL table and GPKG
+        sql.query(f"drop table if exists {ms_schema}.{test_write_gpkg_table_name}")
+        os.remove(os.path.join(fp, gpkg_name))
+
+        assert os.path.exists(os.path.join(fp, gpkg_name)) == False # confirm that the gpkg is removed
+        assert os.path.isfile(os.path.join(fp, shp_name + '.shp')) # confirm that the shp file exists
 
         # run function to convert Shapefile to GPKG
         s = Geopackage(path=fp, gpkg_name=gpkg_name)
-        s.shp_to_gpkg(gpkg_tbl = test_write_gpkg_table_name, shp_name = shp_name, print_cmd = True)
+        s.shp_to_gpkg(gpkg_tbl = test_write_gpkg_table_name, shp_name = shp_name + '.shp', print_cmd = True)
 
         # assert that the output file exists and that it matches the geopackage
         assert os.path.isfile(os.path.join(fp, gpkg_name))
 
         # assert that the data is the same
-        cmd_gpkg = f'ogrinfo {gpkg_name} -sql "SELECT test_col1 FROM {test_write_gpkg_table_name} LIMIT 1" -q'
-        cmd_shp = f'ogrinfo {shp_name} -sql "SELECT test_col1 FROM {test_write_gpkg_table_name} LIMIT 1" -q'
+        cmd_gpkg = f'ogrinfo "{fp}/{gpkg_name}" -sql "SELECT test_col1 FROM {test_write_gpkg_table_name} LIMIT 1" -q'
+        cmd_shp = f'ogrinfo "{fp}/{shp_name}.shp" -sql "SELECT test_col1 FROM {test_write_gpkg_table_name} LIMIT 1" -q'
 
         ogr_response_gpkg = subprocess.check_output(shlex.split(cmd_gpkg), stderr=subprocess.STDOUT)
         ogr_response_shp = subprocess.check_output(shlex.split(cmd_shp), stderr=subprocess.STDOUT)
@@ -1332,23 +1356,23 @@ class TestGpkgShpConversion:
         # copy the same shp file as an additional table in the gpkg
         # this test confirms that the update function for the gpkg is working correctly
 
-        fp = os.path.join(os.path.dirname(os.path.abspath(__file__)))+'\\test_data'
+        fp = os.path.join(os.path.dirname(os.path.abspath(__file__)))+'/test_data'
         gpkg_name = 'gpkg_to_shp.gpkg'
-        shp_name = f'{test_write_gpkg_table_name}.shp'
+        shp_name = test_write_gpkg_table_name
 
         # Check table in folder
-        assert os.path.isfile(os.path.join(fp, shp_name))
+        assert os.path.isfile(os.path.join(fp, shp_name) + '.shp')
 
         # run function to convert Shapefile to GPKG
         s = Geopackage(path=fp, gpkg_name=gpkg_name)
-        s.shp_to_gpkg(shp_name = shp_name, gpkg_tbl = f'{test_write_gpkg_table_name}_2')
+        s.shp_to_gpkg(shp_name = shp_name + '.shp', gpkg_tbl = f'{test_write_gpkg_table_name}_2')
 
         # assert that the output file exists and that it matches the geopackage
         assert os.path.isfile(os.path.join(fp, gpkg_name))
 
         # assert that the data is the same
-        cmd_gpkg = f'ogrinfo {gpkg_name} -sql "SELECT test_col1 FROM {test_write_gpkg_table_name}_2 LIMIT 1" -q'
-        cmd_shp = f'ogrinfo {shp_name} -sql "SELECT test_col1 FROM {test_write_gpkg_table_name} LIMIT 1" -q'
+        cmd_gpkg = f'ogrinfo "{fp}/{gpkg_name}" -sql "SELECT test_col1 FROM {test_write_gpkg_table_name}_2 LIMIT 1" -q'
+        cmd_shp = f'ogrinfo "{fp}/{shp_name}.shp" -sql "SELECT test_col1 FROM {test_write_gpkg_table_name} LIMIT 1" -q'
 
         ogr_response_gpkg_2 = subprocess.check_output(shlex.split(cmd_gpkg), stderr=subprocess.STDOUT)
         ogr_response_shp_2 = subprocess.check_output(shlex.split(cmd_shp), stderr=subprocess.STDOUT)
@@ -1357,10 +1381,10 @@ class TestGpkgShpConversion:
 
         # remove shape file
         for ext in ('.dbf', '.prj', '.shx', '.shp'):
-                try:
-                    os.remove(os.path.join(fp, shp_name.replace('.shp', ext)))
-                except Exception as e:
-                    print(e)
+            try:
+                os.remove(os.path.join(fp, shp_name + ext))
+            except Exception as e:
+                print(e)
 
         # remove gpkg output
         os.remove(os.path.join(fp, gpkg_name))
@@ -1368,4 +1392,3 @@ class TestGpkgShpConversion:
     @classmethod
     def teardown_class(cls):
         helpers.clean_up_geopackage()
-

--- a/pysqldb3/tests/test_table_to_gpkg.py
+++ b/pysqldb3/tests/test_table_to_gpkg.py
@@ -37,7 +37,7 @@ sql = pysqldb.DbConnect(type=config.get('SQL_DB', 'TYPE'),
 test_table = '__testing_query_to_gpkg_{}__'.format(db.user)
 ms_schema = 'risadmin'
 pg_schema = 'working'
-
+FOLDER_PATH = helpers.DIR
 
 class TestTableToGpkgPg:
     def test_table_to_gpkg_basic(self):
@@ -147,13 +147,13 @@ class TestTableToGpkgPg:
         db.table_to_gpkg(table = test_table, schema=pg_schema, gpkg_name=gpkg, path=fldr, print_cmd=True)
 
         # this should fail
-        cmd_gpkg = f'ogrinfo ./test_data/{gpkg} -sql "SELECT id FROM {test_table} LIMIT 1" -q'
-        ogr_response_gpkg = subprocess.check_output(shlex.split(cmd_gpkg), stderr=subprocess.STDOUT)
+        cmd_gpkg = f'ogrinfo {FOLDER_PATH}/{gpkg} -sql "SELECT id FROM {test_table} LIMIT 1" -q'
+        ogr_response_gpkg = subprocess.check_output(shlex.split(cmd_gpkg.replace('\\','/')), stderr=subprocess.STDOUT)
         assert 'ERROR' in str(ogr_response_gpkg), "table was not overwritten in the geopackage"
 
         # check that the overwritten table works
-        cmd_gpkg2 = f'ogrinfo ./test_data/{gpkg} -sql "SELECT id2 FROM {test_table} LIMIT 2" -q'
-        ogr_response_gpkg = subprocess.check_output(shlex.split(cmd_gpkg2), stderr=subprocess.STDOUT)
+        cmd_gpkg2 = f'ogrinfo {FOLDER_PATH}/{gpkg} -sql "SELECT id2 FROM {test_table} LIMIT 2" -q'
+        ogr_response_gpkg = subprocess.check_output(shlex.split(cmd_gpkg2.replace('\\','/')), stderr=subprocess.STDOUT)
         assert 'id2 (Integer) = 2' in str(ogr_response_gpkg), "table was not overwritten in the geopackage"
 
         # clean up
@@ -306,11 +306,11 @@ class TestTableTogpkgMs:
         assert os.path.isfile(os.path.join(fldr, gpkg))
 
         # check the number of tables within the geopackage
-        cmd_gpkg_1 = f'ogrinfo ./test_data/{gpkg} -sql "SELECT id FROM {test_table} LIMIT 1" -q '
-        cmd_gpkg_2 = f'ogrinfo ./test_data/{gpkg} -sql "SELECT id_test FROM {test_table}_2 LIMIT 1" -q'
+        cmd_gpkg_1 = f'ogrinfo {FOLDER_PATH}/{gpkg} -sql "SELECT id FROM {test_table} LIMIT 1" -q '
+        cmd_gpkg_2 = f'ogrinfo {FOLDER_PATH}/{gpkg} -sql "SELECT id_test FROM {test_table}_2 LIMIT 1" -q'
 
-        ogr_response_gpkg_1 = subprocess.check_output(shlex.split(cmd_gpkg_1), stderr=subprocess.STDOUT)
-        ogr_response_gpkg_2 = subprocess.check_output(shlex.split(cmd_gpkg_2), stderr=subprocess.STDOUT)
+        ogr_response_gpkg_1 = subprocess.check_output(shlex.split(cmd_gpkg_1.replace('\\','/')), stderr=subprocess.STDOUT)
+        ogr_response_gpkg_2 = subprocess.check_output(shlex.split(cmd_gpkg_2.replace('\\','/')), stderr=subprocess.STDOUT)
 
         assert 'id (Integer) = 1' in str(ogr_response_gpkg_1) and 'id_test (Integer) = 2' in str(ogr_response_gpkg_2), "Cannot find 2 tables in the same geopackage"
 
@@ -355,13 +355,13 @@ class TestTableTogpkgMs:
         assert os.path.isfile(os.path.join(fldr, gpkg))
 
         # this should fail
-        cmd_gpkg = f'ogrinfo ./test_data/{gpkg} -sql "SELECT id FROM {test_table} LIMIT 1" -q'
-        ogr_response_gpkg = subprocess.check_output(shlex.split(cmd_gpkg), stderr=subprocess.STDOUT)
+        cmd_gpkg = f'ogrinfo {FOLDER_PATH}/{gpkg} -sql "SELECT id FROM {test_table} LIMIT 1" -q'
+        ogr_response_gpkg = subprocess.check_output(shlex.split(cmd_gpkg.replace('\\','/')), stderr=subprocess.STDOUT)
         assert 'ERROR' in str(ogr_response_gpkg), "table was not overwritten in the geopackage"
 
         # check that the overwritten table works
-        cmd_gpkg2 = f'ogrinfo ./test_data/{gpkg} -sql "SELECT id3 FROM {test_table} LIMIT 1" -q'
-        ogr_response_gpkg = subprocess.check_output(shlex.split(cmd_gpkg2), stderr=subprocess.STDOUT)
+        cmd_gpkg2 = f'ogrinfo {FOLDER_PATH}/{gpkg} -sql "SELECT id3 FROM {test_table} LIMIT 1" -q'
+        ogr_response_gpkg = subprocess.check_output(shlex.split(cmd_gpkg2.replace('\\','/')), stderr=subprocess.STDOUT)
         assert 'id3 (Integer) = 3' in str(ogr_response_gpkg), "table was not overwritten in the geopackage"
 
         # clean up


### PR DESCRIPTION
Fixed issue related to changing the folder location of the test file from `pysqldb3/test` to `pysqldb3/test/test_data/`. Also changed one of the tests so that it wasn't reusing an output file from the previous test, and instead, the shp file was getting created in the test.
