### PR TITLE
Data io db to db transfer to temp table

### DIFF
--- a/pysqldb3/README.md
+++ b/pysqldb3/README.md
@@ -55,13 +55,21 @@ In Jupyter or Python shell, use help(pysqldb) to show all public functions and t
 
 #### Data IO functions:
 1. [`pg_to_sql`](#pg_to_sql): Convert PG table to a SQL table
+1. [`pg_to_sql_temp_tbl`](#pg_to_sql_temp_tbl): Convert PG table to a SQL temporary table
 1. [`pg_to_sql_qry`](#pg_to_sql_qry): Convert the output of a PG query to a SQL table
-1. [`sql_to_pg`](#pg_to_sql): Convert SQL table to a PG table
+1. [`pg_to_sql_qry_temp_tbl`](#pg_to_sql_qry_temp_tbl): Convert the output of a PG query to a SQL temporary table
+1. [`sql_to_pg`](#sql_to_pg): Convert SQL table to a PG table
+1. [`sql_to_pg_temp_tbl`](#sql_to_pg_temp_tbl): Convert SQL table to a PG temporary table
 1. [`sql_to_pg_qry`](#sql_to_pg_qry): Convert the output of a SQL query to a PG table
+1. [`sql_to_pg_qry_temp_tbl`](#sql_to_pg_qry_temp_tbl): Convert the output of a SQL query to a PG temporary table
 1. [`sql_to_sql`](#sql_to_sql): Copy a SQL table to a different SQL database or schema
+1. [`sql_to_sql_temp_tbl`](#sql_to_sql_temp_tbl): Copy a SQL table to a different SQL database or schema to temporary table
 1. [`sql_to_sql_qry`](#sql_to_sql_qry): Copy an output table from a SQL query to a different SQL database or schema
+1. [`sql_to_sql_qry_temp_tbl`](#sql_to_sql_qry_temp_tbl): Copy an output table from a SQL query to a different SQL database or schema to temporary table
 1. [`pg_to_pg`](#pg_to_pg): Copy a PG table to a different PG database or schema
+1. [`pg_to_pg_temp_tbl`](#pg_to_pg_temp_tbl): Copy a PG table to a different PG database or schema to temporary table
 1. [`pg_to_pg_qry`](#pg_to_pg_qry): Copy an output table from a PG query to a different PG database or schema
+1. [`pg_to_pg_qry_temp_tbl`](#pg_to_pg_qry_temp_tbl): Copy an output table from a PG query to a different PG database or schema to temporary table
 
 #### Geopackage functions:
 1. [`list_gpkg_tables`](#list_gpkg_tables): View a list of all the tables in the Geopackage file to help isolate tables of interest
@@ -1265,6 +1273,33 @@ b'0...10...20...30...40...50...60...70...80...90...100 - done.\r\n'
 [Back to Table of Contents](#data-io-functions)
 <br>
 
+### pg_to_sql_temp_tbl
+**`data_io.pg_to_sql_temp_tbl(pg, ms, org_table, org_schema=None, dest_table=None, print_cmd=False)`**
+
+Copy a table from a PG database to a temp table in a database in SQL, uses `##` for global temp table 
+
+###### Parameters:
+- **`pg` obj**:  PG database connection
+- **`ms` obj**:  SQL database connection
+- **`org_table` str**: PG table to be copied to SQL
+- **`org_schema` str, default None**:  Database schema for the "origin" PG table
+- **`dest_table` str, default None**: Name of the copied SQL table. If set to None, it will default to the original PG table name
+- **`print_cmd` str, default False**: Option to print ogr command (without password)
+
+**Sample**
+
+```
+>>> from pysqldb3 import pysqldb3, data_io
+>>> db = pysqldb3.DbConnect(type='pg', server=server_address, database='ris', user='user_name', password='*******')
+>>> ms = pysqldb3.DbConnect(type='ms', server=server_address, database='STREETASSESSMENT', user='user_name', password='*******')
+>>> data_io.pg_to_sql_temp_tbl(db, ms, org_table = 'large_pg_table', org_schema = 'working', dest_table = 'large_sql_table')
+
+b'0...10...20...30...40...50...60...70...80...90...100 - done.\r\n'
+```
+
+[Back to Table of Contents](#data-io-functions)
+<br>
+
 
 ### pg_to_sql_qry
 **`data_io.pg_to_sql_qry(pg, ms, query, LDAP = False, spatial = True, dest_schema = None, dest_table = None,
@@ -1290,6 +1325,33 @@ Copy the table output of a query from a PG database to a database in SQL
 >>> db = pysqldb3.DbConnect(type='pg', server=server_address, database='ris', user='user_name', password='*******')
 >>> ms = pysqldb3.DbConnect(type='ms', server=server_address, database='StreetAssessment', user='user_name', password='*******')
 >>> data_io.pg_to_sql_qry(db, ms, query = "select * from test_new_crashes where id = 10283", dest_schema = 'dbo', dest_table = 'test_new_crashes')
+
+b'0...10...20...30...40...50...60...70...80...90...100 - done.\r\n'
+```
+
+[Back to Table of Contents](#data-io-functions)
+<br>
+
+
+### pg_to_sql_qry_temp_tbl
+**`data_io.pg_to_sql_qry_temp_tbl(pg, ms, query, dest_table = None, print_cmd = False)`**
+
+Copy the table output of a query from a PG database to a temp table in a database in SQL, uses `##` for global temp table 
+
+###### Parameters:
+- **`pg` obj**:  PG database connection
+- **`ms` obj**:  SQL database connection
+- **`query` str**:  PG query that generates a table output
+- **`dest_table` str, default None**: Name of the copied SQL table. If set to None, it will default to the original PG table name
+- **`print_cmd` str, default False**: Option to print ogr command (without password)
+
+**Sample**
+
+```
+>>> from pysqldb3 import pysqldb3, data_io
+>>> db = pysqldb3.DbConnect(type='pg', server=server_address, database='ris', user='user_name', password='*******')
+>>> ms = pysqldb3.DbConnect(type='ms', server=server_address, database='StreetAssessment', user='user_name', password='*******')
+>>> data_io.pg_to_sql_qry_temp_tbl(db, ms, query = "select * from test_new_crashes where id = 10283", dest_table = 'test_new_crashes')
 
 b'0...10...20...30...40...50...60...70...80...90...100 - done.\r\n'
 ```
@@ -1332,6 +1394,33 @@ b'0...10...20...30...40...50...60...70...80...90...100 - done.\r\n'
 [Back to Table of Contents](#data-io-functions)
 <br>
 
+### sql_to_pg_temp_tbl
+**`data_io.sql_to_pg_temp_tbl(ms, pg, org_table, org_schema=None, print_cmd=False, dest_table=None)`**
+ 
+Copy a table from a SQL database to a temp table in a PG database
+
+##### Parameters:
+- **`ms` obj**:  SQL database connection
+- **`pg` obj**:  PG database connection
+- **`org_table` str**: SQL table to be copied into PG
+- **`org_schema` str, default None**:  Database schema for the "origin" SQL table
+- **`print_cmd` str, default False**: Option to print ogr command (without password)
+- **`dest_table` str, default None**: Name of the copied PG table. If set to None, it will default to the original SQL table name
+
+**Sample**
+
+```
+>>> from pysqldb3 import pysqldb3, data_io
+>>> ms = pysqldb3.DbConnect(type='ms', server=server_address, database='StreetAssessment', user='user_name', password='*******')
+>>> db = pysqldb3.DbConnect(type='pg', server=server_address, database='ris', user='user_name', password='*******')
+>>> data_io.sql_to_pg_temp_tbl(ms, pg, org_schema = 'dbo', org_table = 'test_table_cchen1', dest_table = 'test_table_cchen2')
+
+b'0...10...20...30...40...50...60...70...80...90...100 - done.\r\n'
+```
+
+[Back to Table of Contents](#data-io-functions)
+<br>
+
 ### sql_to_pg_qry
 **`data_io.sql_to_pg_qry(ms, pg, query, LDAP=False, spatial=True, dest_schema=None, print_cmd=False, temp=True,
                   dest_table=None, pg_encoding='UTF8', permission = True)`**`**
@@ -1360,6 +1449,31 @@ Copy the table output of a query from a SQL database to a database in PG
 >>> ms = pysqldb3.DbConnect(type='ms', server=server_address, database='StreetAssessment', user='user_name', password='*******')
 >>> db = pysqldb3.DbConnect(type='pg', server=server_address, database='ris', user='user_name', password='*******')
 >>> data_io.sql_to_pg_qry(ms, pg, query = "select * from [dbo].[test_table_cchen1] where id_num > 50", dest_schema = 'working', dest_table = 'test_table_cchen2')
+
+b'0...10...20...30...40...50...60...70...80...90...100 - done.\r\n'
+```
+
+[Back to Table of Contents](#data-io-functions)
+<br>
+### sql_to_pg_qry_temp_tbl
+**`data_io.sql_to_pg_qry_temp_tbl(ms, pg, query, print_cmd=False, dest_table=None)`**`**
+
+Copy the table output of a query from a SQL database to a temp table in a PG database
+
+###### Parameters:
+- **`ms` obj**:  SQL database connection
+- **`pg` obj**:  PG database connection
+- **`query` str**:  SQL query that generates a table output
+- - **`print_cmd` str, default False**: Option to print ogr command (without password)
+- **`dest_table` str, default None**: Name of the copied PG table. If set to None, it will default to the original SQL table name
+
+**Sample**
+
+```
+>>> from pysqldb3 import pysqldb3, data_io
+>>> ms = pysqldb3.DbConnect(type='ms', server=server_address, database='StreetAssessment', user='user_name', password='*******')
+>>> db = pysqldb3.DbConnect(type='pg', server=server_address, database='ris', user='user_name', password='*******')
+>>> data_io.sql_to_pg_qry_temp_tbl(ms, pg, query = "select * from [dbo].[test_table_cchen1] where id_num > 50", dest_table = 'test_table_cchen2')
 
 b'0...10...20...30...40...50...60...70...80...90...100 - done.\r\n'
 ```
@@ -1395,6 +1509,34 @@ Copy a table from one SQL database/schema to another SQL database/schema
 >>> ms1 = pysqldb3.DbConnect(type='ms', server=server_address, database='RISCRASHDATA', user='user_name', password='*******')
 >>> ms2 = pysqldb3.DbConnect(type='ms', server=server_address, database='STREETASSESSMENT', user='user_name', password='*******')
 >>> data_io.sql_to_sql(ms1, ms2, org_schema = 'dbo', org_table = 'test_table_cchen1', dest_schema = 'rb1', dest_table = 'test_table_cchen1', spatial = False)
+
+b'0...10...20...30...40...50...60...70...80...90...100 - done.\r\n'
+```
+
+
+[Back to Table of Contents](#data-io-functions)
+<br>
+### sql_to_sql
+**`data_io.sql_to_sql_temp_tbl(from_sql, to_sql, org_table, LDAP_from=False, org_schema=None, print_cmd=False, dest_table=None)`**
+
+Copy a table from one SQL database/schema to a temporary table in another SQL database/schema, uses `##` global temp table
+
+###### Parameters:
+- **`from_ms` obj**:  SQL database connection of the original table
+- **`to_ms` obj**:  PG database connection for the copied table
+- **`org_table` str**: SQL table to be copied
+- **`LDAP_from`: bool, default False**: When true will use windows login for database connection
+- **`org_schema` str, default None**:  Database schema for the "origin" SQL table
+- **`dest_table` str, default None**: Name of the copied SQL table. If set to None, it will default to the original SQL table name
+- **`print_cmd` str, default False**: Option to print ogr command (without password)
+
+**Sample**
+
+```
+>>> from pysqldb3 import pysqldb3, data_io
+>>> ms1 = pysqldb3.DbConnect(type='ms', server=server_address, database='RISCRASHDATA', user='user_name', password='*******')
+>>> ms2 = pysqldb3.DbConnect(type='ms', server=server_address, database='STREETASSESSMENT', user='user_name', password='*******')
+>>> data_io.sql_to_sql_temp_tbl(ms1, ms2, org_schema = 'dbo', org_table = 'test_table_cchen1', dest_table = 'test_table_cchen1')
 
 b'0...10...20...30...40...50...60...70...80...90...100 - done.\r\n'
 ```
@@ -1438,6 +1580,34 @@ b'0...10...20...30...40...50...60...70...80...90...100 - done.\r\n'
 [Back to Table of Contents](#data-io-functions)
 <br>
 
+### sql_to_sql_qry_temp_tbl
+**`data_io.sql_to_sql_qry_temp_tbl(from_sql, to_sql, qry, LDAP_from=False, org_schema=None, dest_table=None,
+                   print_cmd=False, dest_table=None)`**
+
+Copy a table from one SQL database/schema to a temporary table in another SQL database/schema, uses `##` global temp
+
+###### Parameters:
+- **`from_sql` obj**: SQL database connection of the query
+- **`to_sql` obj**:  SQL database connection for the copied table
+- **`qry` str**: SQL query that generates a table output
+- **`LDAP_from`: bool, default False**: When true will use windows login for database connection
+- **`dest_table` str, default None**: Name of the copied SQL table. If set to None, it will default to the original SQL table name
+
+
+**Sample**
+
+```
+>>> from pysqldb3 import pysqldb3, data_io
+>>> ms1 = pysqldb3.DbConnect(type='ms', server=server_address, database='RISCRASHDATA', user='user_name', password='*******')
+>>> ms2 = pysqldb3.DbConnect(type='ms', server=server_address, database='STREETASSESSMENT', user='user_name', password='*******')
+>>> data_io.sql_to_sql_qry_temp_tbl(ms1, m2, query = "select top (10) * from [dbo].[test_table_cchdn1] where id = 1", dest_table = 'test_table_cchen1')
+
+b'0...10...20...30...40...50...60...70...80...90...100 - done.\r\n'
+```
+
+[Back to Table of Contents](#data-io-functions)
+<br>
+
 
 ### pg_to_pg
 **`data_io.pg_to_pg(from_pg, to_pg, org_table, org_schema=None, dest_schema=None, print_cmd=False, dest_table=None,
@@ -1471,6 +1641,33 @@ b'0...10...20...30...40...50...60...70...80...90...100 - done.\r\n'
 [Back to Table of Contents](#data-io-functions)
 <br>
 
+### pg_to_pg
+**`data_io.pg_to_pg_temp_tbl(from_pg, to_pg, org_table, org_schema=None, print_cmd=False, dest_table=None)`**
+
+Copy a table from one PG database/schema to a temporary tabble in another PG database/schema
+
+###### Parameters:
+- **`from_pg` obj**: PG database connection of the original table
+- **`to_pg` obj**:  PG database connection for the copied table
+- **`org_table` str, default None**:  PG table to be copied
+- **`org_schema` str, default None**:  Database schema for the "origin" PG table
+- **`print_cmd` str, default False**: Option to print ogr command (without password)
+- **`dest_table` str, default None**: Name of the copied PG table. If set to None, it will default to the original PG table name
+
+**Sample**
+
+```
+>>> from pysqldb3 import pysqldb3, data_io
+>>> db = pysqldb3.DbConnect(type='pg', server=server_address, database='ris', user='user_name', password='*******')
+>>> db2 = pysqldb3.DbConnect(type='pg', server=server_address, database='ris3', user='user_name', password='*******')
+>>> data_io.pg_to_pg_temp_tbl(db, db2, org_schema = 'public', org_table = 'wc_accident_f', dest_table = 'crashes_from_ris')
+
+b'0...10...20...30...40...50...60...70...80...90...100 - done.\r\n'
+```
+
+[Back to Table of Contents](#data-io-functions)
+<br>
+
 ### pg_to_pg_qry
 **`data_io.pg_to_pg_qry(from_pg, to_pg, query, dest_schema=None, print_cmd=False, dest_table=None,
              spatial=True, temp=True, permission = True)`**
@@ -1495,6 +1692,32 @@ Copy the output table from a query in one PG database/schema to another PG datab
 >>> db = pysqldb3.DbConnect(type='pg', server=server_address, database='ris', user='user_name', password='*******')
 >>> db2 = pysqldb3.DbConnect(type='pg', server=server_address, database='ris3', user='user_name', password='*******')
 >>> data_io.pg_to_pg_qry(db, db2, query = "select id, boro from working.cindys_boros limit 5", dest_schema = 'working', dest_table = 'crashes_from_ris')
+
+b'0...10...20...30...40...50...60...70...80...90...100 - done.\r\n'
+```
+
+[Back to Table of Contents](#data-io-functions)
+<br>
+
+### pg_to_pg_qry
+**`data_io.pg_to_pg_qry_temp_tbl(from_pg, to_pg, query, print_cmd=False, dest_table=None)`**
+
+Copy the output table from a query in one PG database/schema to a temporary table in another PG database/schema
+
+###### Parameters:
+- **`from_pg` obj**: PG database connection of the original table
+- **`to_pg` obj**:  PG database connection for the copied table
+- **`query` str**: PG query that generates a table output
+- **`print_cmd` str, default False**: Option to print ogr command (without password)
+- **`dest_table` str, default None**: Name of the copied PG table. If set to None, it will default to the original PG table name
+
+**Sample**
+
+```
+>>> from pysqldb3 import pysqldb3, data_io
+>>> db = pysqldb3.DbConnect(type='pg', server=server_address, database='ris', user='user_name', password='*******')
+>>> db2 = pysqldb3.DbConnect(type='pg', server=server_address, database='ris3', user='user_name', password='*******')
+>>> data_io.pg_to_pg_qry_temp_tbl(db, db2, query = "select id, boro from working.cindys_boros limit 5", dest_table = 'crashes_from_ris')
 
 b'0...10...20...30...40...50...60...70...80...90...100 - done.\r\n'
 ```

--- a/pysqldb3/README.md
+++ b/pysqldb3/README.md
@@ -1516,7 +1516,7 @@ b'0...10...20...30...40...50...60...70...80...90...100 - done.\r\n'
 
 [Back to Table of Contents](#data-io-functions)
 <br>
-### sql_to_sql
+### sql_to_sql_temp_table
 **`data_io.sql_to_sql_temp_tbl(from_sql, to_sql, org_table, LDAP_from=False, org_schema=None, print_cmd=False, dest_table=None)`**
 
 Copy a table from one SQL database/schema to a temporary table in another SQL database/schema, uses `##` global temp table
@@ -1641,7 +1641,7 @@ b'0...10...20...30...40...50...60...70...80...90...100 - done.\r\n'
 [Back to Table of Contents](#data-io-functions)
 <br>
 
-### pg_to_pg
+### pg_to_pg_temp_tbl
 **`data_io.pg_to_pg_temp_tbl(from_pg, to_pg, org_table, org_schema=None, print_cmd=False, dest_table=None)`**
 
 Copy a table from one PG database/schema to a temporary tabble in another PG database/schema
@@ -1699,7 +1699,7 @@ b'0...10...20...30...40...50...60...70...80...90...100 - done.\r\n'
 [Back to Table of Contents](#data-io-functions)
 <br>
 
-### pg_to_pg_qry
+### pg_to_pg_qry_temp_tbl
 **`data_io.pg_to_pg_qry_temp_tbl(from_pg, to_pg, query, print_cmd=False, dest_table=None)`**
 
 Copy the output table from a query in one PG database/schema to a temporary table in another PG database/schema

--- a/pysqldb3/cmds.py
+++ b/pysqldb3/cmds.py
@@ -188,3 +188,11 @@ dbname={to_pg_database} user={to_pg_user} password={to_pg_pass}" PG:"host={from_
 dbname={from_pg_database}  user={from_pg_user} password={from_pg_pass}"  -sql "{sql_select}"
 -lco OVERWRITE=yes -nln {to_pg_schema}.{to_pg_name} {nlt_spatial} -progress
 """.replace('\n', ' ')
+
+PG_TO_CSV_CMD = """
+ogr2ogr --config GDAL_DATA "{gdal_data}"
+-f CSV "{output_csv}" 
+PG:"host={from_pg_host} port={from_pg_port} dbname={from_pg_database} user={from_pg_user} password={from_pg_pass}" 
+-sql "{sql_select}"
+-lco GEOMETRY=AS_WKT
+""".replace('\n', ' ')

--- a/pysqldb3/cmds.py
+++ b/pysqldb3/cmds.py
@@ -196,3 +196,12 @@ PG:"host={from_pg_host} port={from_pg_port} dbname={from_pg_database} user={from
 -sql "{sql_select}"
 -lco GEOMETRY=AS_WKT
 """.replace('\n', ' ')
+
+SQL_TO_CSV_CMD = """
+ogr2ogr --config GDAL_DATA "{gdal_data}"
+--config MSSQLSPATIAL_USE_GEOMETRY_COLUMNS NO 
+-f CSV "{output_csv}" 
+"MSSQL:server={from_server};database={from_database};UID={from_user};PWD={from_pass}" "MSSQLSpatial"
+-sql "{sql_select}" 
+-lco GEOMETRY=AS_WKT
+""".replace('\n', ' ')

--- a/pysqldb3/data_io.py
+++ b/pysqldb3/data_io.py
@@ -7,6 +7,7 @@ import pysqldb3
 from .cmds import *
 from .util import *
 
+# TODO: standardize this into db to db (table, query, temp table) DRY up code and simplify
 
 # PG to SQL ##########################################################################################################
 def pg_to_sql(pg, ms, org_table, LDAP=False, spatial=True, org_schema=None, dest_schema=None, dest_table=None,

--- a/pysqldb3/data_io.py
+++ b/pysqldb3/data_io.py
@@ -131,7 +131,7 @@ def pg_to_sql_qry(pg, ms, query, LDAP=False, spatial=True, dest_schema=None, des
     # apply regex to the query to filter out any dashed comments in the query
     # comments are defined by at least 2 dashes followed by a line break or the end of the query
     # comments with /* */ do not need to be filtered out from the query
-    query = re.sub('(-){2,}.*(\n|$)', '', query)
+    query = re.sub('(-){2,}.*(\n|$)', ' ', query)
 
     if LDAP:
         cmd = PG_TO_SQL_QRY_CMD.format(
@@ -203,7 +203,7 @@ def pg_to_sql_qry_temp_tbl(pg, ms, query, dest_table=None, print_cmd=False):
     # apply regex to the query to filter out any dashed comments in the query
     # comments are defined by at least 2 dashes followed by a line break or the end of the query
     # comments with /* */ do not need to be filtered out from the query
-    query = re.sub('(-){2,}.*(\n|$)', '', query)
+    query = re.sub('(-){2,}.*(\n|$)', ' ', query)
 
     # write data to local csv
     temp_csv = r'C:\Users\{}\Documents\temp_csv_{}.csv'.format(getpass.getuser(), datetime.datetime.now().strftime('%Y%m%d%H%M%S'))
@@ -301,7 +301,7 @@ def sql_to_pg_qry(ms, pg, query, LDAP=False, spatial=True, dest_schema=None, pri
     # apply regex to the query to filter out any dashed comments in the query
     # comments are defined by at least 2 dashes followed by a line break or the end of the query
     # comments with /* */ do not need to be filtered out from the query
-    query = re.sub('(-){2,}.*(\n|$)', '', query)
+    query = re.sub('(-){2,}.*(\n|$)', ' ', query)
 
     if LDAP:
         cmd = SQL_TO_PG_LDAP_QRY_CMD.format(
@@ -488,7 +488,7 @@ def sql_to_pg_qry_temp_tbl(ms, pg, query, dest_table=None, LDAP_from=False, prin
     # apply regex to the query to filter out any dashed comments in the query
     # comments are defined by at least 2 dashes followed by a line break or the end of the query
     # comments with /* */ do not need to be filtered out from the query
-    query = re.sub('(-){2,}.*(\n|$)', '', query)
+    query = re.sub('(-){2,}.*(\n|$)', ' ', query)
 
     # write data to local csv
     temp_csv = r'C:\Users\{}\Documents\temp_csv_{}.csv'.format(
@@ -721,7 +721,7 @@ def sql_to_sql_qry_temp_tbl(from_sql, to_sql, query, dest_table=None, LDAP_from=
     # apply regex to the query to filter out any dashed comments in the query
     # comments are defined by at least 2 dashes followed by a line break or the end of the query
     # comments with /* */ do not need to be filtered out from the query
-    query = re.sub('(-){2,}.*(\n|$)', '', query)
+    query = re.sub('(-){2,}.*(\n|$)', ' ', query)
 
     # write data to local csv
     temp_csv = r'C:\Users\{}\Documents\temp_csv_{}.csv'.format(getpass.getuser(), datetime.datetime.now().strftime('%Y%m%d%H%M%S'))
@@ -894,7 +894,7 @@ def pg_to_pg_qry(from_pg, to_pg, query, dest_schema=None, print_cmd=False, dest_
     # apply regex to the query to filter out any dashed comments in the query
     # comments are defined by at least 2 dashes followed by a line break or the end of the query
     # comments with /* */ do not need to be filtered out from the query
-    query = re.sub('(-){2,}.*(\n|$)', '', query)
+    query = re.sub('(-){2,}.*(\n|$)', ' ', query)
 
     cmd = PG_TO_PG_QRY_CMD.format(
         from_pg_host=from_pg.server,
@@ -955,7 +955,7 @@ def pg_to_pg_qry_temp_tbl(from_pg, to_pg, query, dest_table=None, print_cmd=Fals
     # apply regex to the query to filter out any dashed comments in the query
     # comments are defined by at least 2 dashes followed by a line break or the end of the query
     # comments with /* */ do not need to be filtered out from the query
-    query = re.sub('(-){2,}.*(\n|$)', '', query)
+    query = re.sub('(-){2,}.*(\n|$)', ' ', query)
 
     # write data to local csv
     temp_csv = r'C:\Users\{}\Documents\temp_csv_{}.csv'.format(getpass.getuser(), datetime.datetime.now().strftime('%Y%m%d%H%M%S'))

--- a/pysqldb3/pysqldb3.py
+++ b/pysqldb3/pysqldb3.py
@@ -1102,7 +1102,7 @@ class DbConnect:
         if not table:
             table = os.path.basename(input_file).split('.')[0]
 
-        if not overwrite and self.table_exists(schema=schema, table=table):
+        if not overwrite and self.table_exists(schema=schema, table=table) and not temp_table:
             print('Must set overwrite=True; table already exists.')
             return
 

--- a/pysqldb3/tests/test_io.py
+++ b/pysqldb3/tests/test_io.py
@@ -20,10 +20,11 @@ db = pysqldb.DbConnect(type=config.get('PG_DB', 'TYPE'),
 
 # should be RIS DB as the second database in db_config
 ris = pysqldb.DbConnect(type=config.get('SECOND_PG_DB', 'TYPE'),
-                            server=config.get('SECOND_PG_DB', 'SERVER'),
-                            database=config.get('SECOND_PG_DB', 'DB_NAME'),
-                            user=config.get('SECOND_PG_DB', 'DB_USER'),
-                            password=config.get('SECOND_PG_DB', 'DB_PASSWORD'))
+                        server=config.get('SECOND_PG_DB', 'SERVER'),
+                        database=config.get('SECOND_PG_DB', 'DB_NAME'),
+                        user=config.get('SECOND_PG_DB', 'DB_USER'),
+                        password=config.get('SECOND_PG_DB', 'DB_PASSWORD'),
+                        allow_temp_tables=True)
 
 sql = pysqldb.DbConnect(type=config.get('SQL_DB', 'TYPE'),
                         server=config.get('SQL_DB', 'SERVER'),
@@ -57,7 +58,7 @@ test_dest_schema = 'dbo'
 test_sql_to_sql_tbl_to = f'tst_sql_to_sql_to_tbl_{db.user}'
 test_sql_to_sql_tbl_from = f'tst_sql_to_sql_from_tbl_{db.user}'
 
-
+# PG to SQL ##########################################################################################################
 class TestPgToSql:
     @classmethod
     def setup_class(cls):
@@ -239,180 +240,7 @@ class TestPgToSql:
         helpers.clean_up_test_table_sql(sql)
 
 
-class TestPgToSqlTemp:
-    @classmethod
-    def setup_class(cls):
-        helpers.set_up_test_table_pg(db)
-
-    def test_pg_to_sql_basic(self):
-
-        """
-        Copy an existing Postgres table to MS SQL Server, maintaining the name of the original table
-        """
-
-        # assert that output tables are droped
-        sql.query(f"""
-                    IF OBJECT_ID(N'tempdb..##{test_pg_to_sql_table}', N'U') IS NOT NULL
-                    DROP TABLE ##{test_pg_to_sql_table};
-                """)
-        db.drop_table(schema=pg_schema, table=test_pg_to_sql_table)
-        assert not db.table_exists(schema=pg_schema, table=test_pg_to_sql_table)
-
-        # create table in pg
-        db.query(f"""
-        create table {pg_schema}.{test_pg_to_sql_table} as
-
-        select *
-        from {pg_schema}.{pg_table_name}
-        limit 10
-        """)
-
-        # Assert table created correctly
-        assert db.table_exists(table=test_pg_to_sql_table, schema=pg_schema)
-
-        # Run pg_to_sql
-        data_io.pg_to_sql_temp_tbl(db, sql, test_pg_to_sql_table, org_schema=pg_schema)
-
-        # Assert df equality -- some types need to be coerced from the Pandas df for the equality assertion to hold
-
-        pg_df = db.dfquery(f"""
-        select *
-        from {pg_schema}.{test_pg_to_sql_table}
-        order by id
-        """).infer_objects()
-
-        sql_df = sql.dfquery(f"""
-        select *
-        from ##{test_pg_to_sql_table}
-        order by id
-        """).infer_objects()
-
-        # Assert that data columns are equal
-        shared_non_geom_cols = list(set(pg_df.columns).intersection(set(sql_df.columns)) - {'geom'})
-
-        pd.testing.assert_frame_equal(pg_df[shared_non_geom_cols], sql_df[shared_non_geom_cols],
-                                      check_dtype=False,
-                                      check_exact=False,
-                                      check_datetimelike_compat=True)
-
-        # Clean up
-        db.drop_table(table=test_pg_to_sql_table, schema=pg_schema)
-
-    def test_pg_to_sql_naming(self):
-
-        """
-        Copy an existing Postgres table to MS SQL Server, and change the name of the copied table.
-        """
-
-        # assert that output tables are not created
-        dest_name = f'another_tst_name_{db.user}'
-        sql.query(f"""
-           IF OBJECT_ID(N'tempdb..##{dest_name}', N'U') IS NOT NULL
-           DROP TABLE ##{dest_name};
-       """)
-        db.drop_table(schema=pg_schema, table=test_pg_to_sql_table)
-        assert not db.table_exists(schema=pg_schema, table=test_pg_to_sql_table)
-
-
-        # create table in pg
-        db.query(f"""
-           drop table if exists {pg_schema}.{test_pg_to_sql_table};
-           create table {pg_schema}.{test_pg_to_sql_table} as
-            select *
-            from {pg_schema}.{pg_table_name}
-            limit 10
-        """)
-
-        # Assert table created correctly
-        assert db.table_exists(table=test_pg_to_sql_table, schema=pg_schema)
-
-        # Run pg_to_sql
-        data_io.pg_to_sql_temp_tbl(db, sql, test_pg_to_sql_table, org_schema=pg_schema, dest_table=dest_name)
-
-        # Assert df equality -- some types need to be coerced from the Pandas df for the equality assertion to hold
-        pg_df = db.dfquery(f"""
-                select *
-                from {pg_schema}.{test_pg_to_sql_table}
-                order by id
-        """).infer_objects()
-
-        sql_df = sql.dfquery(f"""
-                select * 
-                from ##{dest_name}
-                order by id
-                """).infer_objects()
-
-        # Assert that tables are the same
-        shared_non_geom_cols = list(set(pg_df.columns).intersection(set(sql_df.columns)) - {'geom'})
-        pd.testing.assert_frame_equal(pg_df[shared_non_geom_cols], sql_df[shared_non_geom_cols],
-                                      check_dtype=False,
-                                      check_exact=False,
-                                      check_datetimelike_compat=True)
-
-        # Clean up
-        db.drop_table(table=test_pg_to_sql_table, schema=pg_schema)
-
-    def test_pg_to_sql_spatial_table(self):
-        """
-        Copy a table with spatial data in Postgres to MS SQL Server.
-        """
-
-        # assert that output tables dropped
-        sql.drop_table(schema=sql.default_schema, table=test_pg_to_sql_table)
-        db.drop_table(table=test_pg_to_sql_table, schema=pg_schema)
-        assert not sql.table_exists(schema=sql.default_schema, table=test_pg_to_sql_table)
-        assert not db.table_exists(table=test_pg_to_sql_table, schema=pg_schema)
-
-        # create table in pg
-        db.query(f"""
-           drop table if exists {pg_schema}.{test_pg_to_sql_table};
-           create table {pg_schema}.{test_pg_to_sql_table} as
-
-           select 'hello' as c, st_transform(geom, 4326) as geom
-           from {pg_schema}.{pg_table_name}
-           limit 10
-        """)
-
-        # Assert table created correctly
-        assert db.table_exists(table=test_pg_to_sql_table, schema=pg_schema)
-
-        # Assert neither table in SQL Server yet
-        assert not sql.table_exists(table=test_pg_to_sql_table)
-
-        # run pg_to_sql, with different spatial flags
-        data_io.pg_to_sql(db, sql, org_table=test_pg_to_sql_table, org_schema=pg_schema, dest_table=test_pg_to_sql_table, spatial=True,
-                          print_cmd=True)
-
-        # Assert move worked and output tables were created
-        assert sql.table_exists(table=test_pg_to_sql_table)
-
-        # assert that the SQL dataframes are the same
-        spatial_df = sql.dfquery(f"""
-        select c, geom.STX test_lat, geom.STY test_long
-        from {test_pg_to_sql_table}
-        """).infer_objects()
-
-        # Assert df equality -- some types need to be coerced from the Pandas df for the equality assertion to hold
-        pg_df = db.dfquery(f"""
-        select c, ST_X(geom) test_lat, ST_Y(geom) test_long
-        from {pg_schema}.{test_pg_to_sql_table}
-        """).infer_objects()
-
-        pd.testing.assert_frame_equal(pg_df, spatial_df,
-                                      check_dtype=False,
-                                      check_exact=False,
-                                      check_datetimelike_compat=True)
-
-        # Clean up
-        sql.drop_table(schema=sql.default_schema, table=test_pg_to_sql_table)
-        db.drop_table(table=test_pg_to_sql_table, schema=pg_schema)
-
-    @classmethod
-    def teardown_class(cls):
-        helpers.clean_up_test_table_pg(db)
-
-
-class TestPgtoSqlQry:
+class TestPgToSqlQry:
 
     @classmethod
     def setup_class(cls):
@@ -587,7 +415,180 @@ class TestPgtoSqlQry:
         helpers.clean_up_test_table_sql(sql)
 
 
-class TestPgtoSqlQryTemp:
+class TestPgToSqlTemp:
+    @classmethod
+    def setup_class(cls):
+        helpers.set_up_test_table_pg(db)
+
+    def test_pg_to_sql_basic(self):
+
+        """
+        Copy an existing Postgres table to MS SQL Server, maintaining the name of the original table
+        """
+
+        # assert that output tables are droped
+        sql.query(f"""
+                    IF OBJECT_ID(N'tempdb..##{test_pg_to_sql_table}', N'U') IS NOT NULL
+                    DROP TABLE ##{test_pg_to_sql_table};
+                """)
+        db.drop_table(schema=pg_schema, table=test_pg_to_sql_table)
+        assert not db.table_exists(schema=pg_schema, table=test_pg_to_sql_table)
+
+        # create table in pg
+        db.query(f"""
+        create table {pg_schema}.{test_pg_to_sql_table} as
+
+        select *
+        from {pg_schema}.{pg_table_name}
+        limit 10
+        """)
+
+        # Assert table created correctly
+        assert db.table_exists(table=test_pg_to_sql_table, schema=pg_schema)
+
+        # Run pg_to_sql
+        data_io.pg_to_sql_temp_tbl(db, sql, test_pg_to_sql_table, org_schema=pg_schema)
+
+        # Assert df equality -- some types need to be coerced from the Pandas df for the equality assertion to hold
+
+        pg_df = db.dfquery(f"""
+        select *
+        from {pg_schema}.{test_pg_to_sql_table}
+        order by id
+        """).infer_objects()
+
+        sql_df = sql.dfquery(f"""
+        select *
+        from ##{test_pg_to_sql_table}
+        order by id
+        """).infer_objects()
+
+        # Assert that data columns are equal
+        shared_non_geom_cols = list(set(pg_df.columns).intersection(set(sql_df.columns)) - {'geom'})
+
+        pd.testing.assert_frame_equal(pg_df[shared_non_geom_cols], sql_df[shared_non_geom_cols],
+                                      check_dtype=False,
+                                      check_exact=False,
+                                      check_datetimelike_compat=True)
+
+        # Clean up
+        db.drop_table(table=test_pg_to_sql_table, schema=pg_schema)
+
+    def test_pg_to_sql_naming(self):
+
+        """
+        Copy an existing Postgres table to MS SQL Server, and change the name of the copied table.
+        """
+
+        # assert that output tables are not created
+        dest_name = f'another_tst_name_{db.user}'
+        sql.query(f"""
+           IF OBJECT_ID(N'tempdb..##{dest_name}', N'U') IS NOT NULL
+           DROP TABLE ##{dest_name};
+       """)
+        db.drop_table(schema=pg_schema, table=test_pg_to_sql_table)
+        assert not db.table_exists(schema=pg_schema, table=test_pg_to_sql_table)
+
+
+        # create table in pg
+        db.query(f"""
+           drop table if exists {pg_schema}.{test_pg_to_sql_table};
+           create table {pg_schema}.{test_pg_to_sql_table} as
+            select *
+            from {pg_schema}.{pg_table_name}
+            limit 10
+        """)
+
+        # Assert table created correctly
+        assert db.table_exists(table=test_pg_to_sql_table, schema=pg_schema)
+
+        # Run pg_to_sql
+        data_io.pg_to_sql_temp_tbl(db, sql, test_pg_to_sql_table, org_schema=pg_schema, dest_table=dest_name)
+
+        # Assert df equality -- some types need to be coerced from the Pandas df for the equality assertion to hold
+        pg_df = db.dfquery(f"""
+                select *
+                from {pg_schema}.{test_pg_to_sql_table}
+                order by id
+        """).infer_objects()
+
+        sql_df = sql.dfquery(f"""
+                select * 
+                from ##{dest_name}
+                order by id
+                """).infer_objects()
+
+        # Assert that tables are the same
+        shared_non_geom_cols = list(set(pg_df.columns).intersection(set(sql_df.columns)) - {'geom'})
+        pd.testing.assert_frame_equal(pg_df[shared_non_geom_cols], sql_df[shared_non_geom_cols],
+                                      check_dtype=False,
+                                      check_exact=False,
+                                      check_datetimelike_compat=True)
+
+        # Clean up
+        db.drop_table(table=test_pg_to_sql_table, schema=pg_schema)
+
+    def test_pg_to_sql_spatial_table(self):
+        """
+        Copy a table with spatial data in Postgres to MS SQL Server.
+        """
+
+        # assert that output tables dropped
+        sql.drop_table(schema=sql.default_schema, table=test_pg_to_sql_table)
+        db.drop_table(table=test_pg_to_sql_table, schema=pg_schema)
+        assert not sql.table_exists(schema=sql.default_schema, table=test_pg_to_sql_table)
+        assert not db.table_exists(table=test_pg_to_sql_table, schema=pg_schema)
+
+        # create table in pg
+        db.query(f"""
+           drop table if exists {pg_schema}.{test_pg_to_sql_table};
+           create table {pg_schema}.{test_pg_to_sql_table} as
+
+           select 'hello' as c, st_transform(geom, 4326) as geom
+           from {pg_schema}.{pg_table_name}
+           limit 10
+        """)
+
+        # Assert table created correctly
+        assert db.table_exists(table=test_pg_to_sql_table, schema=pg_schema)
+
+        # Assert neither table in SQL Server yet
+        assert not sql.table_exists(table=test_pg_to_sql_table)
+
+        # run pg_to_sql, with different spatial flags
+        data_io.pg_to_sql(db, sql, org_table=test_pg_to_sql_table, org_schema=pg_schema, dest_table=test_pg_to_sql_table, spatial=True,
+                          print_cmd=True)
+
+        # Assert move worked and output tables were created
+        assert sql.table_exists(table=test_pg_to_sql_table)
+
+        # assert that the SQL dataframes are the same
+        spatial_df = sql.dfquery(f"""
+        select c, geom.STX test_lat, geom.STY test_long
+        from {test_pg_to_sql_table}
+        """).infer_objects()
+
+        # Assert df equality -- some types need to be coerced from the Pandas df for the equality assertion to hold
+        pg_df = db.dfquery(f"""
+        select c, ST_X(geom) test_lat, ST_Y(geom) test_long
+        from {pg_schema}.{test_pg_to_sql_table}
+        """).infer_objects()
+
+        pd.testing.assert_frame_equal(pg_df, spatial_df,
+                                      check_dtype=False,
+                                      check_exact=False,
+                                      check_datetimelike_compat=True)
+
+        # Clean up
+        sql.drop_table(schema=sql.default_schema, table=test_pg_to_sql_table)
+        db.drop_table(table=test_pg_to_sql_table, schema=pg_schema)
+
+    @classmethod
+    def teardown_class(cls):
+        helpers.clean_up_test_table_pg(db)
+
+
+class TestPgToSqlQryTemp:
 
     @classmethod
     def setup_class(cls):
@@ -746,6 +747,7 @@ class TestPgtoSqlQryTemp:
         helpers.clean_up_test_table_pg(db)
 
 
+# SQL to PG ##########################################################################################################
 class TestSqlToPgQry:
 
 
@@ -1231,6 +1233,158 @@ class TestSqlToPg:
         helpers.clean_up_test_table_pg(db)
 
 
+class TestSqlToPgTemp:
+
+    def test_sql_to_pg_basic(self):
+
+        """
+        Copy an existing MS SQL Server to Postgres table , maintaining the name of the original table
+        """
+
+        # assert that output tables are droped
+        db.query(f"drop table if exists {test_sql_to_pg_table}")
+        sql.drop_table(schema=sql_schema, table=test_sql_to_pg_table)
+        assert not sql.table_exists(schema=sql_schema, table=test_sql_to_pg_table)
+
+        # create table in src
+        sql.query(f"""
+            create table {sql_schema}.{test_sql_to_pg_table} (test_col1 int, test_col2 int, test_col3 varchar(4));
+            insert into {sql_schema}.{test_sql_to_pg_table} (test_col1, test_col2, test_col3) VALUES (1, 2, 'ABCD');
+            insert into {sql_schema}.{test_sql_to_pg_table} (test_col1, test_col2, test_col3) VALUES (3, 4, 'DE*G');
+            insert into {sql_schema}.{test_sql_to_pg_table} (test_col1, test_col2, test_col3) VALUES (5, 60, 'HIj_');
+            insert into {sql_schema}.{test_sql_to_pg_table} (test_col1, test_col2, test_col3) VALUES (-3, 24271, 'zhyw');
+            """)
+
+        # Assert table created correctly
+        assert sql.table_exists(table=test_sql_to_pg_table, schema=sql_schema)
+
+        # Run pg_to_sql
+        data_io.sql_to_pg_temp_tbl(sql, db, test_sql_to_pg_table, org_schema=sql_schema)
+
+        # Assert df equality -- some types need to be coerced from the Pandas df for the equality assertion to hold
+
+        pg_df = db.dfquery(f"""
+        select *
+        from {test_sql_to_pg_table}
+        order by test_col1
+        """).infer_objects()
+
+        sql_df = sql.dfquery(f"""
+        select *
+        from {sql_schema}.{test_sql_to_pg_table}
+        order by test_col1
+        """).infer_objects()
+
+        # # Assert that data columns are equal
+        # shared_non_geom_cols = list(set(pg_df.columns).intersection(set(sql_df.columns)) - {'geom'})
+
+        pd.testing.assert_frame_equal(pg_df, sql_df,
+                                      check_dtype=False,
+                                      check_exact=False,
+                                      check_datetimelike_compat=True)
+
+        # Clean up
+        sql.drop_table(table=test_sql_to_pg_table, schema=sql_schema)
+
+    def test_sql_to_pg_naming(self):
+
+        """
+        Copy an existing MS SQL Server to Postgres temp table, and change the name of the copied table.
+        """
+
+        # assert that output tables are not created
+        dest_name = f'another_tst_name_{db.user}'
+        db.query(f"drop table if exists {dest_name}")
+        sql.drop_table(schema=sql_schema, table=test_pg_to_sql_table)
+        assert not db.table_exists(schema=pg_schema, table=test_sql_to_pg_table)
+
+
+        # create table in src
+        sql.query(f"""
+           create table {sql_schema}.{test_sql_to_pg_table} (test_col1 int, test_col2 int, test_col3 varchar(4));
+           insert into {sql_schema}.{test_sql_to_pg_table} (test_col1, test_col2, test_col3) VALUES (1, 2, 'ABCD');
+           insert into {sql_schema}.{test_sql_to_pg_table} (test_col1, test_col2, test_col3) VALUES (3, 4, 'DE*G');
+           insert into {sql_schema}.{test_sql_to_pg_table} (test_col1, test_col2, test_col3) VALUES (5, 60, 'HIj_');
+           insert into {sql_schema}.{test_sql_to_pg_table} (test_col1, test_col2, test_col3) VALUES (-3, 24271, 'zhyw');
+           """)
+
+        # Assert table created correctly
+        assert sql.table_exists(table=test_sql_to_pg_table, schema=sql_schema)
+
+        # Run pg_to_sql
+        data_io.sql_to_pg_temp_tbl(sql, db, test_sql_to_pg_table, org_schema=sql_schema, dest_table=dest_name)
+
+        # Assert df equality -- some types need to be coerced from the Pandas df for the equality assertion to hold
+        pg_df = db.dfquery(f"""
+                select *
+                from {dest_name}
+                order by test_col1
+        """).infer_objects()
+
+        sql_df = sql.dfquery(f"""
+                select * 
+                from {sql_schema}.{test_sql_to_pg_table}
+                order by test_col1
+                """).infer_objects()
+
+        # Assert that tables are the same
+        pd.testing.assert_frame_equal(pg_df, sql_df,
+                                      check_dtype=False,
+                                      check_exact=False,
+                                      check_datetimelike_compat=True)
+
+        # Clean up
+        sql.drop_table(table=test_sql_to_pg_table, schema=sql_schema)
+
+    def test_pg_to_sql_spatial_table(self):
+        """
+        Copy a table with spatial data in MS SQL Server to Postgres temp table.
+        """
+
+        # assert that output tables dropped
+        sql.drop_table(schema=sql_schema, table=test_sql_to_pg_table)
+        db.query(f"drop table if exists {test_sql_to_pg_table}")
+        assert not sql.table_exists(schema=sql_schema, table=test_pg_to_sql_table)
+
+
+        # create table in src
+        sql.query(f"""
+            create table {sql_schema}.{test_sql_to_pg_table} (test_col1 int, test_col2 int, test_col3 varchar(4), geom geometry);
+            insert into {sql_schema}.{test_sql_to_pg_table} (test_col1, test_col2, test_col3, geom) VALUES (1, 2, 'ABCD', geometry::Point(1015329.1, 213793.1, 2263));
+            insert into {sql_schema}.{test_sql_to_pg_table} (test_col1, test_col2, test_col3, geom) VALUES (3, 4, 'DE*G', geometry::Point(1015329.1, 213793.1, 2263));
+            insert into {sql_schema}.{test_sql_to_pg_table} (test_col1, test_col2, test_col3, geom) VALUES (5, 60, 'HIj_', geometry::Point(1015329.1, 213793.1, 2263));
+            insert into {sql_schema}.{test_sql_to_pg_table} (test_col1, test_col2, test_col3, geom) VALUES (-3, 24271, 'zhyw', geometry::Point(1015329.1, 213793.1, 2263));
+        """)
+
+        # Assert table created correctly
+        assert sql.table_exists(table=test_sql_to_pg_table, schema=sql_schema)
+
+        # copy data over
+        data_io.sql_to_pg_temp_tbl(sql, db, test_sql_to_pg_table, org_schema=sql_schema,
+                                    dest_table=test_sql_to_pg_table)
+
+        # assert that the SQL dataframes are the same
+        spatial_df = sql.dfquery(f"""
+        select test_col1, geom.STX test_lat, geom.STY test_long
+        from {sql_schema}.{test_sql_to_pg_table}
+        """).infer_objects()
+
+        # Assert df equality -- some types need to be coerced from the Pandas df for the equality assertion to hold
+        pg_df = db.dfquery(f"""
+        select test_col1, ST_X(geom) test_lat, ST_Y(geom) test_long
+        from {test_sql_to_pg_table}
+        """).infer_objects()
+
+        pd.testing.assert_frame_equal(pg_df, spatial_df,
+                                      check_dtype=False,
+                                      check_exact=False,
+                                      check_datetimelike_compat=True)
+
+        # Clean up
+        sql.drop_table(schema=sql.default_schema, table=test_pg_to_sql_table)
+
+
+# PG to PG ##########################################################################################################
 class TestPgToPg:
     @classmethod
     def setup_class(cls):
@@ -1665,6 +1819,324 @@ class TestPgToPgQry:
         helpers.clean_up_test_table_pg(db)
 
 
+class TestPgToPgTemp:
+    @classmethod
+    def setup_class(cls):
+        helpers.set_up_test_table_pg(db)
+
+    def test_pg_to_sql_basic(self):
+
+        """
+        Copy an existing Postgres table to Postgres temp table, maintaining the name of the original table
+        """
+
+        # assert that output tables are droped
+        db.drop_table(schema=pg_schema, table=test_pg_to_pg_tbl)
+        assert not db.table_exists(schema=pg_schema, table=test_pg_to_pg_tbl)
+        ris.query(f"drop table if exists {test_pg_to_pg_tbl}")
+
+        # create table in src
+        db.query(f"""
+        create table {pg_schema}.{test_pg_to_pg_tbl} as
+
+        select *
+        from {pg_schema}.{pg_table_name}
+        limit 10
+        """)
+
+        # Assert table created correctly
+        assert db.table_exists(table=test_pg_to_pg_tbl, schema=pg_schema)
+
+        # Run pg_to_sql
+        data_io.pg_to_pg_temp_tbl(db, ris, test_pg_to_pg_tbl, org_schema=pg_schema)
+
+        # Assert df equality -- some types need to be coerced from the Pandas df for the equality assertion to hold
+
+        pg_df = db.dfquery(f"""
+        select *
+        from {pg_schema}.{test_pg_to_pg_tbl}
+        order by id
+        """).infer_objects()
+
+        dest_df = ris.dfquery(f"""
+        select *
+        from {test_pg_to_pg_tbl}
+        order by id
+        """).infer_objects()
+
+        # Assert that data columns are equal
+        shared_non_geom_cols = list(set(pg_df.columns).intersection(set(dest_df.columns)) - {'geom'})
+
+        pd.testing.assert_frame_equal(pg_df[shared_non_geom_cols], dest_df[shared_non_geom_cols],
+                                      check_dtype=False,
+                                      check_exact=False,
+                                      check_datetimelike_compat=True)
+
+        # Clean up
+        db.drop_table(table=test_pg_to_pg_tbl, schema=pg_schema)
+
+    def test_pg_to_pg_naming(self):
+
+        """
+        Copy an existing Postgres table to Postgres temp table, and change the name of the copied table.
+        """
+
+        # assert that output tables are not created
+        dest_name = f'another_tst_name_{db.user}'
+        db.drop_table(schema=pg_schema, table=test_pg_to_pg_tbl)
+        assert not db.table_exists(schema=pg_schema, table=test_pg_to_pg_tbl)
+        ris.query(f"drop table if exists {dest_name}")
+
+
+        # create table in src
+        db.query(f"""
+           drop table if exists {pg_schema}.{test_pg_to_pg_tbl};
+           create table {pg_schema}.{test_pg_to_pg_tbl} as
+            select *
+            from {pg_schema}.{pg_table_name}
+            limit 10
+        """)
+
+        # Assert table created correctly
+        assert db.table_exists(table=test_pg_to_pg_tbl, schema=pg_schema)
+
+        # Run pg_to_sql
+        data_io.pg_to_pg_temp_tbl(db, ris, test_pg_to_pg_tbl, org_schema=pg_schema, dest_table=dest_name)
+
+        # Assert df equality -- some types need to be coerced from the Pandas df for the equality assertion to hold
+        pg_df = db.dfquery(f"""
+                select *
+                from {pg_schema}.{test_pg_to_pg_tbl}
+                order by id
+        """).infer_objects()
+
+        dest_df = ris.dfquery(f"""
+                select * 
+                from {dest_name}
+                order by id
+                """).infer_objects()
+
+        # Assert that tables are the same
+        shared_non_geom_cols = list(set(pg_df.columns).intersection(set(dest_df.columns)) - {'geom'})
+        pd.testing.assert_frame_equal(pg_df[shared_non_geom_cols], dest_df[shared_non_geom_cols],
+                                      check_dtype=False,
+                                      check_exact=False,
+                                      check_datetimelike_compat=True)
+
+        # Clean up
+        db.drop_table(table=test_pg_to_pg_tbl, schema=pg_schema)
+
+    def test_pg_to_pg_spatial_table(self):
+        """
+        Copy a table with spatial data in Postgres to MS SQL Server.
+        """
+
+        # assert that output tables dropped
+        db.drop_table(table=test_pg_to_pg_tbl, schema=pg_schema)
+        assert not db.table_exists(table=test_pg_to_sql_table, schema=pg_schema)
+        ris.query(f"drop table if exists {test_pg_to_pg_tbl}")
+
+        # create table in pg
+        db.query(f"""
+           drop table if exists {pg_schema}.{test_pg_to_pg_tbl};
+           create table {pg_schema}.{test_pg_to_pg_tbl} as
+
+           select 'hello' as c, st_transform(geom, 4326) as geom
+           from {pg_schema}.{pg_table_name}
+           limit 10
+        """)
+
+        # Assert table created correctly
+        assert db.table_exists(table=test_pg_to_pg_tbl, schema=pg_schema)
+
+
+        # copy data
+        data_io.pg_to_pg_temp_tbl(db, ris, test_pg_to_pg_tbl, org_schema=pg_schema)
+
+        # assert that the SQL dataframes are the same
+        spatial_df = ris.dfquery(f"""
+        select c, ST_X(geom) test_lat, ST_Y(geom) test_long
+        from {test_pg_to_pg_tbl}
+        """).infer_objects()
+
+        # Assert df equality -- some types need to be coerced from the Pandas df for the equality assertion to hold
+        pg_df = db.dfquery(f"""
+        select c, ST_X(geom) test_lat, ST_Y(geom) test_long
+        from {pg_schema}.{test_pg_to_pg_tbl}
+        """).infer_objects()
+
+        pd.testing.assert_frame_equal(pg_df, spatial_df,
+                                      check_dtype=False,
+                                      check_exact=False,
+                                      check_datetimelike_compat=True)
+
+        # Clean up
+        db.drop_table(table=test_pg_to_pg_tbl, schema=pg_schema)
+
+    @classmethod
+    def teardown_class(cls):
+        helpers.clean_up_test_table_pg(db)
+
+
+class TestPgToPgQryTemp:
+
+    @classmethod
+    def setup_class(cls):
+        helpers.set_up_test_table_pg(db)
+
+    def test_pg_to_sql_qry_basic_table_temp(self):
+
+        """
+        Copy a query from Postgres to an output table in SQL
+        """
+
+        # drop output tables if they exist
+        db.drop_table(schema=pg_schema, table=test_pg_to_sql_qry_table)
+        assert not db.table_exists(schema = pg_schema, table = test_pg_to_sql_qry_table)
+        sql.query(f"""
+            IF OBJECT_ID(N'tempdb..##{test_pg_to_sql_qry_table}', N'U') IS NOT NULL
+            DROP TABLE ##{test_pg_to_sql_qry_table};
+        """)
+
+        # create pg table
+        db.query(f"""
+                    create table {pg_schema}.{test_pg_to_sql_qry_table} (test_col1 int, test_col2 int);
+                    insert into {pg_schema}.{test_pg_to_sql_qry_table} VALUES(1, 2);
+                    insert into {pg_schema}.{test_pg_to_sql_qry_table} VALUES(3, 4);
+        """)
+
+        # run pg_to_sql_qry
+        data_io.pg_to_sql_qry_temp_tbl(db, sql, query=
+                             f"""
+                             select test_col1, test_col2 from {pg_schema}.{test_pg_to_sql_qry_table}
+                             """,
+                             dest_table=test_pg_to_sql_qry_table)
+
+        # Assert df equality
+        pg_df = db.dfquery(f"""
+        select test_col1, test_col2 from {pg_schema}.{test_pg_to_sql_qry_table}
+        order by test_col1
+        """).infer_objects().replace(r'\s+', '', regex=True)
+
+        sql_df = sql.dfquery(f"""
+        select test_col1, test_col2 from ##{test_pg_to_sql_qry_table}
+        order by test_col1
+        """).infer_objects().replace(r'\s+', '', regex=True)
+
+        # Assert
+        pd.testing.assert_frame_equal(pg_df, sql_df,
+                                      check_dtype=False,
+                                      check_column_type=False)
+
+        # Cleanup
+        db.drop_table(schema=pg_schema, table=test_pg_to_sql_qry_table)
+
+    def test_pg_to_sql_qry_basic_with_comments_table_temp(self):
+
+        """
+        Copy a query full of text comments from Postgres to an output table in SQL.
+        """
+
+        # assert that output table dropped
+        sql.query(f"""
+                    IF OBJECT_ID(N'tempdb..##{test_pg_to_sql_qry_table}', N'U') IS NOT NULL
+                    DROP TABLE ##{test_pg_to_sql_qry_table};
+                """)
+
+        # run pg_to_sql_qry
+        data_io.pg_to_sql_qry_temp_tbl(db, sql, query=f"""
+                                -- testing out comments
+                                select id, test_col1, test_col2 from /* what if there are comments here too */
+                                {pg_schema}.{pg_table_name} -- table name
+                                order by test_col1
+                                -- another comment
+                                limit 10; -- limit to 10 rows
+                                """,
+                                       dest_table=test_pg_to_sql_qry_table)
+
+        # Assert df equality
+        pg_df = db.dfquery(f"""
+        select id, test_col1, test_col2 from {pg_schema}.{pg_table_name}
+        order by test_col1
+        limit 10
+        """).infer_objects().replace(r'\s+', '', regex=True)
+
+        # hardcoded the columns because they go in a different order when uploaded
+        sql_df = sql.dfquery(f"""
+        select id, test_col1, test_col2 from ##{test_pg_to_sql_qry_table}
+        order by test_col1
+        """).infer_objects().replace(r'\s+', '', regex=True)
+
+        # Assert that dataframes are equal
+        pd.testing.assert_frame_equal(pg_df, sql_df,
+                                    check_dtype=False,
+                                      check_column_type=False)
+
+    def test_pg_to_sql_qry_spatial(self):
+
+        """
+        Copy a spatial query from Postgres to SQL
+        """
+
+        # confirm that output tables are dropped
+        sql.query(f"""
+                    IF OBJECT_ID(N'tempdb..##{test_pg_to_sql_qry_spatial_table}', N'U') IS NOT NULL
+                    DROP TABLE ##{test_pg_to_sql_qry_spatial_table};
+                """)
+        db.drop_table(schema = pg_schema, table = test_pg_to_sql_qry_spatial_table)
+        assert not db.table_exists(table=test_pg_to_sql_qry_spatial_table, schema = pg_schema)
+
+
+        # create spatial table
+        db.query(f"""
+            create table {pg_schema}.{test_pg_to_sql_qry_spatial_table}
+                (test_col1 int, test_col2 int, test_geom geometry);
+            insert into {pg_schema}.{test_pg_to_sql_qry_spatial_table} (test_col1, test_col2, test_geom)
+                 VALUES (1, 2, ST_SetSRID(ST_MAKEPOINT(-71.10434, 42.31506), 2236));
+            insert into {pg_schema}.{test_pg_to_sql_qry_spatial_table} (test_col1, test_col2, test_geom)
+                VALUES (3, 4, ST_SetSRID(ST_MAKEPOINT(91.2763, 11.9434), 2236));
+        """)
+
+        # make sure data is in source
+        assert len(db.dfquery(
+            f'select test_col1, test_col2, test_geom from {pg_schema}.{test_pg_to_sql_qry_spatial_table}')) == 2
+
+        # run pg_to_sql_qry
+        data_io.pg_to_sql_qry_temp_tbl(db, sql, query=f"""
+                                               SELECT test_col1, test_col2, test_geom --comments within the query
+                                                FROM {pg_schema}.{test_pg_to_sql_qry_spatial_table} -- geom here
+                                                -- end here""",
+                                       dest_table=test_pg_to_sql_qry_spatial_table)
+
+        # doing it by long / lat was the only way the data frames would be equivalent
+        pg_df = db.dfquery(f"""
+        select test_col1, test_col2, ST_X(test_geom) test_lat, ST_Y(test_geom) test_long
+        from {pg_schema}.{test_pg_to_sql_qry_spatial_table}
+        order by test_col1
+        """)
+
+        sql_df = sql.dfquery(f"""select * from ##{test_pg_to_sql_qry_spatial_table}""")
+        sql_df = sql.dfquery(f"""
+                select test_col1, test_col2, 
+                geom.STX test_lat, 
+                geom.STY test_long
+                from ##{test_pg_to_sql_qry_spatial_table}
+                order by test_col1
+        """)
+
+        # check the first 2 columns using assert_frame_equal
+        pd.testing.assert_frame_equal(pg_df, sql_df,
+                                      check_dtype=False,
+                                      check_column_type=False)
+
+        # clean up tables
+        db.drop_table(schema=pg_schema, table=test_pg_to_sql_qry_spatial_table)
+
+    @classmethod
+    def teardown_class(cls):
+        helpers.clean_up_test_table_pg(db)
+
+# SQL to SQL ##########################################################################################################
 class TestSqlToSqlQry:
 
     def test_sql_to_sql_basic_table(self):
@@ -2109,6 +2581,7 @@ class TestSqlToSqlQry:
     @classmethod
     def teardown_class(cls):
         helpers.clean_up_test_table_sql(sql)
+
 
 class TestSqlToSqlTemp:
 

--- a/pysqldb3/tests/test_io.py
+++ b/pysqldb3/tests/test_io.py
@@ -239,6 +239,185 @@ class TestPgToSql:
         helpers.clean_up_test_table_sql(sql)
 
 
+class TestPgToSqlTemp:
+    @classmethod
+    def setup_class(cls):
+        helpers.set_up_test_table_pg(db)
+
+    def test_pg_to_sql_basic(self):
+
+        """
+        Copy an existing Postgres table to MS SQL Server, maintaining the name of the original table
+        """
+
+        # assert that output tables are droped
+        sql.query(f"""
+                    IF OBJECT_ID(N'tempdb..##{test_pg_to_sql_table}', N'U') IS NOT NULL
+                    DROP TABLE ##{test_pg_to_sql_table};
+                """)
+        db.drop_table(schema=pg_schema, table=test_pg_to_sql_table)
+        assert not db.table_exists(schema=pg_schema, table=test_pg_to_sql_table)
+
+        # create table in pg
+        db.query(f"""
+        create table {pg_schema}.{test_pg_to_sql_table} as
+
+        select *
+        from {pg_schema}.{pg_table_name}
+        limit 10
+        """)
+
+        # Assert table created correctly
+        assert db.table_exists(table=test_pg_to_sql_table, schema=pg_schema)
+
+        # Run pg_to_sql
+        data_io.pg_to_sql_temp_tbl(db, sql, test_pg_to_sql_table, org_schema=pg_schema)
+
+        # Assert df equality -- some types need to be coerced from the Pandas df for the equality assertion to hold
+
+        pg_df = db.dfquery(f"""
+        select *
+        from {pg_schema}.{test_pg_to_sql_table}
+        order by id
+        """).infer_objects()
+
+        sql_df = sql.dfquery(f"""
+        select id, test_col1, test_col2, geometry::STGeomFromText(wkt, 2263) as geom
+        from ##{test_pg_to_sql_table}
+        order by id
+        """).infer_objects()
+
+        # Assert that data columns are equal
+        shared_non_geom_cols = list(set(pg_df.columns).intersection(set(sql_df.columns)) - {'geom'})
+
+        pd.testing.assert_frame_equal(pg_df[shared_non_geom_cols], sql_df[shared_non_geom_cols],
+                                      check_dtype=False,
+                                      check_exact=False,
+                                      check_datetimelike_compat=True)
+
+        # Clean up
+        db.drop_table(table=test_pg_to_sql_table, schema=pg_schema)
+
+
+    def test_pg_to_sql_naming(self):
+
+        """
+        Copy an existing Postgres table to MS SQL Server, and change the name of the copied table.
+        """
+
+        # assert that output tables are not created
+        dest_name = f'another_tst_name_{db.user}'
+        db.drop_table(schema=pg_schema, table=test_pg_to_sql_table)
+        sql.drop_table(table=dest_name, schema = sql.default_schema)
+        assert not db.table_exists(schema=pg_schema, table=test_pg_to_sql_table)
+        assert not sql.table_exists(table=dest_name)
+
+        # create table in pg
+        db.query(f"""
+           drop table if exists {pg_schema}.{test_pg_to_sql_table};
+           create table {pg_schema}.{test_pg_to_sql_table} as
+            select *
+            from {pg_schema}.{pg_table_name}
+            limit 10
+        """)
+
+        # Assert table created correctly
+        assert db.table_exists(table=test_pg_to_sql_table, schema=pg_schema)
+
+        # Run pg_to_sql
+        data_io.pg_to_sql(db, sql,
+                          org_schema=pg_schema, org_table=test_pg_to_sql_table,
+                          dest_table=dest_name,
+                          print_cmd=True)
+
+        # Assert created properly in sql with names
+        assert sql.table_exists(table=dest_name, schema=sql.default_schema)
+
+        # Assert df equality -- some types need to be coerced from the Pandas df for the equality assertion to hold
+        pg_df = db.dfquery(f"""
+                select *
+                from {pg_schema}.{test_pg_to_sql_table}
+                order by id
+        """).infer_objects()
+
+        sql_df = sql.dfquery(f"""
+                select *
+                from {dest_name}
+                order by id
+        """).infer_objects()
+
+        # Assert that tables are the same
+        shared_non_geom_cols = list(set(pg_df.columns).intersection(set(sql_df.columns)) - {'geom'})
+        pd.testing.assert_frame_equal(pg_df[shared_non_geom_cols], sql_df[shared_non_geom_cols],
+                                      check_dtype=False,
+                                      check_exact=False,
+                                      check_datetimelike_compat=True)
+
+        # Clean up
+        sql.drop_table(schema=sql.default_schema, table=test_pg_to_sql_table)
+        db.drop_table(table=test_pg_to_sql_table, schema=pg_schema)
+
+    def test_pg_to_sql_spatial_table(self):
+        """
+        Copy a table with spatial data in Postgres to MS SQL Server.
+        """
+
+        # assert that output tables dropped
+        sql.drop_table(schema=sql.default_schema, table=test_pg_to_sql_table)
+        db.drop_table(table=test_pg_to_sql_table, schema=pg_schema)
+        assert not sql.table_exists(schema=sql.default_schema, table=test_pg_to_sql_table)
+        assert not db.table_exists(table=test_pg_to_sql_table, schema=pg_schema)
+
+        # create table in pg
+        db.query(f"""
+           drop table if exists {pg_schema}.{test_pg_to_sql_table};
+           create table {pg_schema}.{test_pg_to_sql_table} as
+
+           select 'hello' as c, st_transform(geom, 4326) as geom
+           from {pg_schema}.{pg_table_name}
+           limit 10
+        """)
+
+        # Assert table created correctly
+        assert db.table_exists(table=test_pg_to_sql_table, schema=pg_schema)
+
+        # Assert neither table in SQL Server yet
+        assert not sql.table_exists(table=test_pg_to_sql_table)
+
+        # run pg_to_sql, with different spatial flags
+        data_io.pg_to_sql(db, sql, org_table=test_pg_to_sql_table, org_schema=pg_schema, dest_table=test_pg_to_sql_table, spatial=True,
+                          print_cmd=True)
+
+        # Assert move worked and output tables were created
+        assert sql.table_exists(table=test_pg_to_sql_table)
+
+        # assert that the SQL dataframes are the same
+        spatial_df = sql.dfquery(f"""
+        select c, geom.STX test_lat, geom.STY test_long
+        from {test_pg_to_sql_table}
+        """).infer_objects()
+
+        # Assert df equality -- some types need to be coerced from the Pandas df for the equality assertion to hold
+        pg_df = db.dfquery(f"""
+        select c, ST_X(geom) test_lat, ST_Y(geom) test_long
+        from {pg_schema}.{test_pg_to_sql_table}
+        """).infer_objects()
+
+        pd.testing.assert_frame_equal(pg_df, spatial_df,
+                                      check_dtype=False,
+                                      check_exact=False,
+                                      check_datetimelike_compat=True)
+
+        # Clean up
+        sql.drop_table(schema=sql.default_schema, table=test_pg_to_sql_table)
+        db.drop_table(table=test_pg_to_sql_table, schema=pg_schema)
+
+    @classmethod
+    def teardown_class(cls):
+        helpers.clean_up_test_table_pg(db)
+        helpers.clean_up_test_table_sql(sql)
+
+
 class TestPgtoSqlQry:
 
     @classmethod
@@ -412,6 +591,170 @@ class TestPgtoSqlQry:
     def teardown_class(cls):
         helpers.clean_up_test_table_pg(db)
         helpers.clean_up_test_table_sql(sql)
+
+
+class TestPgtoSqlQryTemp:
+
+    @classmethod
+    def setup_class(cls):
+        helpers.set_up_test_table_pg(db)
+
+    def test_pg_to_sql_qry_basic_table_temp(self):
+
+        """
+        Copy a query from Postgres to an output table in SQL
+        """
+
+        # drop output tables if they exist
+        db.drop_table(schema=pg_schema, table=test_pg_to_sql_qry_table)
+        assert not db.table_exists(schema = pg_schema, table = test_pg_to_sql_qry_table)
+        sql.query(f"""
+            IF OBJECT_ID(N'tempdb..##{test_pg_to_sql_qry_table}', N'U') IS NOT NULL
+            DROP TABLE ##{test_pg_to_sql_qry_table};
+        """)
+
+        # create pg table
+        db.query(f"""
+                    create table {pg_schema}.{test_pg_to_sql_qry_table} (test_col1 int, test_col2 int);
+                    insert into {pg_schema}.{test_pg_to_sql_qry_table} VALUES(1, 2);
+                    insert into {pg_schema}.{test_pg_to_sql_qry_table} VALUES(3, 4);
+        """)
+
+        # run pg_to_sql_qry
+        data_io.pg_to_sql_qry_temp_tbl(db, sql, query=
+                             f"""
+                             select test_col1, test_col2 from {pg_schema}.{test_pg_to_sql_qry_table}
+                             """,
+                             dest_table=test_pg_to_sql_qry_table)
+
+        # Assert df equality
+        pg_df = db.dfquery(f"""
+        select test_col1, test_col2 from {pg_schema}.{test_pg_to_sql_qry_table}
+        order by test_col1
+        """).infer_objects().replace(r'\s+', '', regex=True)
+
+        sql_df = sql.dfquery(f"""
+        select test_col1, test_col2 from ##{test_pg_to_sql_qry_table}
+        order by test_col1
+        """).infer_objects().replace(r'\s+', '', regex=True)
+
+        # Assert
+        pd.testing.assert_frame_equal(pg_df, sql_df,
+                                      check_dtype=False,
+                                      check_column_type=False)
+
+        # Cleanup
+        db.drop_table(schema=pg_schema, table=test_pg_to_sql_qry_table)
+
+
+    def test_pg_to_sql_qry_basic_with_comments_table_temp(self):
+
+        """
+        Copy a query full of text comments from Postgres to an output table in SQL.
+        """
+
+        # assert that output table dropped
+        sql.query(f"""
+                    IF OBJECT_ID(N'tempdb..##{test_pg_to_sql_qry_table}', N'U') IS NOT NULL
+                    DROP TABLE ##{test_pg_to_sql_qry_table};
+                """)
+
+        # run pg_to_sql_qry
+        data_io.pg_to_sql_qry_temp_tbl(db, sql, query=f"""
+                                -- testing out comments
+                                select id, test_col1, test_col2 from /* what if there are comments here too */
+                                {pg_schema}.{pg_table_name} -- table name
+                                order by test_col1
+                                -- another comment
+                                limit 10; -- limit to 10 rows
+                                """,
+                                       dest_table=test_pg_to_sql_qry_table)
+
+        # Assert df equality
+        pg_df = db.dfquery(f"""
+        select id, test_col1, test_col2 from {pg_schema}.{pg_table_name}
+        order by test_col1
+        limit 10
+        """).infer_objects().replace(r'\s+', '', regex=True)
+
+        # hardcoded the columns because they go in a different order when uploaded
+        sql_df = sql.dfquery(f"""
+        select id, test_col1, test_col2 from ##{test_pg_to_sql_qry_table}
+        order by test_col1
+        """).infer_objects().replace(r'\s+', '', regex=True)
+
+        # Assert that dataframes are equal
+        pd.testing.assert_frame_equal(pg_df, sql_df,
+                                    check_dtype=False,
+                                      check_column_type=False)
+
+
+    def test_pg_to_sql_qry_spatial(self):
+
+        """
+        Copy a spatial query from Postgres to SQL
+        """
+
+        # confirm that output tables are dropped
+        sql.query(f"""
+                    IF OBJECT_ID(N'tempdb..##{test_pg_to_sql_qry_spatial_table}', N'U') IS NOT NULL
+                    DROP TABLE ##{test_pg_to_sql_qry_spatial_table};
+                """)
+        db.drop_table(schema = pg_schema, table = test_pg_to_sql_qry_spatial_table)
+        assert not db.table_exists(table=test_pg_to_sql_qry_spatial_table, schema = pg_schema)
+
+
+        # create spatial table
+        db.query(f"""
+            create table {pg_schema}.{test_pg_to_sql_qry_spatial_table}
+                (test_col1 int, test_col2 int, test_geom geometry);
+            insert into {pg_schema}.{test_pg_to_sql_qry_spatial_table} (test_col1, test_col2, test_geom)
+                 VALUES (1, 2, ST_SetSRID(ST_MAKEPOINT(-71.10434, 42.31506), 2236));
+            insert into {pg_schema}.{test_pg_to_sql_qry_spatial_table} (test_col1, test_col2, test_geom)
+                VALUES (3, 4, ST_SetSRID(ST_MAKEPOINT(91.2763, 11.9434), 2236));
+        """)
+
+        # make sure data is in source
+        assert len(db.dfquery(
+            f'select test_col1, test_col2, test_geom from {pg_schema}.{test_pg_to_sql_qry_spatial_table}')) == 2
+
+        # run pg_to_sql_qry
+        data_io.pg_to_sql_qry_temp_tbl(db, sql, query=f"""
+                                               SELECT test_col1, test_col2, test_geom --comments within the query
+                                                FROM {pg_schema}.{test_pg_to_sql_qry_spatial_table} -- geom here
+                                                -- end here""",
+                                       dest_table=test_pg_to_sql_qry_spatial_table)
+
+        # doing it by long / lat was the only way the data frames would be equivalent
+        pg_df = db.dfquery(f"""
+        select test_col1, test_col2, ST_X(test_geom) test_lat, ST_Y(test_geom) test_long
+        from {pg_schema}.{test_pg_to_sql_qry_spatial_table}
+        order by test_col1
+        """)
+
+        sql_df = sql.dfquery(f"""select * from ##{test_pg_to_sql_qry_spatial_table}""")
+        sql_df = sql.dfquery(f"""
+                select test_col1, test_col2, 
+                geometry::STGeomFromText(wkt, 2263).STX test_lat, 
+                geometry::STGeomFromText(wkt, 2263).STY test_long
+                from ##{test_pg_to_sql_qry_spatial_table}
+                order by test_col1
+        """)
+
+        # check the first 2 columns using assert_frame_equal
+        pd.testing.assert_frame_equal(pg_df, sql_df,
+                                      check_dtype=False,
+                                      check_column_type=False)
+
+        # clean up tables
+        db.drop_table(schema=pg_schema, table=test_pg_to_sql_qry_spatial_table)
+
+
+    @classmethod
+    def teardown_class(cls):
+        helpers.clean_up_test_table_pg(db)
+
+
 
 class TestSqlToPgQry:
 


### PR DESCRIPTION
Creates db to db transfer to temp table for:
- SQL->PG temp table
- SQL->SQL temp table
- PG->PG temp table
- PG->SQL temp table


There is a lot of duplicated code, but to refactor to simplify and DRY up will be a breaking change for any existing process, so I want to hold off on that until there's time to understand and make appropriate fixes elsewhere. 