### PR TITLE
Fix get_table_columns

### DIFF
--- a/pysqldb3/pysqldb3.py
+++ b/pysqldb3/pysqldb3.py
@@ -11,6 +11,7 @@ import os
 from .Config import write_config
 import pyarrow.csv as pyarrowcsv
 import numpy as np
+import datetime
 
 write_config(confi_path=os.path.dirname(os.path.abspath(__file__)) + "\\config.cfg")
 config = configparser.ConfigParser()
@@ -749,14 +750,41 @@ class DbConnect:
 
         return [schema_row[0] for schema_row in self.__get_most_recent_query_data(internal=True)]
 
-    def get_table_columns(self, table, schema=None, full=False):
+    def get_table_columns(self, table_or_query, is_query = False, schema=None, full=False):
+        
         if not schema:
             schema = self.default_schema
+
+        if is_query:
+            # check if allow_temp_tables is on if a query is being used. if not, turn it on
+            initial_temp_status = self.allow_temp_tables 
+            self.allow_temp_tables = True
+            # Makes a temp table name
+            tmp_table_name = f"tmp_get_tbl_columns_{self.user}_{str(datetime.datetime.now())[:16].replace('-', '_').replace(' ', '_').replace(':', '')}"
+
+        # Drop the temp table if it already exists and create new temp table
+            if self.type == PG:
+                self.query(f"drop table if exists {tmp_table_name}", internal=True, strict=False)
+                self.query(f"""    
+                            create temp table {tmp_table_name} as     
+                            select * 
+                            from ({table_or_query}) q 
+                            limit 10
+                            """, internal=True)
+            elif self.type == MS:
+                self.query(f"drop table if exists #{tmp_table_name}", internal=True, strict=False)
+                self.query(f"""        
+                            select top 10 * 
+                            into #{tmp_table_name}
+                            from ({table_or_query}) q 
+                            """, internal=True)
+
+        
+        # if full columns or select columns are requested
         if full:
             columns = '*'
         else:
             if self.type == PG:
-
                 columns = """
                 column_name, case when CHARACTER_MAXIMUM_LENGTH is not null then 
                       DATA_TYPE || ' ('|| cast(CHARACTER_MAXIMUM_LENGTH as varchar) ||')'
@@ -765,39 +793,79 @@ class DbConnect:
                       else DATA_TYPE end as DATA_TYPE
                       """
             else:
+                # MS
                 columns = """
-                    column_name, case 
-                       when DATA_TYPE = 'text' then DATA_TYPE
+                    column_name, case when DATA_TYPE = 'text' then DATA_TYPE
                     when CHARACTER_MAXIMUM_LENGTH is not null 
-                    then DATA_TYPE + ' ('+ cast(CHARACTER_MAXIMUM_LENGTH as varchar)+')' 
+                    then DATA_TYPE + ' ('+ cast(CHARACTER_MAXIMUM_LENGTH as varchar) +')' 
                     when CHARACTER_MAXIMUM_LENGTH >= 3000 then DATA_TYPE + ' (3000)' 
                           else DATA_TYPE end as DATA_TYPE
                       """
 
+        # query the columns
         if self.type == PG:
-            self.query(f"""
-            with t as (
-                select *, 
-                udt_name::regtype array_type 
-                FROM information_schema.columns
-                WHERE table_schema = '{schema}' 
-                AND table_name = '{table}'
-            )
-            SELECT {columns}
-            FROM t
-            ORDER BY ordinal_position;
-            """, timeme=False, internal=True)
+             
+            if is_query == True:
+                 # if it's a query, it uses a temp table and does not need a schema
+                 where_table_schema = ""
+                 information_schema_table = tmp_table_name
+            else:
+                where_table_schema = f"table_schema = '{schema}' AND "
+                information_schema_table = table_or_query
 
-        if self.type == MS:
             self.query(f"""
-            SELECT {columns}
-            FROM INFORMATION_SCHEMA.COLUMNS
-            WHERE table_schema = '{schema}' 
-                AND table_name = '{table}'
+                        with t as (
+                            select *, 
+                            udt_name::regtype array_type 
+                            FROM information_schema.columns
+                            where {where_table_schema}
+                            table_name = '{information_schema_table}'
+                        )
+                        SELECT {columns}
+                        FROM t
+                        ORDER BY ordinal_position;
+                        """, timeme=False, internal=True)
+
+        elif self.type == MS and not is_query:
+            self.query(f"""
+                SELECT {columns}
+                FROM INFORMATION_SCHEMA.COLUMNS
+                WHERE table_schema = '{schema}' 
+                AND table_name = '{table_or_query}'
             ORDER BY ORDINAL_POSITION;
             """, timeme=False, internal=True)
 
-        return self.__get_most_recent_query_data(internal=True)
+        elif self.type == MS and is_query:
+            
+            # querying the temp table is very different in MS
+            self.query(f"""
+                SELECT
+                    c.name as column_name, 
+                    case    when t.name in ('text', 'int', 'date') then t.name
+                            when t.max_length is not null and t.max_length < 3000 then t.name + ' ('+ cast(t.max_length as varchar)+')'  
+                            when t.max_length >= 3000 then t.name + ' (3000)'
+                       else t.name
+                       end as DATA_TYPE
+                FROM
+                    tempdb.sys.columns AS c
+                LEFT JOIN
+                    tempdb.sys.types AS t
+                ON
+                    c.system_type_id = t.system_type_id
+                    AND
+                    t.system_type_id = t.user_type_id
+                WHERE
+                    [object_id] = OBJECT_ID(N'tempdb.dbo.#{tmp_table_name}')
+                """, internal=True)
+
+        # this is the desired output for a table input
+        results = self.__get_most_recent_query_data(internal=True)
+
+        # revert to the original state if allow_temp_tables was set to False
+        if is_query:
+            self.allow_temp_tables = initial_temp_status
+
+        return results
 
     def query(self, query, strict=True, permission=True, temp=True, timeme=True, no_comment=False, comment='',
               lock_table=None, return_df=False, days=7, internal=False, no_print_out=False):

--- a/pysqldb3/tests/test_get_column_types.py
+++ b/pysqldb3/tests/test_get_column_types.py
@@ -78,6 +78,34 @@ def test_column_types_array_pg():
 
     db.query(f"drop table if exists {pg_schema}.{table_name}")
 
+
+def test_query_and_table_same_result_pg():
+
+    # create table
+    db.query(f"drop table if exists {pg_schema}.{table_name}")
+    db.query(f"""
+        create table {pg_schema}.{table_name} (
+            id int,
+            name_ varchar(27),
+            list_ varchar[],
+            list2_ int[],
+            dte date);
+
+        insert into {pg_schema}.{table_name} values (1, 'lala', array['a', 'b'], array[54, 77], '2019-01-01');
+
+    """)
+    assert db.table_exists(table_name, schema=pg_schema)
+    cols = db.get_table_columns(table_name, schema=pg_schema)
+
+    # create query
+    query_for_testing = f"select id, name_, list_, list2_, dte from {pg_schema}.{table_name}"
+    query_cols = db.get_table_columns(query_for_testing, is_query = True, schema = pg_schema)
+
+    # assert that they're equal
+    assert cols == query_cols
+    # clean tables
+    db.drop_table(schema = pg_schema, table = table_name)
+
 def test_column_types_basic_ms():
     sql.drop_table(sql_schema, table_name)
     sql.query(f"""
@@ -110,6 +138,33 @@ def test_column_types_basic_funcy_names_ms():
     assert cols == [('123id', 'int'), ('nam e_', 'varchar (27)'), ('dte', 'date')]
 
     sql.drop_table(sql_schema, table_name)
+
+def test_query_and_table_same_result_ms():
+
+  # create table
+    sql.query(f"drop table if exists {sql_schema}.{table_name}")
+    sql.query(f"""
+         create table {sql_schema}.{table_name} (
+            "123id" int,
+            [nam e_] varchar(27),
+            dte date );
+
+    """)
+    assert sql.table_exists(table_name, schema=sql_schema)
+    cols = sql.get_table_columns(table_name, schema=sql_schema)
+
+    # create query and assert that it matches the table's columns
+    query_for_testing = f'select "123id", dte from {sql_schema}.{table_name}'
+    query_cols = sql.get_table_columns(query_for_testing, is_query = True, schema = sql_schema)
+    assert [cols[0], cols[2]] == query_cols # assert that all columns but varchar are equal
+
+    # assert that varchar datatype has max limit that we set for undefined
+    varchar_query_for_testing = f'select [nam e_] from {sql_schema}.{table_name}'
+    query_varchar_cols = sql.get_table_columns(varchar_query_for_testing, is_query = True, schema = sql_schema)
+    assert query_varchar_cols == [('nam e_', 'varchar (3000)')]
+
+    # clean tables
+    sql.drop_table(schema = sql_schema, table = table_name)
 
 # no array type in sql
 # def test_column_types_array_ms():


### PR DESCRIPTION
Changes to `pysqldb3.py` and `test_get_column_types.py` to retrieve table columns based on both a table AND a query. This is part of changes to ultimately simplify the `write_geospatial()` function when either a query or a table is an input.