### PR TITLE
Geospatial new tests dtypes

### DIFF
--- a/pysqldb3/geospatial.py
+++ b/pysqldb3/geospatial.py
@@ -109,8 +109,7 @@ def write_geo_cmd_query(dbo, query_or_table, is_query = False, schema = ''):
     columns_with_brackets = [left_bracket + c[0] + right_bracket for c in columns_with_types]
 
     # identify date columns if they are in the intended output
-    dt_col_names = [c for c in columns_with_types if c[1] is not None] ## TODO - what is this doing/is it needed?
-    dt_col_names = [c[0] for c in dt_col_names if (('datetime' in c[1]) | ('timestamp' in c[1]))] # after, check if there is datetime / timestamp
+    dt_col_names = [c[0] for c in columns_with_types if (('datetime' in c[1]) | ('timestamp' in c[1]))] # after, check if there is datetime / timestamp
 
     # if there are no date columns, we can query immediately
     if len(dt_col_names) == 0:

--- a/pysqldb3/geospatial.py
+++ b/pysqldb3/geospatial.py
@@ -131,7 +131,7 @@ def write_geo_cmd_query(dbo, query_or_table, is_query = False, schema = ''):
                                 col=col_name, shortened_col = shortened_col
                                 )
             elif dbo.type == MS:
-                results += " , convert(datetime, [{col}]) [{shortened_col}_dt], convert(varchar, convert(time, [{col}]))" \
+                results += " , convert(date, [{col}]) [{shortened_col}_dt], convert(varchar, convert(time, [{col}]))" \
                                 " [{shortened_col}_tm] ".format(
                                 col=col_name, shortened_col = shortened_col
                                 )

--- a/pysqldb3/geospatial.py
+++ b/pysqldb3/geospatial.py
@@ -131,7 +131,7 @@ def write_geo_cmd_query(dbo, query_or_table, is_query = False, schema = ''):
                                 col=col_name, shortened_col = shortened_col
                                 )
             elif dbo.type == MS:
-                results += " , cast([{col}] as date) [{shortened_col}_dt], cast(cast([{col}] as time) as varchar)" \
+                results += " , convert(datetime, [{col}]) [{shortened_col}_dt], convert(varchar, convert(time, [{col}]))" \
                                 " [{shortened_col}_tm] ".format(
                                 col=col_name, shortened_col = shortened_col
                                 )
@@ -221,6 +221,11 @@ def write_geospatial(dbo, path,  table = None, schema = '', query = None, gpkg_t
     
     # update allows you to add an extra table into an existing geopackage
         _update = '-update'
+        _overwrite = '' 
+
+    else: # if not overwrite and path ends with .shp instead
+
+        _update = ''
         _overwrite = ''
 
     # run the final command

--- a/pysqldb3/pysqldb3.py
+++ b/pysqldb3/pysqldb3.py
@@ -798,7 +798,7 @@ class DbConnect:
                     column_name, case when DATA_TYPE = 'text' then DATA_TYPE
                     when CHARACTER_MAXIMUM_LENGTH is not null 
                     then DATA_TYPE + ' ('+ cast(CHARACTER_MAXIMUM_LENGTH as varchar) +')' 
-                    when CHARACTER_MAXIMUM_LENGTH >= 3000 then DATA_TYPE + ' (3000)' 
+                    when CHARACTER_MAXIMUM_LENGTH >= 3000 then DATA_TYPE + ' (3000)'
                           else DATA_TYPE end as DATA_TYPE
                       """
 
@@ -844,7 +844,7 @@ class DbConnect:
                     case    when t.name in ('text', 'int', 'date') then t.name
                             when t.max_length is not null and t.max_length < 3000 then t.name + ' ('+ cast(t.max_length as varchar)+')'  
                             when t.max_length >= 3000 then t.name + ' (3000)'
-                       else t.name
+                       else coalesce(t.name, 'Unknown')
                        end as DATA_TYPE
                 FROM
                     tempdb.sys.columns AS c

--- a/pysqldb3/tests/helpers.py
+++ b/pysqldb3/tests/helpers.py
@@ -505,6 +505,7 @@ def identify_default_dtypes(db, sql, ms_schema = ''):
 
     """
     Identify default data types in PostgreSQL and MS SQL Servers for integer, varchar, and geometry.
+    This was created to address "USER-DEFINED" data types or variations in data type names.
     :param db: Database connection
     :param ms_schema: SQL Server schema
     """

--- a/pysqldb3/tests/helpers.py
+++ b/pysqldb3/tests/helpers.py
@@ -546,6 +546,6 @@ def identify_default_dtypes(db, sql, ms_schema = ''):
 
     # drop the tables
     db.query("drop table if exists test_default_types;")
-    sql.drop_table(schema = 'working', table = 'test_default_dtypes')
+    sql.drop_table(schema = ms_schema, table = 'test_default_dtypes')
 
     return db_int, db_geom, sql_int, sql_geom

--- a/pysqldb3/tests/helpers.py
+++ b/pysqldb3/tests/helpers.py
@@ -501,7 +501,7 @@ def clean_up_geopackage():
     print ('Deleting any existing gpkg')
 
 
-def identify_default_dtypes(db, sql, ms_schema = ''):
+def identify_default_dtypes(db, schema = 'working'):
 
     """
     Identify default data types in PostgreSQL and MS SQL Servers for integer, varchar, and geometry.
@@ -509,44 +509,22 @@ def identify_default_dtypes(db, sql, ms_schema = ''):
     :param db: Database connection
     :param ms_schema: SQL Server schema
     """
+    db.query(f"""
     
-    ### POSTGRESQL ###
-
-    data_types_db = db.dfquery("""
+        drop table if exists {schema}.test_default_dtypes;                               
+        create table {schema}.test_default_dtypes(int_col int, geom geometry);
+        insert into {schema}.test_default_dtypes
+            VALUES(1, {"geometry::STGeomFromText('POINT(1015329.1 213793.1)', 2263)" 
+                       if db.type == 'MS'
+                       else "st_setsrid(st_point(1015329.1, 213793.1), 2263)::geometry"});
+        """)
     
-        drop table if exists test_default_dtypes;
-                               
-        create temp table test_default_dtypes as
-        select 1 as int_col,
-        st_setsrid(st_point(1015329.1, 213793.1), 2263)::geometry as geom;
+    data_types = db.get_table_columns('test_default_dtypes', schema = schema)
 
-	    select column_name, data_type
-        FROM information_schema.columns
-        WHERE table_name = 'test_default_dtypes';
-        """)['data_type']
-    
-    db_int = data_types_db[0]
-    db_geom = data_types_db[1]
-
-    ### MS SQL SERVER ###
-    # not done in temp table since there is an issue with geometry dtype in SQL Server
-
-    data_types_sql = sql.dfquery(f"""
-                                 
-        drop table if exists [{ms_schema}].[test_default_dtypes];
-        create table [{ms_schema}].[test_default_dtypes] (int_col int, geom geometry);
-        insert into [{ms_schema}].[test_default_dtypes] VALUES(1, geometry::STGeomFromText('POINT(1015329.1 213793.1)', 2263));
-            
-        select * FROM INFORMATION_SCHEMA.COLUMNS
-                WHERE table_schema = '{ms_schema}' 
-                AND table_name = 'test_default_dtypes';
-                          """)['DATA_TYPE']
-    
-    sql_int = data_types_sql[0]
-    sql_geom = data_types_sql[1]
+    db_int = data_types[0][1]
+    db_geom = data_types[1][1]
 
     # drop the tables
-    db.query("drop table if exists test_default_types;")
-    sql.drop_table(schema = ms_schema, table = 'test_default_dtypes')
+    db.drop_table(schema = schema, table = 'test_default_types')
 
-    return db_int, db_geom, sql_int, sql_geom
+    return db_int, db_geom

--- a/pysqldb3/tests/helpers.py
+++ b/pysqldb3/tests/helpers.py
@@ -282,33 +282,6 @@ def clean_up_feature_class():
     # os.remove(os.path.join(fldr, gdb))
     os.rmdir(fldr)
 
-# def set_up_fc_and_shapefile():
-#     """
-#     Builds file gdb with a feature class with sample data
-#     Builds a shapefile for import
-#     :return:
-#     """
-#     fldr = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'test_data')
-#     set_up_feature_class()
-#
-#     print 'Deleting any existing shp'
-#     shp = 'test_feature_class.shp'
-#     Delete_management(os.path.join(fldr, shp))
-#
-#     print 'Building shapefile'
-#     FeatureClassToShapefile_conversion(["test_feature_class"], fldr)
-#
-#
-# def clean_up_fc_and_shapefile():
-#     fldr = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'test_data')
-#     gdb = "fGDB.gdb"
-#     shp = 'test_feature_class.shp'
-#
-#     Delete_management(os.path.join(fldr, gdb))
-#     Delete_management(os.path.join(fldr, shp))
-#     print 'Deleted ESRI sample files'
-#
-#
 def set_up_shapefile():
     data = {
         'gid': {0: 1, 1: 2},
@@ -526,3 +499,53 @@ def clean_up_geopackage():
             os.remove(_fle)
 
     print ('Deleting any existing gpkg')
+
+
+def identify_default_dtypes(db, sql, ms_schema = ''):
+
+    """
+    Identify default data types in PostgreSQL and MS SQL Servers for integer, varchar, and geometry.
+    :param db: Database connection
+    :param ms_schema: SQL Server schema
+    """
+    
+    ### POSTGRESQL ###
+
+    data_types_db = db.dfquery("""
+    
+        drop table if exists test_default_dtypes;
+                               
+        create temp table test_default_dtypes as
+        select 1 as int_col,
+        st_setsrid(st_point(1015329.1, 213793.1), 2263)::geometry as geom;
+
+	    select column_name, data_type
+        FROM information_schema.columns
+        WHERE table_name = 'test_default_dtypes';
+        """)['data_type']
+    
+    db_int = data_types_db[0]
+    db_geom = data_types_db[1]
+
+    ### MS SQL SERVER ###
+    # not done in temp table since there is an issue with geometry dtype in SQL Server
+
+    data_types_sql = sql.dfquery(f"""
+                                 
+        drop table if exists [{ms_schema}].[test_default_dtypes];
+        create table [{ms_schema}].[test_default_dtypes] (int_col int, geom geometry);
+        insert into [{ms_schema}].[test_default_dtypes] VALUES(1, geometry::STGeomFromText('POINT(1015329.1 213793.1)', 2263));
+            
+        select * FROM INFORMATION_SCHEMA.COLUMNS
+                WHERE table_schema = '{ms_schema}' 
+                AND table_name = 'test_default_dtypes';
+                          """)['DATA_TYPE']
+    
+    sql_int = data_types_sql[0]
+    sql_geom = data_types_sql[1]
+
+    # drop the tables
+    db.query("drop table if exists test_default_types;")
+    sql.drop_table(schema = 'working', table = 'test_default_dtypes')
+
+    return db_int, db_geom, sql_int, sql_geom

--- a/pysqldb3/tests/test_geospatial.py
+++ b/pysqldb3/tests/test_geospatial.py
@@ -47,7 +47,8 @@ pg_schema = 'working'
 fgdb = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'test_data/lion/lion.gdb')
 fc = 'node.shp'
 
-db_int, db_geom, sql_int, sql_geom = helpers.identify_default_dtypes(db, sql, ms_schema)
+db_int, db_geom = helpers.identify_default_dtypes(db, pg_schema)
+sql_int, sql_geom = helpers.identify_default_dtypes(sql, ms_schema)
 
 class TestReadgpkgPG:
     @classmethod
@@ -442,6 +443,7 @@ class TestReadgpkgMS:
 
 
 class TestWritegpkgPG:
+
     @classmethod
     def setup_class(cls):
         helpers.set_up_test_table_pg(db)
@@ -654,7 +656,6 @@ class TestWritegpkgPG:
         gpkg_name = 'testgpkg.gpkg'
 
         db.drop_table(schema = pg_schema, table = test_write_gpkg_table_name)
-        db.drop_table(schema = pg_schema, table = test_reuploaded_table_name)
 
         db.query(f"""
 
@@ -843,9 +844,9 @@ class TestWritegpkgMS:
 
         # Add test_table
         sql.query(f"""
-        create table {ms_schema}.{test_write_gpkg_table_name} (test_col1 int, test_col2 int, dte datetime, geom geometry);
-        insert into {ms_schema}.{test_write_gpkg_table_name} VALUES(1, 2, current_timestamp, geometry::Point(985831.79200444, 203371.60461367, 2263));
-        insert into {ms_schema}.{test_write_gpkg_table_name} VALUES(3, 4, current_timestamp, geometry::Point(985831.79200444, 203371.60461367, 2263));
+        create table {ms_schema}.{test_write_gpkg_table_name} (test_col1 int, test_col2 int, geom geometry);
+        insert into {ms_schema}.{test_write_gpkg_table_name} VALUES(1, 2, geometry::Point(985831.79200444, 203371.60461367, 2263));
+        insert into {ms_schema}.{test_write_gpkg_table_name} VALUES(3, 4, geometry::Point(985831.79200444, 203371.60461367, 2263));
         """)
 
         gpkg_name = 'test_write.gpkg'
@@ -2152,6 +2153,7 @@ class TestWriteShpPG:
         cmd_shp = f'ogrinfo -so -al "{FOLDER_PATH}/{shp_name}" '
         ogr_response_shp = subprocess.check_output(shlex.split(cmd_shp), stderr=subprocess.STDOUT)   
         assert 'dt_col_dt: Date' in str(ogr_response_shp), "'dt_col_dt column is not a Date data type when it should be"
+        assert 'dt_col: Timedate' in str(ogr_response_shp), "'dt_col column is not a Datetime data type when it should be"
 
         # clean up
         db.drop_table(schema=pg_schema, table=test_write_shp_table_name)
@@ -2371,6 +2373,7 @@ class TestWriteShpMS:
         helpers.clean_up_shapefile()
 
 class TestFeatureClassToTablePg:
+
     @classmethod
     def setup_class(cls):
         helpers.set_up_feature_class()
@@ -2543,6 +2546,7 @@ class TestFeatureClassToTablePg:
 
 
 class TestFeatureClassToTableMs:
+
     @classmethod
     def setup_class(cls):
         helpers.set_up_feature_class()
@@ -2748,6 +2752,7 @@ class TestSHPDeleteIndexPG:
 
 
 class TestSHPDeleteIndexMS:
+
     @classmethod
     def setup_class(cls):
         # Setup; create sample file

--- a/pysqldb3/tests/test_geospatial.py
+++ b/pysqldb3/tests/test_geospatial.py
@@ -653,8 +653,10 @@ class TestWritegpkgPG:
             
         gpkg_name = 'testgpkg.gpkg'
 
+        db.drop_table(schema = pg_schema, table = test_write_gpkg_table_name)
+        db.drop_table(schema = pg_schema, table = test_reuploaded_table_name)
+
         db.query(f"""
-                drop table if exists {pg_schema}.{test_write_gpkg_table_name};
 
                 create table {pg_schema}.{test_write_gpkg_table_name} as
                 select *,
@@ -665,11 +667,16 @@ class TestWritegpkgPG:
                 limit 100
                 """)
         
-        s.write_geospatial(path=os.path.join(FOLDER_PATH, gpkg_name), dbo=db, schema=pg_schema,
-                            table=test_write_gpkg_table_name)
+        s.write_geospatial(path=os.path.join(FOLDER_PATH, gpkg_name), dbo=db, schema=pg_schema, table=test_write_gpkg_table_name,
+                           gpkg_tbl = test_write_gpkg_table_name)
 
         # Assert successful
         assert os.path.isfile(os.path.join(FOLDER_PATH, gpkg_name))
+
+        # check the date columns
+        cmd_gpkg = f'ogrinfo -so -al "{FOLDER_PATH}/{gpkg_name}"'
+        ogr_response_gpkg = subprocess.check_output(shlex.split(cmd_gpkg), stderr=subprocess.STDOUT)
+        assert 'dt_col_dt: Date' in str(ogr_response_gpkg), "'dt_col_dt column is not a Date data type when it should be"
 
         # clean up
         db.drop_table(schema=pg_schema, table=test_write_gpkg_table_name)
@@ -868,13 +875,43 @@ class TestWritegpkgMS:
         # Assert before/after geom columns are all 0 ft from each other, even if represented differently
         dist_df = sql.dfquery(f"""
         select distinct b.geom.STDistance(a.geom) as distance
-        from {ms_schema}.{test_reuploaded_table_name} b
+        from {ms_schema}.{test_write_gpkg_table_name} b
         join {ms_schema}.{test_reuploaded_table_name} a
             on b.test_col1=a.test_col1
         """)
 
         assert len(dist_df) == 1
         assert dist_df.iloc[0]['distance'] == 0
+
+        # Clean up
+        os.remove(os.path.join(FOLDER_PATH, gpkg_name))
+        sql.query(f"drop table if exists {ms_schema}.{test_write_gpkg_table_name};")
+        sql.query(f"drop table if exists {ms_schema}.{test_reuploaded_table_name};")
+
+    def test_write_gpkg_dates_table(self):
+        
+        sql.drop_table(schema=ms_schema, table=test_write_gpkg_table_name)
+
+        # Add test_table
+        sql.query(f"""
+        create table {ms_schema}.{test_write_gpkg_table_name} (test_col1 int, test_col2 int, dte datetime, geom geometry);
+        insert into {ms_schema}.{test_write_gpkg_table_name} VALUES(1, 2, current_timestamp, geometry::Point(985831.79200444, 203371.60461367, 2263));
+        insert into {ms_schema}.{test_write_gpkg_table_name} VALUES(3, 4, current_timestamp, geometry::Point(985831.79200444, 203371.60461367, 2263));
+        """)
+
+        gpkg_name = 'test_write.gpkg'
+
+        # Write gpkg
+        s.write_geospatial(dbo=sql, schema = ms_schema, path=os.path.join(FOLDER_PATH, gpkg_name), 
+                           gpkg_tbl = test_write_gpkg_table_name, table=test_write_gpkg_table_name, print_cmd=True)
+
+        # # Assert successful
+        assert os.path.isfile(os.path.join(FOLDER_PATH, gpkg_name))
+
+        # run ogrinfo for data types
+        cmd_gpkg = f'ogrinfo -so -al "{FOLDER_PATH}/{gpkg_name}"'
+        ogr_response_gpkg = subprocess.check_output(shlex.split(cmd_gpkg), stderr=subprocess.STDOUT)
+        assert 'dte_dt: Date' in str(ogr_response_gpkg), "'dte_dt column is not a Date data type when it should be"
 
         # Clean up
         os.remove(os.path.join(FOLDER_PATH, gpkg_name))
@@ -1021,6 +1058,7 @@ class TestWritegpkgMS:
         os.remove(os.path.join(FOLDER_PATH, gpkg_name))
         sql.query(f"drop table if exists {ms_schema}.{test_write_gpkg_table_name};")
         sql.query(f"drop table if exists {ms_schema}.{test_write_gpkg_table_name}_2;")
+        sql.query(f"drop table if exists {ms_schema}.{test_reuploaded_table_name};")
 
     def test_write_gpkg_table_pth(self):
 
@@ -1070,8 +1108,8 @@ class TestWritegpkgMS:
         assert dist_df.iloc[0]['distance'] == 0
  
         # Clean up
-        sql.query(f"drop table if exists {ms_schema}.{test_write_gpkg_table_name}")
-        sql.query(f"drop table if exists {ms_schema}.{test_reuploaded_table_name}")
+        sql.drop_table(schema = ms_schema, table = test_write_gpkg_table_name)
+        sql.drop_table(schema = ms_schema, table = test_reuploaded_table_name)
         os.remove(os.path.join(FOLDER_PATH, gpkg_name))
     
     def test_write_gpkg_query(self):
@@ -1443,12 +1481,9 @@ class TestReadShpPG:
         fp = FOLDER_PATH + '/test.zip'
         shp_name = "test.shp"
 
-        # Make sure table doesn't alredy exist
+        # Make sure table doesn't already exist
         db.drop_table(pg_schema, test_read_shp_table_name)
         assert not db.table_exists(schema=pg_schema, table=test_read_shp_table_name)
-
-        # Assert successful
-        db.drop_table(schema=pg_schema, table=test_read_shp_table_name)
 
         # Read shp to new, test table
         s.upload_geospatial(dbo=db, path=fp, schema=pg_schema, input_file=shp_name, table=test_read_shp_table_name,
@@ -1908,7 +1943,7 @@ class TestWriteShpPG:
         db.shp_to_table(path=fp, shp_name=shp_name, schema=pg_schema, table=test_reuploaded_table_name, print_cmd=True)
  
         # Assert equality
-        db_df = db.dfquery(f"select * from {pg_schema}.{pg_table_name} order by id limit 100")
+        db_df = db.dfquery(f"select * from {pg_schema}.{test_write_shp_table_name} order by id limit 100")
         shp_uploaded_df = db.dfquery(f"select * from {pg_schema}.{test_reuploaded_table_name} order by id")
  
         assert len(db_df) == len(shp_uploaded_df)
@@ -1922,7 +1957,7 @@ class TestWriteShpPG:
         # Assert before/after geom columns are all 0 ft from each other, even if represented differently
         dist_df = db.dfquery(f"""
         select distinct st_distance(st_setsrid(b.geom, 2263), a.geom) as distance
-        from {pg_schema}.{pg_table_name} b
+        from {pg_schema}.{test_write_shp_table_name} b
         join {pg_schema}.{test_reuploaded_table_name} a
             on b.id=a.id
         """)
@@ -1962,7 +1997,7 @@ class TestWriteShpPG:
         s.upload_geospatial(dbo = db, path=fp, input_file=shp_name, schema=pg_schema, table=test_reuploaded_table_name, print_cmd=True)
 
         # Assert equality
-        db_df = db.dfquery(f"select * from {pg_schema}.{pg_table_name} order by id limit 100")
+        db_df = db.dfquery(f"select * from {pg_schema}.{test_write_shp_table_name} order by id limit 100")
         shp_uploaded_df = db.dfquery(f"select * from {pg_schema}.{test_reuploaded_table_name} order by id")
 
         assert len(db_df) == len(shp_uploaded_df)
@@ -1976,7 +2011,7 @@ class TestWriteShpPG:
         # Assert before/after geom columns are all 0 ft from each other, even if represented differently
         dist_df = db.dfquery(f"""
         select distinct st_distance(st_setsrid(b.geom, 2263), a.geom) as distance
-        from {pg_schema}.{pg_table_name} b
+        from {pg_schema}.{test_write_shp_table_name} b
         join {pg_schema}.{test_reuploaded_table_name} a
         on b.id=a.id
         """)
@@ -2098,20 +2133,23 @@ class TestWriteShpPG:
                 drop table if exists {pg_schema}.{test_write_shp_table_name};
 
                 create table {pg_schema}.{test_write_shp_table_name} as
-                select *,
-                        now() as dt_col,
+                select  now() as dt_col,
                         current_date as dt_col2,
-                        cast('2020-01-01' as date) as next_dt_col
-                from {pg_schema}.{pg_table_name}
-                order by id
-                limit 100
+                        cast('2020-01-01' as date) as next_dt_col,
+                        geom
+                from {pg_schema}.{pg_table_name};
+
                 """)
         
-        s.write_geospatial(path=os.path.join(FOLDER_PATH, shp_name), dbo=db, schema=pg_schema,
-                            table=test_write_shp_table_name)
+        s.write_geospatial(path=os.path.join(FOLDER_PATH, shp_name), dbo=db, schema=pg_schema, table=test_write_shp_table_name, overwrite = True)
         
         # Assert successful
         assert os.path.isfile(os.path.join(FOLDER_PATH, shp_name))
+
+        # check that Date column is set as a Date type
+        cmd_shp = f'ogrinfo -so -al "{FOLDER_PATH}/{shp_name}" '
+        ogr_response_shp = subprocess.check_output(shlex.split(cmd_shp), stderr=subprocess.STDOUT)   
+        assert 'dt_col_dt: Date' in str(ogr_response_shp), "'dt_col_dt column is not a Date data type when it should be"
 
         # clean up
         db.drop_table(schema=pg_schema, table=test_write_shp_table_name)
@@ -2130,9 +2168,9 @@ class TestWriteShpMS:
 
         # Add test_table
         sql.query(f"""
-        create table {ms_schema}.{test_write_shp_table_name} (test_col1 int, test_col2 int, dte datetime, geom geometry);
-        insert into {ms_schema}.{test_write_shp_table_name} VALUES(1, 2, current_timestamp, geometry::Point(985831.79200444, 203371.60461367, 2263));
-        insert into {ms_schema}.{test_write_shp_table_name} VALUES(3, 4, current_timestamp, geometry::Point(985831.79200444, 203371.60461367, 2263));
+        create table {ms_schema}.{test_write_shp_table_name} (test_col1 int, test_col2 int, geom geometry);
+        insert into {ms_schema}.{test_write_shp_table_name} VALUES(1, 2, geometry::Point(985831.79200444, 203371.60461367, 2263));
+        insert into {ms_schema}.{test_write_shp_table_name} VALUES(3, 4, geometry::Point(985831.79200444, 203371.60461367, 2263));
         """)
 
         fp = FOLDER_PATH
@@ -2179,6 +2217,39 @@ class TestWriteShpMS:
                 os.remove(os.path.join(fp, shp_name.replace('shp', ext)))
             except Exception as e:
                 print(e)
+
+    def test_write_shp_dates_table(self):
+        sql.drop_table(schema=ms_schema, table=test_write_shp_table_name)
+
+        # Add test_table
+        sql.query(f"""
+        create table {ms_schema}.{test_write_shp_table_name} (test_col1 int, test_col2 int, dte datetime, geom geometry);
+        insert into {ms_schema}.{test_write_shp_table_name} VALUES(1, 2, current_timestamp, geometry::Point(985831.79200444, 203371.60461367, 2263));
+        insert into {ms_schema}.{test_write_shp_table_name} VALUES(3, 4, current_timestamp, geometry::Point(985831.79200444, 203371.60461367, 2263));
+        """)
+
+        fp = FOLDER_PATH
+        shp_name = 'test_write.shp'
+
+        # Write shp
+        s.write_geospatial(dbo=sql, path= os.path.join(fp, shp_name), table=test_write_shp_table_name, schema=ms_schema, print_cmd=True)
+
+        # Assert successful
+        assert os.path.isfile(os.path.join(fp, shp_name))
+
+        # check that Date column is set as a Date type
+        cmd_shp = f'ogrinfo -so -al "{FOLDER_PATH}/{shp_name}" '
+        ogr_response_shp = subprocess.check_output(shlex.split(cmd_shp), stderr=subprocess.STDOUT)   
+        assert 'dte_dt: Date' in str(ogr_response_shp), "'dte_dt column is not a Date data type when it should be"
+  
+        # Clean up
+        sql.drop_table(schema=ms_schema, table=test_write_shp_table_name)
+
+        # for ext in ('dbf', 'prj', 'shx', 'shp'):
+        #     try:
+        #         os.remove(os.path.join(fp, shp_name.replace('shp', ext)))
+        #     except Exception as e:
+        #         print(e)
 
     def test_write_shp_table_pth(self):
  

--- a/pysqldb3/tests/test_geospatial.py
+++ b/pysqldb3/tests/test_geospatial.py
@@ -47,8 +47,7 @@ pg_schema = 'working'
 fgdb = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'test_data/lion/lion.gdb')
 fc = 'node.shp'
 
-
-# TODO -  detect int types for GDAL and detect default geo column name for testing variables
+db_int, db_geom, sql_int, sql_geom = helpers.identify_default_dtypes(db, sql, ms_schema)
 
 class TestReadgpkgPG:
     @classmethod
@@ -447,29 +446,6 @@ class TestWritegpkgPG:
     def setup_class(cls):
         helpers.set_up_test_table_pg(db)
 
-    # todo - was missing test for table - didnt catch paren issue - add more tests
-    def test_write_shp_table(self):
-        db.query(f"""
-               drop table if exists {pg_schema}.{test_write_gpkg_table_name};
-
-               create table {pg_schema}.{test_write_gpkg_table_name} as
-               select *, now() as dt_col
-               from {pg_schema}.{pg_table_name}
-               order by id
-               limit 100
-               """)
-        shp_name = 'wrtie_shp_test.shp'
-        s.write_geospatial(path=os.path.join(FOLDER_PATH, shp_name), dbo=db, schema=pg_schema,
-                           table=test_write_gpkg_table_name)
-
-        # Assert successful
-        assert os.path.isfile(os.path.join(FOLDER_PATH, shp_name))
-
-        # clean up
-        db.drop_table(schema=pg_schema, table=test_write_gpkg_table_name)
-        os.remove(os.path.join(FOLDER_PATH, shp_name))
-
-
     def test_write_gpkg_table(self):
         db.query(f"""
         drop table if exists {pg_schema}.{test_write_gpkg_table_name};
@@ -672,6 +648,33 @@ class TestWritegpkgPG:
         db.drop_table(schema=pg_schema, table=test_reuploaded_table_name + '_2')
         os.remove(os.path.join(FOLDER_PATH, gpkg_name))
 
+
+    def test_write_gpkg_dates_table(self):
+            
+        gpkg_name = 'testgpkg.gpkg'
+
+        db.query(f"""
+                drop table if exists {pg_schema}.{test_write_gpkg_table_name};
+
+                create table {pg_schema}.{test_write_gpkg_table_name} as
+                select *,
+                        now() as dt_col,
+                        cast('2020-01-01' as date) as next_dt_col
+                from {pg_schema}.{pg_table_name}
+                order by id
+                limit 100
+                """)
+        
+        s.write_geospatial(path=os.path.join(FOLDER_PATH, gpkg_name), dbo=db, schema=pg_schema,
+                            table=test_write_gpkg_table_name)
+
+        # Assert successful
+        assert os.path.isfile(os.path.join(FOLDER_PATH, gpkg_name))
+
+        # clean up
+        db.drop_table(schema=pg_schema, table=test_write_gpkg_table_name)
+        os.remove(os.path.join(FOLDER_PATH, gpkg_name))
+    
     def test_write_gpkg_table_pth(self):
         db.drop_table(pg_schema, test_write_gpkg_table_name)
         db.query(f"""
@@ -827,14 +830,15 @@ class TestWritegpkgPG:
 
 
 class TestWritegpkgMS:
+
     def test_write_gpkg_table(self):
         sql.drop_table(schema=ms_schema, table=test_write_gpkg_table_name)
 
         # Add test_table
         sql.query(f"""
-        create table {ms_schema}.{test_write_gpkg_table_name} (test_col1 int, test_col2 int, geom geometry);
-        insert into {ms_schema}.{test_write_gpkg_table_name} VALUES(1, 2, geometry::Point(985831.79200444, 203371.60461367, 2263));
-        insert into {ms_schema}.{test_write_gpkg_table_name} VALUES(3, 4, geometry::Point(985831.79200444, 203371.60461367, 2263));
+        create table {ms_schema}.{test_write_gpkg_table_name} (test_col1 int, test_col2 int, dte datetime, geom geometry);
+        insert into {ms_schema}.{test_write_gpkg_table_name} VALUES(1, 2, current_timestamp, geometry::Point(985831.79200444, 203371.60461367, 2263));
+        insert into {ms_schema}.{test_write_gpkg_table_name} VALUES(3, 4, current_timestamp, geometry::Point(985831.79200444, 203371.60461367, 2263));
         """)
 
         gpkg_name = 'test_write.gpkg'
@@ -2086,6 +2090,34 @@ class TestWriteShpPG:
         for ext in ('dbf', 'prj', 'shx', 'shp'):
             os.remove(os.path.join(FOLDER_PATH, shp_name.replace('shp', ext)))
 
+    def test_write_shp_dates_table(self):
+
+        p = FOLDER_PATH
+        shp_name = 'test_write.shp'
+
+        db.query(f"""
+                drop table if exists {pg_schema}.{test_write_shp_table_name};
+
+                create table {pg_schema}.{test_write_shp_table_name} as
+                select *,
+                        now() as dt_col,
+                        current_date as dt_col2,
+                        cast('2020-01-01' as date) as next_dt_col
+                from {pg_schema}.{pg_table_name}
+                order by id
+                limit 100
+                """)
+        
+        s.write_geospatial(path=os.path.join(FOLDER_PATH, shp_name), dbo=db, schema=pg_schema,
+                            table=test_write_shp_table_name)
+        
+        # Assert successful
+        assert os.path.isfile(os.path.join(FOLDER_PATH, shp_name))
+
+        # clean up
+        db.drop_table(schema=pg_schema, table=test_write_shp_table_name)
+        os.remove(os.path.join(FOLDER_PATH, shp_name))
+
     @classmethod
     def teardown_class(cls):
         helpers.clean_up_test_table_pg(db)
@@ -2093,14 +2125,15 @@ class TestWriteShpPG:
 
 
 class TestWriteShpMS:
+    
     def test_write_shp_table(self):
         sql.drop_table(schema=ms_schema, table=test_write_shp_table_name)
 
         # Add test_table
         sql.query(f"""
-        create table {ms_schema}.{test_write_shp_table_name} (test_col1 int, test_col2 int, geom geometry);
-        insert into {ms_schema}.{test_write_shp_table_name} VALUES(1, 2, geometry::Point(985831.79200444, 203371.60461367, 2263));
-        insert into {ms_schema}.{test_write_shp_table_name} VALUES(3, 4, geometry::Point(985831.79200444, 203371.60461367, 2263));
+        create table {ms_schema}.{test_write_shp_table_name} (test_col1 int, test_col2 int, dte datetime, geom geometry);
+        insert into {ms_schema}.{test_write_shp_table_name} VALUES(1, 2, current_timestamp, geometry::Point(985831.79200444, 203371.60461367, 2263));
+        insert into {ms_schema}.{test_write_shp_table_name} VALUES(3, 4, current_timestamp, geometry::Point(985831.79200444, 203371.60461367, 2263));
         """)
 
         fp = FOLDER_PATH
@@ -2130,7 +2163,7 @@ class TestWriteShpMS:
         # Assert before/after geom columns are all 0 ft from each other, even if represented differently
         dist_df = sql.dfquery(f"""
         select distinct b.geom.STDistance(a.geom) as distance
-        from {ms_schema}.{test_reuploaded_table_name} b
+        from {ms_schema}.{test_write_shp_table_name} b
         join {ms_schema}.{test_reuploaded_table_name} a
         on b.test_col1=a.test_col1
         """)
@@ -2269,7 +2302,7 @@ class TestFeatureClassToTablePg:
     @classmethod
     def setup_class(cls):
         helpers.set_up_feature_class()
-        
+
     def test_import_fc_basic(self):
         db.drop_table(table=test_feature_class_table_name, schema=db.default_schema)
         assert not db.table_exists(test_feature_class_table_name, schema=db.default_schema)
@@ -2319,7 +2352,16 @@ class TestFeatureClassToTablePg:
         db.feature_class_to_table(path = fgdb, table=test_feature_class_table_name, feature_class=fc, schema=pg_schema, srid=4326)
         assert db.table_exists(test_feature_class_table_name, schema=pg_schema)
 
-        db.query(f'select distinct st_srid("Shape") from {pg_schema}.{test_feature_class_table_name}')
+        # identify the uploaded geometry column name, because it can be named geom or Shape depending on user's computer
+        geom_column_name = db.dfquery(f"""
+        select distinct column_name
+                    from information_schema.columns
+                    where table_name = '{test_feature_class_table_name}'
+                        and table_schema = '{pg_schema}'
+                        and data_type = '{db_geom}'
+                        """)['column_name'][0]
+        
+        db.query(f'select distinct st_srid("{geom_column_name}") from {pg_schema}.{test_feature_class_table_name}')
         assert db.data[0][0] == 4326
 
         db.drop_table(pg_schema, test_feature_class_table_name)
@@ -2341,12 +2383,21 @@ class TestFeatureClassToTablePg:
         columns = {i[0] for i in db.data}
         types = {i[1] for i in db.data}
 
-        assert {'vintersect', 'objectid', 'Shape', 'nodeid'}.issubset(columns)
-        assert {'integer', 'integer', 'character varying', 'USER-DEFINED'}.issubset(types)
+        # identify the uploaded geometry column name, because it can be named geom or Shape depending on user's computer
+        geom_column_name = db.dfquery(f"""
+        select distinct column_name
+                    from information_schema.columns
+                    where table_name = '{test_feature_class_table_name}'
+                        and table_schema = '{db.default_schema}'
+                        and data_type = '{db_geom}'
+                        """)['column_name'][0]
+
+        assert {'vintersect', 'objectid', geom_column_name, 'nodeid'}.issubset(columns)
+        assert {db_int, db_int, 'character varying', db_geom}.issubset(types)
 
         # check non geom data
         db.query(f"""
-                    select nodeid, vintersect, st_astext("Shape", 1) geom from {db.default_schema}.{test_feature_class_table_name} where nodeid in (88, 98, 100)
+                    select nodeid, vintersect, st_astext("{geom_column_name}", 1) geom from {db.default_schema}.{test_feature_class_table_name} where nodeid in (88, 98, 100)
                 """)
 
         row_values = [(88, 'VirtualIntersection', 'MULTIPOINT(914145.1 126536.1)'),
@@ -2360,7 +2411,7 @@ class TestFeatureClassToTablePg:
 
         # check geom matches (less than 1 ft off
         db.query(f"""
-            select st_distance(st_setsrid(ST_GeometryN("Shape", 1), 2263),
+            select st_distance(st_setsrid(ST_GeometryN("{geom_column_name}", 1), 2263),
                 st_setsrid(st_makepoint(914145.1,126536.1, 2263),2263))
             from {db.default_schema}.{test_feature_class_table_name}
             where nodeid=88
@@ -2368,7 +2419,7 @@ class TestFeatureClassToTablePg:
         assert db.data[0][0] < 1
 
         db.query(f"""
-            select st_distance(st_setsrid(ST_GeometryN("Shape", 1), 2263),
+            select st_distance(st_setsrid(ST_GeometryN("{geom_column_name}", 1), 2263),
                 st_setsrid(st_makepoint(920184.0, 138084.1, 2263),2263))
             from {db.default_schema}.{test_feature_class_table_name}
             where nodeid=888
@@ -2506,14 +2557,22 @@ class TestFeatureClassToTableMs:
                 and table_schema='{sql.default_schema}'
         """)
 
+        geom_column_name = sql.dfquery(f"""
+                    select distinct data_type
+                    from INFORMATION_SCHEMA.COLUMNS
+                    where table_name = '{test_feature_class_table_name}'
+                        and table_schema='{sql.default_schema}'
+                        and data_type = '{sql_geom}'
+                    """)['data_type'][0]
+
         columns = {i[0] for i in sql.data}
         types = {i[1] for i in sql.data}
 
-        assert {'objectid', 'geom', 'nodeid', 'vintersect'}.issubset(columns)
-        assert {'int', 'geometry', 'int', 'nvarchar'}.issubset(types)
+        assert {'objectid', geom_column_name, 'nodeid', 'vintersect'}.issubset(columns)
+        assert {sql_int, sql_geom, sql_int, 'nvarchar'}.issubset(types)
 
         # check non geom data
-        sql.query(f"""select nodeid, vintersect, geom.STAsText() geom from {sql.default_schema}.{test_feature_class_table_name} where nodeid in (88, 98, 100)
+        sql.query(f"""select nodeid, vintersect, {geom_column_name}.STAsText() geom from {sql.default_schema}.{test_feature_class_table_name} where nodeid in (88, 98, 100)
                         """)
 
         row_values = [(88, 'VirtualIntersection', 'MULTIPOINT ((914145.06807594 126536.07138967514))'),
@@ -2526,14 +2585,14 @@ class TestFeatureClassToTableMs:
 
         # check geom matches (less than 1 ft off)
         sql.query(f"""
-            select geom.STGeometryN(1).STDistance(geometry::Point(914145.1,126536.1, 2263))
+            select {geom_column_name}.STGeometryN(1).STDistance(geometry::Point(914145.1,126536.1, 2263))
             from {sql.default_schema}.{test_feature_class_table_name}
             where nodeid=88
         """)
         assert sql.data[0][0] < 1
 
         sql.query(f"""
-            select geom.STGeometryN(1).STDistance(geometry::Point(920184.0, 138084.1, 2263))
+            select {geom_column_name}.STGeometryN(1).STDistance(geometry::Point(920184.0, 138084.1, 2263))
             from {sql.default_schema}.{test_feature_class_table_name}
             where nodeid=888
                 """)

--- a/pysqldb3/tests/test_geospatial.py
+++ b/pysqldb3/tests/test_geospatial.py
@@ -2092,7 +2092,6 @@ class TestWriteShpPG:
 
     def test_write_shp_dates_table(self):
 
-        p = FOLDER_PATH
         shp_name = 'test_write.shp'
 
         db.query(f"""
@@ -2550,20 +2549,23 @@ class TestFeatureClassToTableMs:
         sql.feature_class_to_table(path = fgdb, table=test_feature_class_table_name, schema=None, feature_class=fc, skip_failures='-skip_failures')
 
         assert sql.table_exists(test_feature_class_table_name, schema=sql.default_schema)
+
+        # query the data_type of the geometry field since it can vary based on user's computer
+        geom_column_name = sql.dfquery(f"""
+                    select distinct column_name
+                    from INFORMATION_SCHEMA.COLUMNS
+                    where table_name = '{test_feature_class_table_name}'
+                        and table_schema='{sql.default_schema}'
+                        and data_type = '{sql_geom}'
+                    """)['column_name'][0]
+
+        # run the query to identify all column names and types from the test table
         sql.query(f"""
                 select column_name, data_type
                 from INFORMATION_SCHEMA.COLUMNS
                 where table_name = '{test_feature_class_table_name}'
                 and table_schema='{sql.default_schema}'
         """)
-
-        geom_column_name = sql.dfquery(f"""
-                    select distinct data_type
-                    from INFORMATION_SCHEMA.COLUMNS
-                    where table_name = '{test_feature_class_table_name}'
-                        and table_schema='{sql.default_schema}'
-                        and data_type = '{sql_geom}'
-                    """)['data_type'][0]
 
         columns = {i[0] for i in sql.data}
         types = {i[1] for i in sql.data}
@@ -2645,7 +2647,7 @@ class TestFeatureClassToTableMs:
         sql.drop_table(table=test_feature_class_table_name, schema=ms_schema)
         assert not sql.table_exists(test_feature_class_table_name, schema=ms_schema)
 
-        sql.feature_class_to_table(path = fgdb, table = test_feature_class_table_name, feature_class = fc, schema=ms_schema, shp_name='lion.gdb',
+        sql.feature_class_to_table(path = fgdb, table = test_feature_class_table_name, feature_class = fc, schema=ms_schema,
                                     extra_cmd='-nlt MULTILINESTRING')
         assert sql.table_exists(test_feature_class_table_name, schema=ms_schema)
 

--- a/pysqldb3/tests/test_geospatial.py
+++ b/pysqldb3/tests/test_geospatial.py
@@ -1718,6 +1718,8 @@ class TestReadShpMS:
         assert len(diff_df) == 1
         assert int(diff_df.iloc[0]['distance']) == 0
 
+        assert sql.tables_created[-1] == (sql.server, sql.database, ms_schema, test_read_shp_table_name)
+
         # Cleanup
         sql.drop_table(schema=ms_schema, table=test_read_shp_table_name)
 
@@ -2422,16 +2424,7 @@ class TestFeatureClassToTablePg:
         db.feature_class_to_table(path = fgdb, table=test_feature_class_table_name, feature_class=fc, schema=pg_schema, srid=4326)
         assert db.table_exists(test_feature_class_table_name, schema=pg_schema)
 
-        # identify the uploaded geometry column name, because it can be named geom or Shape depending on user's computer
-        geom_column_name = db.dfquery(f"""
-        select distinct column_name
-                    from information_schema.columns
-                    where table_name = '{test_feature_class_table_name}'
-                        and table_schema = '{pg_schema}'
-                        and data_type = '{db_geom}'
-                        """)['column_name'][0]
-        
-        db.query(f'select distinct st_srid("{geom_column_name}") from {pg_schema}.{test_feature_class_table_name}')
+        db.query(f'select distinct st_srid(geom) from {pg_schema}.{test_feature_class_table_name}')
         assert db.data[0][0] == 4326
 
         db.drop_table(pg_schema, test_feature_class_table_name)
@@ -2454,20 +2447,12 @@ class TestFeatureClassToTablePg:
         types = {i[1] for i in db.data}
 
         # identify the uploaded geometry column name, because it can be named geom or Shape depending on user's computer
-        geom_column_name = db.dfquery(f"""
-        select distinct column_name
-                    from information_schema.columns
-                    where table_name = '{test_feature_class_table_name}'
-                        and table_schema = '{db.default_schema}'
-                        and data_type = '{db_geom}'
-                        """)['column_name'][0]
 
-        assert {'vintersect', 'objectid', geom_column_name, 'nodeid'}.issubset(columns)
+        assert {'vintersect', 'objectid', 'geom', 'nodeid'}.issubset(columns)
         assert {db_int, db_int, 'character varying', db_geom}.issubset(types)
-
         # check non geom data
         db.query(f"""
-                    select nodeid, vintersect, st_astext("{geom_column_name}", 1) geom from {db.default_schema}.{test_feature_class_table_name} where nodeid in (88, 98, 100)
+                    select nodeid, vintersect, st_astext(geom, 1) geom from {db.default_schema}.{test_feature_class_table_name} where nodeid in (88, 98, 100)
                 """)
 
         row_values = [(88, 'VirtualIntersection', 'MULTIPOINT(914145.1 126536.1)'),
@@ -2481,7 +2466,7 @@ class TestFeatureClassToTablePg:
 
         # check geom matches (less than 1 ft off
         db.query(f"""
-            select st_distance(st_setsrid(ST_GeometryN("{geom_column_name}", 1), 2263),
+            select st_distance(st_setsrid(ST_GeometryN(geom, 1), 2263),
                 st_setsrid(st_makepoint(914145.1,126536.1, 2263),2263))
             from {db.default_schema}.{test_feature_class_table_name}
             where nodeid=88
@@ -2489,7 +2474,7 @@ class TestFeatureClassToTablePg:
         assert db.data[0][0] < 1
 
         db.query(f"""
-            select st_distance(st_setsrid(ST_GeometryN("{geom_column_name}", 1), 2263),
+            select st_distance(st_setsrid(ST_GeometryN(geom, 1), 2263),
                 st_setsrid(st_makepoint(920184.0, 138084.1, 2263),2263))
             from {db.default_schema}.{test_feature_class_table_name}
             where nodeid=888
@@ -2621,15 +2606,6 @@ class TestFeatureClassToTableMs:
 
         assert sql.table_exists(test_feature_class_table_name, schema=sql.default_schema)
 
-        # query the data_type of the geometry field since it can vary based on user's computer
-        geom_column_name = sql.dfquery(f"""
-                    select distinct column_name
-                    from INFORMATION_SCHEMA.COLUMNS
-                    where table_name = '{test_feature_class_table_name}'
-                        and table_schema='{sql.default_schema}'
-                        and data_type = '{sql_geom}'
-                    """)['column_name'][0]
-
         # run the query to identify all column names and types from the test table
         sql.query(f"""
                 select column_name, data_type
@@ -2641,11 +2617,11 @@ class TestFeatureClassToTableMs:
         columns = {i[0] for i in sql.data}
         types = {i[1] for i in sql.data}
 
-        assert {'objectid', geom_column_name, 'nodeid', 'vintersect'}.issubset(columns)
-        assert {sql_int, sql_geom, sql_int, 'nvarchar'}.issubset(types)
+        assert {'objectid', 'geom', 'nodeid', 'vintersect'}.issubset(columns)
+        assert {sql_int, sql_geom, 'nvarchar'}.issubset(types)
 
         # check non geom data
-        sql.query(f"""select nodeid, vintersect, {geom_column_name}.STAsText() geom from {sql.default_schema}.{test_feature_class_table_name} where nodeid in (88, 98, 100)
+        sql.query(f"""select nodeid, vintersect, geom.STAsText() geom from {sql.default_schema}.{test_feature_class_table_name} where nodeid in (88, 98, 100)
                         """)
 
         row_values = [(88, 'VirtualIntersection', 'MULTIPOINT ((914145.06807594 126536.07138967514))'),
@@ -2658,14 +2634,14 @@ class TestFeatureClassToTableMs:
 
         # check geom matches (less than 1 ft off)
         sql.query(f"""
-            select {geom_column_name}.STGeometryN(1).STDistance(geometry::Point(914145.1,126536.1, 2263))
+            select geom.STGeometryN(1).STDistance(geometry::Point(914145.1,126536.1, 2263))
             from {sql.default_schema}.{test_feature_class_table_name}
             where nodeid=88
         """)
         assert sql.data[0][0] < 1
 
         sql.query(f"""
-            select {geom_column_name}.STGeometryN(1).STDistance(geometry::Point(920184.0, 138084.1, 2263))
+            select geom.STGeometryN(1).STDistance(geometry::Point(920184.0, 138084.1, 2263))
             from {sql.default_schema}.{test_feature_class_table_name}
             where nodeid=888
                 """)

--- a/pysqldb3/tests/test_query_to_geospatial.py
+++ b/pysqldb3/tests/test_query_to_geospatial.py
@@ -34,7 +34,8 @@ pg_schema = 'working'
 
 FOLDER_PATH = helpers.DIR
 
-db_int, db_geom, sql_int, sql_geom = helpers.identify_default_dtypes(db, sql, ms_schema)
+db_int, db_geom = helpers.identify_default_dtypes(db, pg_schema)
+sql_int, sql_geom = helpers.identify_default_dtypes(sql, ms_schema)
 
 class TestQueryToGpkgPg:
 
@@ -152,14 +153,8 @@ class TestQueryToGpkgPg:
         assert 'id2 (Integer) = 2' in str(ogr_response_gpkg), "table was not overwritten in the geopackage"
 
         # check the data types
-        db.query(f"""
-            select column_name, data_type
-            from information_schema.columns
-            where table_name = '{test_table}_2'
-                and table_schema = '{pg_schema}'
-                        """)
-        
-        types = {i[1] for i in db.data}
+        data_types = db.get_table_columns(test_table, schema = pg_schema)
+        types = {i[1] for i in data_types}
         assert {db_int, 'text', 'timestamp without time zone', db_geom}.issubset(types)
         
         # clean up
@@ -818,7 +813,7 @@ class TestQueryToGpkgMs:
         select
             case when t1.fld2 = t2.fld2 then 1 else 0 end,
             case when left(t1.fld3, 254) = left(t2.fld3, 254) then 1 else 0 end,
-            case when convert(datetime, t1.fld4)=t2.fld4_dt then 1 else 0 end, -- shapefiles cannot store datetimes
+            case when convert(date, t1.fld4)=t2.fld4_dt then 1 else 0 end, -- shapefiles cannot store datetimes
             case when cast(t1.fld4 as time)=t2.fld4_tm then 1 else 0 end, -- shapefiles cannot store datetimes
             case when t1.fld5 = t2.fld5 then 1 else 0 end,
             case when t1.fld6.STDistance(t2.fld6) < 1  then 1 else 0 end-- default name from pysqldb
@@ -872,7 +867,7 @@ class TestQueryToGpkgMs:
         select
             case when t1.fld2 = t2.fld2 then 1 else 0 end,
             case when left(t1.fld3, 254) = left(t2.fld3, 254) then 1 else 0 end,
-            case when convert(datetime, t1.longfld4)=t2.longfld_dt then 1 else 0 end, -- shapefiles cannot store datetimes
+            case when convert(date, t1.longfld4)=t2.longfld_dt then 1 else 0 end, -- shapefiles cannot store datetimes
             case when cast(t1.longfld4 as time)=t2.longfld_tm then 1 else 0 end, -- shapefiles cannot store datetimes
             case when t1.fld5 = t2.fld5 then 1 else 0 end,
             case when t1.fld6.STDistance(t2.fld6) < 1  then 1 else 0 end-- default name from pysqldb
@@ -880,6 +875,7 @@ class TestQueryToGpkgMs:
         join {ms_schema}.{test_table}QA t2
         on t1.fld1=t2.fld1
         """)
+
         assert set(sql.data[0]) == {1}
 
         # clean up
@@ -1292,14 +1288,9 @@ class TestQueryToShpMs:
         assert b'"EPSG",2263' in ogr_response or b'"EPSG","2263"' in ogr_response
 
         # check the data types
-        sql.query(f"""
-            select column_name, data_type
-            from information_schema.columns
-            where table_name = '{test_table}'
-                and table_schema = '{ms_schema}'
-                        """)
+        table_types = sql.get_table_columns(test_table, schema = ms_schema)
+        types = [x[1] for x in table_types]
         
-        types = {i[1] for i in sql.data}
         assert {sql_int, 'text', 'datetime', sql_geom}.issubset(types)
         
         # clean up

--- a/pysqldb3/tests/test_query_to_geospatial.py
+++ b/pysqldb3/tests/test_query_to_geospatial.py
@@ -34,6 +34,8 @@ pg_schema = 'working'
 
 FOLDER_PATH = helpers.DIR
 
+db_int, db_geom, sql_int, sql_geom = helpers.identify_default_dtypes(db, sql, ms_schema)
+
 class TestQueryToGpkgPg:
 
     def test_query_to_gpkg_basic(self):
@@ -149,6 +151,17 @@ class TestQueryToGpkgPg:
         ogr_response_gpkg = subprocess.check_output(shlex.split(cmd_gpkg2.replace('\\', '/')), stderr=subprocess.STDOUT)
         assert 'id2 (Integer) = 2' in str(ogr_response_gpkg), "table was not overwritten in the geopackage"
 
+        # check the data types
+        db.query(f"""
+            select column_name, data_type
+            from information_schema.columns
+            where table_name = '{test_table}_2'
+                and table_schema = '{pg_schema}'
+                        """)
+        
+        types = {i[1] for i in db.data}
+        assert {db_int, 'text', 'timestamp without time zone', db_geom}.issubset(types)
+        
         # clean up
         db.drop_table(pg_schema, test_table)
         db.drop_table(pg_schema, test_table + '_2')
@@ -1278,6 +1291,17 @@ class TestQueryToShpMs:
         ogr_response = subprocess.check_output(shlex.split(cmd), stderr=subprocess.STDOUT)
         assert b'"EPSG",2263' in ogr_response or b'"EPSG","2263"' in ogr_response
 
+        # check the data types
+        sql.query(f"""
+            select column_name, data_type
+            from information_schema.columns
+            where table_name = '{test_table}'
+                and table_schema = '{ms_schema}'
+                        """)
+        
+        types = {i[1] for i in sql.data}
+        assert {sql_int, 'text', 'datetime', sql_geom}.issubset(types)
+        
         # clean up
         sql.drop_table(ms_schema, test_table_shp)
         for ext in ('dbf', 'prj', 'shx', 'shp'):

--- a/pysqldb3/tests/test_query_to_geospatial.py
+++ b/pysqldb3/tests/test_query_to_geospatial.py
@@ -818,7 +818,7 @@ class TestQueryToGpkgMs:
         select
             case when t1.fld2 = t2.fld2 then 1 else 0 end,
             case when left(t1.fld3, 254) = left(t2.fld3, 254) then 1 else 0 end,
-            case when cast(t1.fld4 as date)=t2.fld4_dt then 1 else 0 end, -- shapefiles cannot store datetimes
+            case when convert(datetime, t1.fld4)=t2.fld4_dt then 1 else 0 end, -- shapefiles cannot store datetimes
             case when cast(t1.fld4 as time)=t2.fld4_tm then 1 else 0 end, -- shapefiles cannot store datetimes
             case when t1.fld5 = t2.fld5 then 1 else 0 end,
             case when t1.fld6.STDistance(t2.fld6) < 1  then 1 else 0 end-- default name from pysqldb
@@ -872,7 +872,7 @@ class TestQueryToGpkgMs:
         select
             case when t1.fld2 = t2.fld2 then 1 else 0 end,
             case when left(t1.fld3, 254) = left(t2.fld3, 254) then 1 else 0 end,
-            case when cast(t1.longfld4 as date)=t2.longfld_dt then 1 else 0 end, -- shapefiles cannot store datetimes
+            case when convert(datetime, t1.longfld4)=t2.longfld_dt then 1 else 0 end, -- shapefiles cannot store datetimes
             case when cast(t1.longfld4 as time)=t2.longfld_tm then 1 else 0 end, -- shapefiles cannot store datetimes
             case when t1.fld5 = t2.fld5 then 1 else 0 end,
             case when t1.fld6.STDistance(t2.fld6) < 1  then 1 else 0 end-- default name from pysqldb

--- a/pysqldb3/tests/test_query_to_geospatial.py
+++ b/pysqldb3/tests/test_query_to_geospatial.py
@@ -73,10 +73,10 @@ class TestQueryToGpkgPg:
         # create table
         db.query(f"""
             DROP TABLE IF EXISTS {pg_schema}.{test_table};
-            CREATE TABLE {pg_schema}.{test_table} (id int, txt text, dte timestamp, geom geometry(Point));
+            CREATE TABLE {pg_schema}.{test_table} (id int, txt text, dte timestamp, dte2 date, geom geometry(Point));
 
             INSERT INTO {pg_schema}.{test_table}
-             VALUES (1, 'test text', now(), st_setsrid(st_makepoint(1015329.1, 213793.1), 2263))
+             VALUES (1, 'test text', now(), current_date, st_setsrid(st_makepoint(1015329.1, 213793.1), 2263))
          """)
         
         assert db.table_exists(test_table, schema=pg_schema)
@@ -903,10 +903,10 @@ class TestQueryToShpPg:
         db.drop_table(schema = pg_schema, table = test_table)
         # create table
         db.query(f"""
-            CREATE TABLE {pg_schema}.{test_table} (id int, txt text, dte timestamp, geom geometry(Point));
+            CREATE TABLE {pg_schema}.{test_table} (id int, txt text, dte timestamp, dt2 date, geom geometry(Point));
 
             INSERT INTO {pg_schema}.{test_table}
-             VALUES (1, 'test text', now(), st_setsrid(st_makepoint(1015329.1, 213793.1), 2263))
+             VALUES (1, 'test text', now(), cast('2020-01-01' as date), st_setsrid(st_makepoint(1015329.1, 213793.1), 2263))
         """)
         assert db.table_exists(test_table, schema=pg_schema)
 

--- a/pysqldb3/tests/test_rename_geom.py
+++ b/pysqldb3/tests/test_rename_geom.py
@@ -73,7 +73,7 @@ class TestRenamesGeomPg:
         # import with pysqldb
 
         assert db.table_exists(table, schema=db.default_schema) is False
-        db.feature_class_to_table(fgdb, table, schema=None, shp_name=fc)
+        db.feature_class_to_table(fgdb, table, schema=None, feature_class=fc)
 
         db.query("""
             SELECT column_name, data_type
@@ -193,7 +193,7 @@ class TestRenamesGeomMs:
         # import with pysqldb
         assert not sql.table_exists(table, schema=sql.default_schema)
 
-        sql.feature_class_to_table(fgdb, table, schema=None, shp_name=fc, skip_failures='-skip_failures')
+        sql.feature_class_to_table(fgdb, table, schema=None, feature_class=fc, skip_failures='-skip_failures')
 
         sql.query("""
             SELECT column_name, data_type


### PR DESCRIPTION
Following our last pair programming session, my to-dos were to:
1. query the user's data types for geometry (I included integer as well) instead of hardcoding them since they can vary by user and we want the tests to work for all users.
2. Add tests for the datetime fields so we know that they are working in PG and MS
3. Edit `write_geo_cmd_query` so that we didn't need an extra line of code to remove columns where the `data_type is None`. This was happening because MS temp tables don't recognize Geometry fields and would set them to None.