### PR TITLE
Simplify long fields

### DIFF
--- a/pysqldb3/pysqldb3.py
+++ b/pysqldb3/pysqldb3.py
@@ -981,7 +981,11 @@ class DbConnect:
             #clean col_name to check against overrides and insert
             col_name=clean_column(col_name)
 
-            if column_type_overrides and col_name in column_type_overrides.keys():
+            if column_type_overrides == 'all':
+                col_type = f'varchar ({VARCHAR_MAX[self.type]})'
+                input_schema.append([col_name, col_type])
+
+            elif column_type_overrides and col_name in column_type_overrides.keys():
                 input_schema.append([col_name, column_type_overrides[col_name]])
             else:
                 input_schema.append([col_name, col_type])

--- a/pysqldb3/pysqldb3.py
+++ b/pysqldb3/pysqldb3.py
@@ -1112,7 +1112,6 @@ class DbConnect:
 
         # Use pandas to get existing data and schema
         # Check for varchar columns > 500 in length
-
         if os.path.getsize(input_file) > 1000000 and not temp_table:
             data = pd.read_csv(input_file, iterator=True, chunksize=10 ** 15, sep=sep, **kwargs)
             df = data.get_chunk(1000)
@@ -1576,7 +1575,7 @@ class DbConnect:
 
 
     def xls_to_table(self, input_file=None, sheet_name=0, overwrite=False, schema=None, table=None, temp=True,
-                     column_type_overrides=None, days=7, temp_table=False, **kwargs):
+                     alow_max_varchar=False, column_type_overrides=None, days=7, temp_table=False, **kwargs):
         """
         Imports xls/x file to database. This uses pandas datatypes to generate the table schema.
         :param input_file: File path to csv file; if None, prompts user input
@@ -1585,6 +1584,7 @@ class DbConnect:
         :param schema: Schema of table; if None, defaults to db's default schema
         :param table: Name for final database table; defaults to filename in path
         :param temp: Boolean for temporary table; defaults to True
+        :param alow_max_varchar: Boolean to allow unlimited/max varchar columns; defaults to False
         :param column_type_overrides: Dict of type key=column name, value=column type. Will manually set the
         raw column name as that type in the query, regardless of the pandas/postgres/sql server automatic
         detection.
@@ -1667,6 +1667,7 @@ class DbConnect:
                     raise AssertionError('Bulk file loading failed.'.format(schema, table))
             else:
                 self.dataframe_to_table(df, table, schema=schema, overwrite=overwrite, temp=temp,
+                                        allow_max_varchar=alow_max_varchar,
                                         column_type_overrides=column_type_overrides, days=days,
                                         temp_table=temp_table)
         except Exception as e:

--- a/pysqldb3/pysqldb3.py
+++ b/pysqldb3/pysqldb3.py
@@ -1093,9 +1093,8 @@ class DbConnect:
         def contains_long_columns(df2):
             long_cols = []
             for c in list(df2.columns):
-                if df2[c].dtype in ('O','object', 'str'):
-                    if df2[c].apply(lambda x: len(str(x)) if x else 0).max() > 500:
-                        long_cols.append(c)
+                if df2[c].dtype in ('O','object', 'str') and df2[c].apply(lambda x: len(str(x)) if x else 0).max() > 500:
+                    long_cols.append(c)
             if long_cols:
                 print(f'Varchar column with length greater than 500 found; allowing max varchar length.\n{long_cols}')
             return long_cols

--- a/pysqldb3/pysqldb3.py
+++ b/pysqldb3/pysqldb3.py
@@ -948,9 +948,9 @@ class DbConnect:
         :param overwrite: If table exists in database will overwrite if True (defaults to False)
         :param temp: Optional flag to make table as not-temporary (defaults to True)
         :param allow_max_varchar: Boolean to allow unlimited/max varchar columns; defaults to False
-        :param column_type_overrides: Dict of type key=column name, value=column type. Will manually set the
+        :param column_type_overrides: 'all' or Dict of type key=column name, value=column type. Will manually set the
                 raw column name as that type in the query, regardless of the pandas/postgres/sql server automatic
-                detection.
+                detection. If 'all' is provided, all fields will be set to varchar(max).
         :param days: if temp=True, the number of days that the temp table will be kept. Defaults to 7.
         :param temp_table: if True, the table made from the dataframe will be a temporary table
         :return: Table schema that was created from DataFrame
@@ -1024,9 +1024,10 @@ class DbConnect:
         :param overwrite: If table exists in database will overwrite if True (defaults to False)
         :param temp: Optional flag to make table temporary (defaults to True)
         :param allow_max_varchar: Boolean to allow unlimited/max varchar columns; defaults to False
-        :param column_type_overrides: Dict of type key=column name, value=column type. Will manually set the
+        :param column_type_overrides: 'all' or Dict of type key=column name, value=column type. Will manually set the
                 raw column name as that type in the query, regardless of the pandas/postgres/sql server automatic
                 detection. **Will not override a custom table_schema, if inputted**
+                If 'all' is provided, all fields will be set to varchar(max).
         :param days: if temp=True and table schema needs to be created, the number of days that the temp table will be
                      kept. Defaults to 7.
         :param temp_table: if True, dataframe created as a temporary table, which will be lost when db connection is closed
@@ -1069,7 +1070,7 @@ class DbConnect:
         print(f'\n{df.cnt.values[0]} rows added to {schema_table}\n')
 
     def csv_to_table(self, input_file=None, overwrite=False, schema=None, table=None, temp=True, sep=',',
-                     alow_max_varchar=False, column_type_overrides=None, days=7, temp_table=False,
+                     allow_max_varchar=False, column_type_overrides=None, days=7, temp_table=False,
                      **kwargs):
         """
         Imports csv file to database. This uses pandas datatypes to generate the table schema.
@@ -1079,8 +1080,10 @@ class DbConnect:
         :param table: Name for final database table; defaults to filename in path
         :param temp: Boolean for temporary table; defaults to True
         :param sep: Separator for csv file, defaults to comma (,)
-        :param alow_max_varchar: Boolean to allow unlimited/max varchar columns; defaults to False
-        :param column_type_overrides: Dict of type key=column name, value=column type. Will manually set the raw column name as that type in the query, regardless of the pandas/postgres/sql server automatic detection. **Will not override a custom table_schema, if inputted**
+        :param allow_max_varchar: Boolean to allow unlimited/max varchar columns; defaults to False
+        :param column_type_overrides: Dict of type key=column name, value=column type.
+        Will manually set the raw column name as that type in the query, regardless of the pandas/postgres/sql server
+        automatic detection. **Will not override a custom table_schema, if inputted**
         :param days: if temp=True, the number of days that the temp table will be kept. Defaults to 7.
         :param temp_table: if True, Uploads csv to temporary table, which will be lost when db connection is closed
         :param **kwargs: parameters to pass to pandas for read csv (ex. skiprows=1)
@@ -1117,7 +1120,7 @@ class DbConnect:
             df = data.get_chunk(1000)
         else:
             df = pd.read_csv(input_file, sep=sep, **kwargs)
-        allow_max = alow_max_varchar or contains_long_columns(df)
+        allow_max = allow_max_varchar or contains_long_columns(df)
 
         if 'ogc_fid' in df.columns:
             df = df.drop('ogc_fid', 1)
@@ -1575,7 +1578,7 @@ class DbConnect:
 
 
     def xls_to_table(self, input_file=None, sheet_name=0, overwrite=False, schema=None, table=None, temp=True,
-                     alow_max_varchar=False, column_type_overrides=None, days=7, temp_table=False, **kwargs):
+                     allow_max_varchar=False, column_type_overrides=None, days=7, temp_table=False, **kwargs):
         """
         Imports xls/x file to database. This uses pandas datatypes to generate the table schema.
         :param input_file: File path to csv file; if None, prompts user input
@@ -1584,7 +1587,7 @@ class DbConnect:
         :param schema: Schema of table; if None, defaults to db's default schema
         :param table: Name for final database table; defaults to filename in path
         :param temp: Boolean for temporary table; defaults to True
-        :param alow_max_varchar: Boolean to allow unlimited/max varchar columns; defaults to False
+        :param allow_max_varchar: Boolean to allow unlimited/max varchar columns; defaults to False
         :param column_type_overrides: Dict of type key=column name, value=column type. Will manually set the
         raw column name as that type in the query, regardless of the pandas/postgres/sql server automatic
         detection.
@@ -1645,7 +1648,8 @@ class DbConnect:
                                                                   overwrite=overwrite,
                                                                   temp=temp,
                                                                   column_type_overrides=column_type_overrides,
-                                                                  days=days)
+                                                                  days=days,
+                                                                  allow_max_varchar=allow_max_varchar)
                     temp_file = os.path.dirname(
                         input_file) + '\\'f'_temp_data_{datetime.datetime.now().strftime("%Y%m%d%H%M%S")}.csv'
                     df.to_csv(temp_file, index=False, header=True)
@@ -1667,7 +1671,7 @@ class DbConnect:
                     raise AssertionError('Bulk file loading failed.'.format(schema, table))
             else:
                 self.dataframe_to_table(df, table, schema=schema, overwrite=overwrite, temp=temp,
-                                        allow_max_varchar=alow_max_varchar,
+                                        allow_max_varchar=allow_max_varchar,
                                         column_type_overrides=column_type_overrides, days=days,
                                         temp_table=temp_table)
         except Exception as e:

--- a/pysqldb3/tests/test_csv_to_table.py
+++ b/pysqldb3/tests/test_csv_to_table.py
@@ -374,7 +374,7 @@ class TestCsvToTablePG:
         base_string = 'text'*150
         fp = helpers.DIR + "\\varchar.csv"
         db.dfquery("select '{}' as long_col".format(base_string)).to_csv(fp, index=False)
-        db.csv_to_table(input_file=fp, table=create_table_name, schema=pg_schema, long_varchar_check=True)
+        db.csv_to_table(input_file=fp, table=create_table_name, schema=pg_schema, alow_max_varchar=True)
 
         # Check to see if table is in database
         assert db.table_exists(table=create_table_name, schema=pg_schema)
@@ -526,7 +526,7 @@ class TestBulkCSVToTablePG:
 
         fp = helpers.DIR + "\\varchar.csv"
         pd.DataFrame(['text'*150]*10000, columns=['long_column']).to_csv(fp)
-        db.csv_to_table(input_file=fp, table=create_table_name, schema=pg_schema, long_varchar_check=True)
+        db.csv_to_table(input_file=fp, table=create_table_name, schema=pg_schema, alow_max_varchar=True)
 
         # Check to see if table is in database
         assert db.table_exists(table=create_table_name, schema=pg_schema)
@@ -900,7 +900,7 @@ class TestCsvToTableMS:
         base_string = 'text'*150
         fp = helpers.DIR + "\\varchar.csv"
         sql.dfquery("select '{}' as long_col".format(base_string)).to_csv(fp, index=False)
-        sql.csv_to_table(input_file=fp, table=create_table_name, schema=sql_schema, long_varchar_check=True)
+        sql.csv_to_table(input_file=fp, table=create_table_name, schema=sql_schema, alow_max_varchar=True)
 
         # Check to see if table is in database
         assert sql.table_exists(table=create_table_name, schema=sql_schema)
@@ -1052,7 +1052,7 @@ class TestBulkCSVToTableMS:
 
         fp = helpers.DIR + "\\varchar.csv"
         pd.DataFrame(['text'*150]*10000, columns=['long_column']).to_csv(fp)
-        sql.csv_to_table(input_file=fp, table=create_table_name, schema=sql_schema, long_varchar_check=True)
+        sql.csv_to_table(input_file=fp, table=create_table_name, schema=sql_schema, alow_max_varchar=True)
 
         # Check to see if table is in database
         assert sql.table_exists(table=create_table_name, schema=sql_schema)

--- a/pysqldb3/tests/test_csv_to_table.py
+++ b/pysqldb3/tests/test_csv_to_table.py
@@ -68,7 +68,6 @@ class TestCsvToTablePG:
 
         # Check to see if table is in database
         assert db.table_exists(table=create_table_name, schema=pg_schema)
-        db_df = db.dfquery("select * from {}.{}".format(pg_schema, create_table_name))
 
         # check table schema
         db.get_table_columns(create_table_name, schema=pg_schema)

--- a/pysqldb3/tests/test_csv_to_table.py
+++ b/pysqldb3/tests/test_csv_to_table.py
@@ -392,7 +392,7 @@ class TestCsvToTablePG:
         base_string = 'text'*150
         fp = helpers.DIR + "\\varchar.csv"
         db.dfquery("select '{}' as long_col".format(base_string)).to_csv(fp, index=False)
-        db.csv_to_table(input_file=fp, table=create_table_name, schema=pg_schema, alow_max_varchar=True)
+        db.csv_to_table(input_file=fp, table=create_table_name, schema=pg_schema, allow_max_varchar=True)
 
         # Check to see if table is in database
         assert db.table_exists(table=create_table_name, schema=pg_schema)
@@ -544,7 +544,7 @@ class TestBulkCSVToTablePG:
 
         fp = helpers.DIR + "\\varchar.csv"
         pd.DataFrame(['text'*150]*10000, columns=['long_column']).to_csv(fp)
-        db.csv_to_table(input_file=fp, table=create_table_name, schema=pg_schema, alow_max_varchar=True)
+        db.csv_to_table(input_file=fp, table=create_table_name, schema=pg_schema, allow_max_varchar=True)
 
         # Check to see if table is in database
         assert db.table_exists(table=create_table_name, schema=pg_schema)
@@ -937,7 +937,7 @@ class TestCsvToTableMS:
         base_string = 'text'*150
         fp = helpers.DIR + "\\varchar.csv"
         sql.dfquery("select '{}' as long_col".format(base_string)).to_csv(fp, index=False)
-        sql.csv_to_table(input_file=fp, table=create_table_name, schema=sql_schema, alow_max_varchar=True)
+        sql.csv_to_table(input_file=fp, table=create_table_name, schema=sql_schema, allow_max_varchar=True)
 
         # Check to see if table is in database
         assert sql.table_exists(table=create_table_name, schema=sql_schema)
@@ -1089,7 +1089,7 @@ class TestBulkCSVToTableMS:
 
         fp = helpers.DIR + "\\varchar.csv"
         pd.DataFrame(['text'*150]*10000, columns=['long_column']).to_csv(fp)
-        sql.csv_to_table(input_file=fp, table=create_table_name, schema=sql_schema, alow_max_varchar=True)
+        sql.csv_to_table(input_file=fp, table=create_table_name, schema=sql_schema, allow_max_varchar=True)
 
         # Check to see if table is in database
         assert sql.table_exists(table=create_table_name, schema=sql_schema)

--- a/pysqldb3/tests/test_data_no_folder/_testing_table_to_csv_2025_04_21_shostetter_.csv
+++ b/pysqldb3/tests/test_data_no_folder/_testing_table_to_csv_2025_04_21_shostetter_.csv
@@ -1,4 +1,0 @@
-WKT,objectid,nd,street1
-,"1","2",Mulberry
-,"2","3",Canal
-,"3","4",Fifth Ave.

--- a/pysqldb3/tests/test_data_no_folder/_testing_table_to_csv_2025_04_21_shostetter_.csv
+++ b/pysqldb3/tests/test_data_no_folder/_testing_table_to_csv_2025_04_21_shostetter_.csv
@@ -1,0 +1,4 @@
+WKT,objectid,nd,street1
+,"1","2",Mulberry
+,"2","3",Canal
+,"3","4",Fifth Ave.


### PR DESCRIPTION
- Adds override all column types option (useful for large messy tables with many data type errors) 
- prints long columns in error 