### PR TITLE
147 db to db temp table in data io needs to be updated for funky table names

### DIFF
--- a/pysqldb3/data_io.py
+++ b/pysqldb3/data_io.py
@@ -967,6 +967,7 @@ def pg_to_pg_qry_temp_tbl(from_pg, to_pg, query, dest_table=None, print_cmd=Fals
     # comments are defined by at least 2 dashes followed by a line break or the end of the query
     # comments with /* */ do not need to be filtered out from the query
     query = re.sub('(-){2,}.*(\n|$)', ' ', query)
+    query = query.replace('"', r'\"')
 
     # write data to local csv
     temp_csv = r'C:\Users\{}\Documents\temp_csv_{}.csv'.format(getpass.getuser(), datetime.datetime.now().strftime('%Y%m%d%H%M%S'))
@@ -1024,5 +1025,5 @@ def pg_to_pg_temp_tbl(from_pg, to_pg, table, org_schema=None, dest_table=None, p
         sch = f"{org_schema}."
     else:
         sch = ''
-    query = f"select * from {sch}{table}"
+    query = f'select * from {sch}"{table}"'
     pg_to_pg_qry_temp_tbl(from_pg, to_pg, query, dest_table=dest_table, print_cmd=print_cmd)

--- a/pysqldb3/data_io.py
+++ b/pysqldb3/data_io.py
@@ -237,11 +237,11 @@ def pg_to_sql_qry_temp_tbl(pg, ms, query, dest_table=None, print_cmd=False):
     _df = pd.read_csv(temp_csv)
     if 'WKT' in _df.columns:
         # add geom column
-        ms.query(f"alter table ##{dest_table} add [geom] [geometry];")
+        ms.query(f"alter table [##{dest_table}] add [geom] [geometry];", internal=True, timeme=False)
         # update from wkt
-        ms.query(f"update ##{dest_table} set geom=geometry::STGeomFromText(wkt, 2263);")
+        ms.query(f"update [##{dest_table}] set geom=geometry::STGeomFromText(wkt, 2263);", internal=True, timeme=False)
         # drop wkt col
-        ms.query(f"alter table  ##{dest_table} drop column wkt")
+        ms.query(f"alter table [##{dest_table}] drop column wkt", internal=True, timeme=False)
 
     # clean up csv
     os.remove(temp_csv)
@@ -265,7 +265,7 @@ def pg_to_sql_temp_tbl(pg, ms, table,  org_schema=None, dest_table=None, print_c
         sch = f"{org_schema}."
     else:
         sch = ''
-    query = f"select * from {sch}{table}"
+    query = f'select * from {sch}"{table}"'
     pg_to_sql_qry_temp_tbl(pg, ms, query, dest_table=dest_table, print_cmd=print_cmd)
 
 
@@ -531,11 +531,11 @@ def sql_to_pg_qry_temp_tbl(ms, pg, query, dest_table=None, LDAP_from=False, prin
     if 'WKT' in _df.columns:
         if not _df.WKT.isnull().all():
             # add geom column
-            pg.query(f"alter table {dest_table} add geom geometry;")
+            pg.query(f'alter table "{dest_table}" add geom geometry;')
             # update from wkt
-            pg.query(f"update {dest_table} set geom=st_setsrid(st_geomfromtext(wkt), 2263);")
+            pg.query(f'update "{dest_table}" set geom=st_setsrid(st_geomfromtext(wkt), 2263);')
         # drop wkt col
-        pg.query(f"alter table {dest_table} drop column wkt")
+        pg.query(f'alter table "{dest_table}" drop column wkt')
 
     # clean up csv
     os.remove(temp_csv)
@@ -766,11 +766,11 @@ def sql_to_sql_qry_temp_tbl(from_sql, to_sql, query, dest_table=None, LDAP_from=
     if 'WKT' in _df.columns:
         if not _df.WKT.isnull().all():
             # add geom column
-            to_sql.query(f"alter table ##{dest_table} add [geom] [geometry];")
+            to_sql.query(f"alter table [##{dest_table}] add [geom] [geometry];")
             # update from wkt
-            to_sql.query(f"update ##{dest_table} set geom=geometry::STGeomFromText(wkt, 2263);")
+            to_sql.query(f"update [##{dest_table}] set geom=geometry::STGeomFromText(wkt, 2263);")
         # drop wkt col
-        to_sql.query(f"alter table  ##{dest_table} drop column wkt")
+        to_sql.query(f"alter table  [##{dest_table}] drop column wkt")
 
     # clean up csv
     os.remove(temp_csv)
@@ -996,11 +996,11 @@ def pg_to_pg_qry_temp_tbl(from_pg, to_pg, query, dest_table=None, print_cmd=Fals
     _df = pd.read_csv(temp_csv)
     if 'WKT' in _df.columns:
         # add geom column
-        to_pg.query(f"alter table {dest_table} add geom geometry;")
+        to_pg.query(f'alter table "{dest_table}" add geom geometry;')
         # update from wkt
-        to_pg.query(f"update {dest_table} set geom=st_setsrid(st_geomfromtext(wkt), 2263);")
+        to_pg.query(f'update "{dest_table}" set geom=st_setsrid(st_geomfromtext(wkt), 2263);')
         # drop wkt col
-        to_pg.query(f"alter table {dest_table} drop column wkt")
+        to_pg.query(f'alter table "{dest_table}" drop column wkt')
 
     # clean up csv
     os.remove(temp_csv)

--- a/pysqldb3/data_io.py
+++ b/pysqldb3/data_io.py
@@ -794,7 +794,7 @@ def sql_to_sql_temp_tbl(from_sql, to_sql, table, dest_table=None, org_schema=Non
         sch = f"{org_schema}."
     else:
         sch = ''
-    query = f"select * from {sch}{table}"
+    query = f"select * from {sch}[{table}]"
 
     sql_to_sql_qry_temp_tbl(from_sql, to_sql, query,dest_table=dest_table, LDAP_from=LDAP_from, print_cmd=print_cmd)
 

--- a/pysqldb3/data_io.py
+++ b/pysqldb3/data_io.py
@@ -559,7 +559,7 @@ def sql_to_pg_temp_tbl(ms, pg, table, dest_table=None, org_schema=None, LDAP_fro
         sch = f"{org_schema}."
     else:
         sch = ''
-    query = f"select * from {sch}{table}"
+    query = f"select * from {sch}[{table}]"
 
     sql_to_pg_qry_temp_tbl(ms, pg, query, dest_table=dest_table, LDAP_from=LDAP_from, print_cmd=print_cmd)
 

--- a/pysqldb3/data_io.py
+++ b/pysqldb3/data_io.py
@@ -205,6 +205,10 @@ def pg_to_sql_qry_temp_tbl(pg, ms, query, dest_table=None, print_cmd=False):
     # comments with /* */ do not need to be filtered out from the query
     query = re.sub('(-){2,}.*(\n|$)', ' ', query)
 
+    # account for "table name"
+    if '"' in query:
+        query = query.replace('"', r'\"')
+
     # write data to local csv
     temp_csv = r'C:\Users\{}\Documents\temp_csv_{}.csv'.format(getpass.getuser(), datetime.datetime.now().strftime('%Y%m%d%H%M%S'))
     cmd = PG_TO_CSV_CMD.format(
@@ -228,7 +232,7 @@ def pg_to_sql_qry_temp_tbl(pg, ms, query, dest_table=None, print_cmd=False):
         raise subprocess.CalledProcessError(cmd=print_cmd_string([ms.password, pg.password], cmd), returncode=1)
 
     # import data to temp table
-    ms.csv_to_table(input_file=temp_csv, table=dest_table, temp_table=True)
+    ms.csv_to_table(input_file=temp_csv, table=f'{dest_table}', temp_table=True)
 
     _df = pd.read_csv(temp_csv)
     if 'WKT' in _df.columns:

--- a/pysqldb3/pysqldb3.py
+++ b/pysqldb3/pysqldb3.py
@@ -996,7 +996,7 @@ class DbConnect:
         elif temp_table and self.type==MS:
             t = ''
             # setting as global temp - if we want private temps will need additional parmeters
-            table_schema = f"##{table}"
+            table_schema = f"[##{table}]"
         else:
             t = ''
             table_schema = f"{schema}.{table}"
@@ -1044,7 +1044,7 @@ class DbConnect:
             schema_table = table
         elif temp_table and self.type==MS:
             # setting as global temp - if we want private temps will need additional parmeters
-            schema_table = f"##{table}"
+            schema_table = f"[##{table}]"
         else:
             schema_table = f"{schema}.{table}"
 

--- a/pysqldb3/pysqldb3.py
+++ b/pysqldb3/pysqldb3.py
@@ -1001,7 +1001,7 @@ class DbConnect:
             t = ''
             table_schema = f"{schema}.{table}"
         qry = f"""
-                CREATE {t} TABLE {table_schema} (
+                CREATE {t} TABLE "{table_schema}" (
                 {str(['"' + str(i[0]) + '" ' + i[1] for i in input_schema])[1:-1].replace("'", "")}
                 )
         """
@@ -1041,7 +1041,7 @@ class DbConnect:
         # Insert data
         print('Reading data into Database\n')
         if temp_table and self.type==PG:
-            schema_table = table
+            schema_table = f'"{table}"'
         elif temp_table and self.type==MS:
             # setting as global temp - if we want private temps will need additional parmeters
             schema_table = f"[##{table}]"
@@ -1102,7 +1102,7 @@ class DbConnect:
         if not table:
             table = os.path.basename(input_file).split('.')[0]
 
-        if not overwrite and self.table_exists(schema=schema, table=table) and not temp_table:
+        if not overwrite and self.table_exists(schema=schema, table=f'"{table}"') and not temp_table:
             print('Must set overwrite=True; table already exists.')
             return
 

--- a/pysqldb3/pysqldb3.py
+++ b/pysqldb3/pysqldb3.py
@@ -992,7 +992,7 @@ class DbConnect:
         # Create table in database
         if temp_table and self.type==PG:
             t='temporary'
-            table_schema = table
+            table_schema = f'"{table}"'
         elif temp_table and self.type==MS:
             t = ''
             # setting as global temp - if we want private temps will need additional parmeters
@@ -1001,7 +1001,7 @@ class DbConnect:
             t = ''
             table_schema = f"{schema}.{table}"
         qry = f"""
-                CREATE {t} TABLE "{table_schema}" (
+                CREATE {t} TABLE {table_schema} (
                 {str(['"' + str(i[0]) + '" ' + i[1] for i in input_schema])[1:-1].replace("'", "")}
                 )
         """

--- a/pysqldb3/tests/test_io.py
+++ b/pysqldb3/tests/test_io.py
@@ -2367,47 +2367,46 @@ class TestPgToPgQryTemp:
         db.drop_table(schema=pg_schema, table=test_io_table_funky_name)
 
 
-    # def test_pg_to_sql_qry_basic_with_comments_table_temp(self):
-    #
-    #     """
-    #     Copy a query full of text comments from Postgres to an output table in SQL.
-    #     """
-    #
-    #     # assert that output table dropped
-    #     sql.query(f"""
-    #                 IF OBJECT_ID(N'tempdb..##{test_pg_to_sql_qry_table}', N'U') IS NOT NULL
-    #                 DROP TABLE ##{test_pg_to_sql_qry_table};
-    #             """)
-    #
-    #     # run pg_to_sql_qry
-    #     data_io.pg_to_sql_qry_temp_tbl(db, sql, query=f"""
-    #                             -- testing out comments
-    #                             select id, test_col1, test_col2 from /* what if there are comments here too */
-    #                             {pg_schema}.{pg_table_name} -- table name
-    #                             order by test_col1
-    #                             -- another comment
-    #                             limit 10; -- limit to 10 rows
-    #                             """,
-    #                                    dest_table=test_pg_to_sql_qry_table)
-    #
-    #     # Assert df equality
-    #     pg_df = db.dfquery(f"""
-    #     select id, test_col1, test_col2 from {pg_schema}.{pg_table_name}
-    #     order by test_col1
-    #     limit 10
-    #     """).infer_objects().replace(r'\s+', '', regex=True)
-    #
-    #     # hardcoded the columns because they go in a different order when uploaded
-    #     sql_df = sql.dfquery(f"""
-    #     select id, test_col1, test_col2 from ##{test_pg_to_sql_qry_table}
-    #     order by test_col1
-    #     """).infer_objects().replace(r'\s+', '', regex=True)
-    #
-    #     # Assert that dataframes are equal
-    #     pd.testing.assert_frame_equal(pg_df, sql_df,
-    #                                 check_dtype=False,
-    #                                   check_column_type=False)
-    #
+    def test_pg_to_pg_qry_basic_with_comments_table_temp(self):
+        """
+        Copy a query full of text comments from Postgres to an output table in SQL.
+        """
+
+        # assert that output table dropped
+        ris.query(f"""
+                    DROP TABLE IF EXISTS {test_pg_to_pg_qry_table};
+                """)
+
+        # run pg_to_sql_qry
+        data_io.pg_to_pg_qry_temp_tbl(db, ris, query=f"""
+                                -- testing out comments
+                                select id, test_col1, test_col2 from /* what if there are comments here too */
+                                {pg_schema}.{pg_table_name} -- table name
+                                order by test_col1
+                                -- another comment
+                                limit 10; -- limit to 10 rows
+                                """,
+                                       dest_table=test_pg_to_pg_qry_table)
+
+        # Assert df equality
+        pg_df = db.dfquery(f"""
+        select id, test_col1, test_col2 from {pg_schema}.{pg_table_name}
+        order by test_col1
+        limit 10
+        """).infer_objects().replace(r'\s+', '', regex=True)
+
+        # hardcoded the columns because they go in a different order when uploaded
+        pg_df2 = ris.dfquery(f"""
+        select id, test_col1, test_col2 from {test_pg_to_pg_qry_table}
+        order by test_col1
+        """).infer_objects().replace(r'\s+', '', regex=True)
+
+        # Assert that dataframes are equal
+        pd.testing.assert_frame_equal(pg_df, pg_df2,
+                                    check_dtype=False,
+                                      check_column_type=False)
+
+
     # def test_pg_to_sql_qry_spatial(self):
     #
     #     """

--- a/pysqldb3/tests/test_io.py
+++ b/pysqldb3/tests/test_io.py
@@ -2320,53 +2320,53 @@ class TestPgToPgQryTemp:
         # Cleanup
         db.drop_table(schema=pg_schema, table=test_pg_to_pg_qry_table)
 
-    # def test_pg_to_pg_qry_basic_table_temp_funky_name(self):
-    #
-    #     """
-    #     Copy a query from Postgres to an output table in PG
-    #     """
-    #
-    #     # drop output tables if they exist
-    #     db.drop_table(schema=pg_schema, table=test_io_table_funky_name)
-    #     assert not db.table_exists(schema = pg_schema, table = test_io_table_funky_name)
-    #     sql.query(f"""
-    #         IF OBJECT_ID(N'tempdb..##{test_pg_to_sql_qry_table}', N'U') IS NOT NULL
-    #         DROP TABLE ##{test_pg_to_sql_qry_table};
-    #     """)
-    #
-    #     # create pg table
-    #     db.query(f"""
-    #                 create table {pg_schema}.{test_pg_to_sql_qry_table} (test_col1 int, test_col2 int);
-    #                 insert into {pg_schema}.{test_pg_to_sql_qry_table} VALUES(1, 2);
-    #                 insert into {pg_schema}.{test_pg_to_sql_qry_table} VALUES(3, 4);
-    #     """)
-    #
-    #     # run pg_to_sql_qry
-    #     data_io.pg_to_sql_qry_temp_tbl(db, sql, query=
-    #                          f"""
-    #                          select test_col1, test_col2 from {pg_schema}.{test_pg_to_sql_qry_table}
-    #                          """,
-    #                          dest_table=test_pg_to_sql_qry_table)
-    #
-    #     # Assert df equality
-    #     pg_df = db.dfquery(f"""
-    #     select test_col1, test_col2 from {pg_schema}.{test_pg_to_sql_qry_table}
-    #     order by test_col1
-    #     """).infer_objects().replace(r'\s+', '', regex=True)
-    #
-    #     sql_df = sql.dfquery(f"""
-    #     select test_col1, test_col2 from ##{test_pg_to_sql_qry_table}
-    #     order by test_col1
-    #     """).infer_objects().replace(r'\s+', '', regex=True)
-    #
-    #     # Assert
-    #     pd.testing.assert_frame_equal(pg_df, sql_df,
-    #                                   check_dtype=False,
-    #                                   check_column_type=False)
-    #
-    #     # Cleanup
-    #     db.drop_table(schema=pg_schema, table=test_pg_to_sql_qry_table)
-    #
+    def test_pg_to_pg_qry_basic_table_temp_funky_name(self):
+
+        """
+        Copy a query from Postgres to an output table in PG
+        """
+
+        # drop output tables if they exist
+        db.drop_table(schema=pg_schema, table=f'"{test_io_table_funky_name}"')
+        assert not db.table_exists(schema = pg_schema, table = f'"{test_io_table_funky_name}"')
+        ris.query(f"""
+            DROP TABLE IF EXISTS "{test_io_table_funky_name}";
+        """)
+
+        # create pg table
+        db.query(f"""
+                    create table {pg_schema}."{test_io_table_funky_name}" (test_col1 int, test_col2 int);
+                    insert into {pg_schema}."{test_io_table_funky_name}" VALUES(1, 2);
+                    insert into {pg_schema}."{test_io_table_funky_name}" VALUES(3, 4);
+        """)
+
+        # run pg_to_sql_qry
+        data_io.pg_to_pg_qry_temp_tbl(db, ris, query=
+                             f"""
+                             select test_col1, test_col2 from {pg_schema}."{test_io_table_funky_name}"
+                             """,
+                             dest_table=test_io_table_funky_name)
+
+        # Assert df equality
+        pg_df = db.dfquery(f"""
+        select test_col1, test_col2 from {pg_schema}."{test_io_table_funky_name}"
+        order by test_col1
+        """).infer_objects().replace(r'\s+', '', regex=True)
+
+        pg_df2 = ris.dfquery(f"""
+        select test_col1, test_col2 from "{test_io_table_funky_name}"
+        order by test_col1
+        """).infer_objects().replace(r'\s+', '', regex=True)
+
+        # Assert
+        pd.testing.assert_frame_equal(pg_df, pg_df2,
+                                      check_dtype=False,
+                                      check_column_type=False)
+
+        # Cleanup
+        db.drop_table(schema=pg_schema, table=test_io_table_funky_name)
+
+
     # def test_pg_to_sql_qry_basic_with_comments_table_temp(self):
     #
     #     """


### PR DESCRIPTION
Fix for db to db temp table that allows for `[Table names Like This]` or `"123Table like this"`