### PR TITLE
Refresh the change to dtypes

### DIFF
--- a/pysqldb3/geospatial.py
+++ b/pysqldb3/geospatial.py
@@ -78,13 +78,14 @@ def geospatial_tbl_exists(path, geospatial_tbl):
         
     return geo_tbl_exists
 
-def write_geo_cmd_query(dbo, query_or_table, is_query = False, schema = ''):
+def write_geo_cmd_query(dbo, query_or_table, path, is_query = False, schema = ''):
 
     """
     Format the query or table from the database to be written to a Geospatial file.
     Formats columns with special characters and/or datetime columns to be compatible with output file.
     :param dbo: Database connection
     :param query_or_table: The specific query or table name to be written to a Geospatial file
+    :param path: Output file path to check if it is a Shp file
     :param is_query (bool): Boolean for whether or not it is a query being written to Geospatial file.
                             Defaults to False (table); if it's query, set to True.
     :param schema: Optional schema name; used only if the command is calling a table
@@ -109,8 +110,7 @@ def write_geo_cmd_query(dbo, query_or_table, is_query = False, schema = ''):
     columns_with_brackets = [left_bracket + c[0] + right_bracket for c in columns_with_types]
 
     # identify date columns if they are in the intended output
-    dt_col_names = [c for c in columns_with_types if c[1] is not None] ## TODO - what is this doing/is it needed?
-    dt_col_names = [c[0] for c in dt_col_names if (('datetime' in c[1]) | ('timestamp' in c[1]))] # after, check if there is datetime / timestamp
+    dt_col_names = [c[0] for c in columns_with_types if (('datetime' in c[1]) | ('timestamp' in c[1]))] # after, check if there is datetime / timestamp
 
     # if there are no date columns, we can query immediately
     if len(dt_col_names) == 0:
@@ -131,7 +131,8 @@ def write_geo_cmd_query(dbo, query_or_table, is_query = False, schema = ''):
                                 'cast(cast(\\"{col}\\" as time) as varchar) \\"{shortened_col}_tm\\" '.format(
                                 col=col_name, shortened_col = shortened_col
                                 )
-            elif dbo.type == MS:
+            elif dbo.type == MS and path.endswith('shp'):
+                # date type only needs correction for MS Shp, not GPKG
                 results += " , cast([{col}] as date) [{shortened_col}_dt], cast(cast([{col}] as time) as varchar)" \
                                 " [{shortened_col}_tm] ".format(
                                 col=col_name, shortened_col = shortened_col
@@ -185,9 +186,8 @@ def write_geospatial(dbo, path,  table = None, schema = '', query = None, gpkg_t
         # if input is query overwrite params for write_geo_cmd_query()
         is_query = True
         query_or_table = query
-    # generate GDAL command
-    qry = write_geo_cmd_query(dbo, schema = schema, query_or_table = query_or_table, is_query = is_query)
-
+    # generate sql for GDAL command
+    qry = write_geo_cmd_query(dbo, schema = schema, query_or_table = query_or_table, is_query = is_query, path = path)
 
     # clean up the output file name
     # need 2 statements because of the difference in characters
@@ -222,6 +222,11 @@ def write_geospatial(dbo, path,  table = None, schema = '', query = None, gpkg_t
     
     # update allows you to add an extra table into an existing geopackage
         _update = '-update'
+        _overwrite = ''
+
+    else: # if not overwrite and path ends with .shp instead
+
+        _update = ''
         _overwrite = ''
 
     # run the final command

--- a/pysqldb3/geospatial.py
+++ b/pysqldb3/geospatial.py
@@ -111,7 +111,7 @@ def write_geo_cmd_query(dbo, query_or_table, path, is_query = False, schema = ''
 
     # certain database connections + output formats require formatting for dates
     if dbo.type == PG or (dbo.type == MS and path.endswith('shp')):
-        results = format_dte_columns(dbo, columns_with_types, columns_with_brackets, is_query, query_or_table, schema)
+        results = format_dte_columns(dbo, columns_with_types, columns_with_brackets)
     else:
         results = ' , '.join([c for c in columns_with_brackets])
 
@@ -121,7 +121,7 @@ def write_geo_cmd_query(dbo, query_or_table, path, is_query = False, schema = ''
     else:
         return  f"select {results} from {schema}{query_or_table} q "
 
-def format_dte_columns(dbo, columns_with_types, columns_with_brackets, is_query, query_or_table, schema):
+def format_dte_columns(dbo, columns_with_types, columns_with_brackets):
 
     """
     Format the DateTime column so the geospatial output fit has formatted Date and Time columns.

--- a/pysqldb3/geospatial.py
+++ b/pysqldb3/geospatial.py
@@ -109,17 +109,39 @@ def write_geo_cmd_query(dbo, query_or_table, path, is_query = False, schema = ''
 
     columns_with_brackets = [left_bracket + c[0] + right_bracket for c in columns_with_types]
 
+    # certain database connections + output formats require formatting for dates
+    if dbo.type == PG or (dbo.type == MS and path.endswith('shp')):
+        results = format_dte_columns(dbo, columns_with_types, columns_with_brackets, is_query, query_or_table, schema)
+    else:
+        results = ' , '.join([c for c in columns_with_brackets])
+
+        # Wrap the original query and select the non-datetime/timestamp columns and the parsed out dates/times
+    if is_query:
+        return  f"select {results} from ({query_or_table}) q "
+    else:
+        return  f"select {results} from {schema}{query_or_table} q "
+
+def format_dte_columns(dbo, columns_with_types, columns_with_brackets, is_query, query_or_table, schema):
+
+    """
+    Format the DateTime column so the geospatial output fit has formatted Date and Time columns.
+    This is applicable if the table is in PG, or MS and the output is a Shp, because it does not automatically format these dates.
+    
+    :param dbo: Database connection
+    :param columns_with_types: Output of get_table_columns that returns the column name and data type
+    :param columns_with_brackets: Column names surrounded by brackets in case names have spaces
+    :param is_query (bool): Boolean for whether or not it is a query being written to Geospatial file.
+                            Defaults to False (table); if it's query, set to True.
+    :param query_or_table: The specific query or table name to be written to a Geospatial file
+    :param schema: Schema
+    """
+
     # identify date columns if they are in the intended output
     dt_col_names = [c[0] for c in columns_with_types if (('datetime' in c[1]) | ('timestamp' in c[1]))] # after, check if there is datetime / timestamp
 
     # if there are no date columns, we can query immediately
-    if len(dt_col_names) == 0:
-        if is_query:
-            return f'select * from ({query_or_table}) t'
-        else:
-            return f'select * from {schema}{query_or_table}'
+    if len(dt_col_names) > 0:
 
-    else:
         # if a date column exists, we must reformat them so that they will be compatible with Shp/Gpkg file
         results = ' , '.join([c for c in columns_with_brackets if c not in dt_col_names])
 
@@ -131,18 +153,17 @@ def write_geo_cmd_query(dbo, query_or_table, path, is_query = False, schema = ''
                                 'cast(cast(\\"{col}\\" as time) as varchar) \\"{shortened_col}_tm\\" '.format(
                                 col=col_name, shortened_col = shortened_col
                                 )
-            elif dbo.type == MS and path.endswith('shp'):
+            elif dbo.type == MS:
                 # date type only needs correction for MS Shp, not GPKG
                 results += " , cast([{col}] as date) [{shortened_col}_dt], cast(cast([{col}] as time) as varchar)" \
                                 " [{shortened_col}_tm] ".format(
                                 col=col_name, shortened_col = shortened_col
                                 )
 
-        # Wrap the original query and select the non-datetime/timestamp columns and the parsed out dates/times
-        if is_query:
-            return  f"select {results} from ({query_or_table}) q "
-        else:
-            return  f"select {results} from {schema}{query_or_table} q "
+    else:
+        results = '*'
+
+    return results
 
 def write_geospatial(dbo, path,  table = None, schema = '', query = None, gpkg_tbl = None,
                         srid='2263', gdal_data_loc=GDAL_DATA_LOC, cmd = None, overwrite = False, print_cmd=False):

--- a/pysqldb3/pysqldb3.py
+++ b/pysqldb3/pysqldb3.py
@@ -844,7 +844,7 @@ class DbConnect:
                     case    when t.name in ('text', 'int', 'date') then t.name
                             when t.max_length is not null and t.max_length < 3000 then t.name + ' ('+ cast(t.max_length as varchar)+')'  
                             when t.max_length >= 3000 then t.name + ' (3000)'
-                       else t.name
+                       else coalesce(t.name, 'Unknown')
                        end as DATA_TYPE
                 FROM
                     tempdb.sys.columns AS c

--- a/pysqldb3/tests/helpers.py
+++ b/pysqldb3/tests/helpers.py
@@ -526,3 +526,34 @@ def clean_up_geopackage():
             os.remove(_fle)
 
     print ('Deleting any existing gpkg')
+
+
+def identify_default_dtypes(db, schema = 'working'):
+
+    """
+    Identify default data types in PostgreSQL and MS SQL Servers for integer, varchar, and geometry.
+    This was created to address "USER-DEFINED" data types or variations in data type names.
+    :param db: Database connection
+    :param ms_schema: SQL Server schema
+    """
+    db.query(f"""
+    
+        drop table if exists {schema}.test_default_dtypes;                               
+        create table {schema}.test_default_dtypes(int_col int, geom geometry);
+        insert into {schema}.test_default_dtypes
+            VALUES(1, {"geometry::STGeomFromText('POINT(1015329.1 213793.1)', 2263)" 
+                       if db.type == 'MS'
+                       else "st_setsrid(st_point(1015329.1, 213793.1), 2263)::geometry"});
+        """)
+
+    data_types = db.get_table_columns('test_default_dtypes', schema = schema)
+
+    # drop the tables
+    db.drop_table(schema = schema, table = 'test_default_dtypes')
+    assert not db.table_exists(schema = schema, table = 'test_default_dtypes')
+
+    # isolate data type and remove the character limit
+    db_int = data_types[0][1]
+    db_geom = data_types[1][1]
+
+    return db_int, db_geom

--- a/pysqldb3/tests/test_geospatial.py
+++ b/pysqldb3/tests/test_geospatial.py
@@ -803,7 +803,8 @@ class TestWritegpkgPG:
         db.query(f"""
         drop table if exists {pg_schema}.{test_write_gpkg_table_name};
         create table {pg_schema}.{test_write_gpkg_table_name} as
-        select now() dt_format, current_date today
+        select  cast('10/14/2010 19:12:00' as timestamp) dt_format,
+                cast('5/4/2003' as date) today
         """)
 
         gpkg_name = 'testgpkg.gpkg'
@@ -815,15 +816,44 @@ class TestWritegpkgPG:
         assert os.path.isfile(os.path.join(FOLDER_PATH, gpkg_name))
 
         # Assert that date columns are in the proper format
-        cmd_shp = f'ogrinfo -so -al "{FOLDER_PATH}/{gpkg_name}" '
+        cmd_shp = f'ogrinfo "{FOLDER_PATH}/{gpkg_name}" -sql "select * from {test_write_gpkg_table_name}"'
         ogr_response_shp = subprocess.check_output(shlex.split(cmd_shp), stderr=subprocess.STDOUT)   
-        assert 'dt_form_dt: Date' in str(ogr_response_shp), "'dt_form_dt column is not a Date data type when it should be"
-        assert 'dt_form_tm: String' in str(ogr_response_shp), "'dt_form_tm column is not a String data type when it should be"
-        assert 'today: Date' in str(ogr_response_shp), "'today column is not a Date data type when it should be"
+        assert 'dt_form_dt (Date) = 2010/10/14' in str(ogr_response_shp), "'dt_form_dt column is not returning hte correct Type and Date"
+        assert 'dt_form_tm (String) = 19:12:00' in str(ogr_response_shp), "'dt_form_tm column is not returning the correct Type and Time"
+        assert 'today (Date) = 2003/05/04' in str(ogr_response_shp), "'today column is not returning the correct Type & Date"
 
         # clean up
         db.drop_table(schema=pg_schema, table=test_write_gpkg_table_name)
         os.remove(os.path.join(FOLDER_PATH, gpkg_name))
+
+    def test_write_gpkg_longdate_table(self):
+        db.query(f"""
+                drop table if exists {pg_schema}.{test_write_gpkg_table_name};
+                create table {pg_schema}.{test_write_gpkg_table_name} as
+                select  cast('10/14/2010 19:12:00' as timestamp) dtformatted2010,
+                        cast('7/11/1988 03:05:00' as timestamp) dtformatted201054
+                """)
+
+        gpkg_name = 'testgpkg.gpkg'
+
+        # Write gpkg
+        s.write_geospatial(path=os.path.join(FOLDER_PATH, gpkg_name), dbo=db, schema=pg_schema, table=test_write_gpkg_table_name, print_cmd=True)
+
+        # Assert successful
+        assert os.path.isfile(os.path.join(FOLDER_PATH, gpkg_name))
+
+        # Assert that date columns are in the proper format
+        cmd_shp = f'ogrinfo "{FOLDER_PATH}/{gpkg_name}" -sql "select * from {test_write_gpkg_table_name}"'
+        ogr_response_shp = subprocess.check_output(shlex.split(cmd_shp), stderr=subprocess.STDOUT)   
+        assert 'dt_form_dt (Date) = 2010/10/14' in str(ogr_response_shp), "'dt_form_dt column is not returning the correct Date and Type"
+        assert 'dt_form_tm (String) = 19:12:00' in str(ogr_response_shp), "'dt_form_tm column is not returning the correct Type and Time"
+        assert 'dtformat (Date) = 1988/07/11' in str(ogr_response_shp), "'dt_form_dt column is not returning the correct Date and Type"
+        assert 'dtformat (String) = 03:05:00' in str(ogr_response_shp), "'dt_form_tm column is not returning the correct Type and Time"
+
+        # clean up
+        db.drop_table(schema=pg_schema, table=test_write_gpkg_table_name)
+        os.remove(os.path.join(FOLDER_PATH, gpkg_name))
+
 
     @classmethod
     def teardown_class(cls):
@@ -1127,6 +1157,28 @@ class TestWritegpkgMS:
 
         os.remove(os.path.join(FOLDER_PATH, gpkg_name))
         
+    def test_write_gpkg_dates_table(self):
+        
+        gpkg_name = 'testgpkg.gpkg'
+        sql.query(f"drop table if exists {ms_schema}.{test_write_gpkg_table_name}")
+
+        # Add test_table
+        sql.query(f"""
+        create table {ms_schema}.{test_write_gpkg_table_name} (test_dt datetime);
+        insert into {ms_schema}.{test_write_gpkg_table_name} VALUES(cast('11/12/1991 5:09:00' as datetime));
+        """)
+
+        # Write gpkg
+        s.write_geospatial(dbo=sql, query=f"select * from {ms_schema}.{test_write_gpkg_table_name}",
+                            path= os.path.join(FOLDER_PATH, gpkg_name), gpkg_tbl = test_write_gpkg_table_name, print_cmd=True)
+
+        # Check table in folder
+        assert os.path.isfile(os.path.join(FOLDER_PATH, gpkg_name))
+
+        cmd_gpkg = f'ogrinfo "{FOLDER_PATH}/{gpkg_name}" -sql "SELECT * FROM {test_write_gpkg_table_name} LIMIT 1" -q'
+        ogr_response_gpkg = subprocess.check_output(shlex.split(cmd_gpkg), stderr=subprocess.STDOUT)
+        assert 'test_dt (DateTime) = 1991/11/12 05:09:00' in str(ogr_response_gpkg), "not returning correct datetime and type"
+
     @classmethod
     def teardown_class(cls):
         helpers.clean_up_test_table_sql(sql)
@@ -2098,8 +2150,8 @@ class TestWriteShpPG:
         db.query(f"""
                 drop table if exists {pg_schema}.{test_write_shp_table_name};
                 create table {pg_schema}.{test_write_shp_table_name} as
-                select  now() as dt_col,
-                        current_date as dt_col2,
+                select  cast('1/1/2000 11:50:00 AM' as timestamp) as dt_col,
+                        cast('1/1/2000 11:50:00 AM' as timestamp) as dt_col2,
                         cast('2020-01-01' as date) as next_dt_col,
                         geom
                 from {pg_schema}.{pg_table_name};
@@ -2111,10 +2163,40 @@ class TestWriteShpPG:
         assert os.path.isfile(os.path.join(FOLDER_PATH, shp_name))
 
         # check that Date column is set as a Date type
-        cmd_shp = f'ogrinfo -so -al "{FOLDER_PATH}/{shp_name}" '
+        cmd_shp = f'ogrinfo "{FOLDER_PATH}/{shp_name}" -sql "select * from test_write limit 1"'
         ogr_response_shp = subprocess.check_output(shlex.split(cmd_shp), stderr=subprocess.STDOUT)   
-        assert 'dt_col_dt: Date' in str(ogr_response_shp), "'dt_col_dt column is not a Date data type when it should be"
-        assert 'dt_col_tm: String' in str(ogr_response_shp), "'dt_col_tm column is not a String data type when it should be"
+        for dt_col in ['dt_col', 'dt_col2']:
+            assert f'{dt_col}_dt (Date) = 2000/01/01' in str(ogr_response_shp), f"{dt_col}_dt column is not returning the correct Date & Value"
+            assert f'{dt_col}_tm (String) = 11:50:00' in str(ogr_response_shp), f"{dt_col}_tm column is not returning the correct Time & Value"
+
+        assert 'next_dt_co (Date) = 2020/01/01' in str(ogr_response_shp), "next_dt_co column is not returning thse correct Date & Value"
+    
+    def test_write_shp_longdate_table(self):
+
+        shp_name = 'test_write.shp'
+
+        db.query(f"""
+                drop table if exists {pg_schema}.{test_write_shp_table_name};
+                create table {pg_schema}.{test_write_shp_table_name} as
+                select  cast('1/1/2000 11:50:00' as timestamp) as long_dt_column123,
+                        cast('8/4/2004 7:20:00' as timestamp) as long_dt_column1234,
+                        geom
+                from {pg_schema}.{pg_table_name};
+                """)
+        
+        s.write_geospatial(path=os.path.join(FOLDER_PATH, shp_name), dbo=db, schema=pg_schema, table=test_write_shp_table_name, overwrite = True)
+
+        # Assert successful
+        assert os.path.isfile(os.path.join(FOLDER_PATH, shp_name))
+
+        # check that Date column is set as a Date type
+        cmd_shp = f'ogrinfo "{FOLDER_PATH}/{shp_name}" -sql "select * from test_write limit 1"'
+        ogr_response_shp = subprocess.check_output(shlex.split(cmd_shp), stderr=subprocess.STDOUT)   
+        
+        assert f'long_dt_co (Date) = 2000/01/01' in str(ogr_response_shp), f"long_dt_co column is not returning the correct Date & Value"
+        assert f'long_dt1_dt (Date) = 2004/08/04' in str(ogr_response_shp), f"long_dt1_dt column is not returning the correct Date & Value"
+        assert f'long_dt_co (Time) = 11:50:00' in str(ogr_response_shp), f"long_dt_co column is not returning the correct Time & Value"
+        assert f'long_dt1_dt (Time) = 07:20:00' in str(ogr_response_shp), f"long_dt1_dt column is not returning the correct Time & Value"
 
     @classmethod
     def teardown_class(cls):
@@ -2294,9 +2376,9 @@ class TestWriteShpMS:
 
         # Add test_table
         sql.query(f"""
-        create table {ms_schema}.{test_write_shp_table_name} (test_col1 int, test_col2 int, dte_standard date, dte datetime, geom geometry);
-        insert into {ms_schema}.{test_write_shp_table_name} VALUES(1, 2, getdate(), current_timestamp, geometry::Point(985831.79200444, 203371.60461367, 2263));
-        insert into {ms_schema}.{test_write_shp_table_name} VALUES(3, 4, getdate(), current_timestamp, geometry::Point(985831.79200444, 203371.60461367, 2263));
+        create table {ms_schema}.{test_write_shp_table_name} (test_col1 int, dte datetime, dte2 datetime, geom geometry);
+        insert into {ms_schema}.{test_write_shp_table_name} VALUES(1, '9/1/1965 18:00:00', '9/1/1965 18:00:00',
+                                                                geometry::Point(985831.79200444, 203371.60461367, 2263));
         """)
 
         fp = FOLDER_PATH
@@ -2309,9 +2391,11 @@ class TestWriteShpMS:
         assert os.path.isfile(os.path.join(fp, shp_name))
 
         # check that Date column is set as a Date type
-        cmd_shp = f'ogrinfo -so -al "{FOLDER_PATH}/{shp_name}" '
+        cmd_shp = f'ogrinfo "{FOLDER_PATH}/{shp_name}" -sql "select * from test_write limit 1"'
         ogr_response_shp = subprocess.check_output(shlex.split(cmd_shp), stderr=subprocess.STDOUT)   
-        assert 'dte: Date' in str(ogr_response_shp), "'dte column is not a Date data type when it should be"
+        for dt_col in ['dte', 'dte2']:
+            assert f'{dt_col}_dt (Date) = 1965/09/01' in str(ogr_response_shp), f"{dt_col}_dt column is not returning the correct Date & Value"
+            assert f'{dt_col}_tm (String) = 18:00:00' in str(ogr_response_shp), f"{dt_col}_tm column is not returning the correct Time & Value"
 
         # Clean up
         sql.drop_table(schema=ms_schema, table=test_write_shp_table_name)
@@ -2321,6 +2405,37 @@ class TestWriteShpMS:
                 os.remove(os.path.join(fp, shp_name.replace('shp', ext)))
             except Exception as e:
                 print(e)
+
+    def test_write_shp_longdate_table(self):
+
+        sql.drop_table(schema=ms_schema, table=test_write_shp_table_name)
+
+        # Add test_table
+        sql.query(f"""
+        create table {ms_schema}.{test_write_shp_table_name} (test_col1 int, long_datetime datetime, dte2 datetime, geom geometry);
+        insert into {ms_schema}.{test_write_shp_table_name} VALUES(1, '9/1/1965 18:00:00', '9/1/1965 18:00:00',
+                                                                geometry::Point(985831.79200444, 203371.60461367, 2263));
+        insert into {ms_schema}.{test_write_shp_table_name} VALUES(3, '9/1/1965 18:00:00', '9/1/1965 18:00:00',
+                                                                geometry::Point(985831.79200444, 203371.60461367, 2263));
+        """)
+
+        fp = FOLDER_PATH
+        shp_name = 'test_write.shp'
+
+        # Write shp
+        s.write_geospatial(dbo=sql, path= os.path.join(fp, shp_name), table=test_write_shp_table_name, schema=ms_schema, print_cmd=True)
+
+        # Assert successful
+        assert os.path.isfile(os.path.join(fp, shp_name))
+
+        # check that Date column is set as a Date type
+        cmd_shp = f'ogrinfo "{FOLDER_PATH}/{shp_name}" -sql "select * from test_write limit 1"'
+        ogr_response_shp = subprocess.check_output(shlex.split(cmd_shp), stderr=subprocess.STDOUT)   
+        
+        assert f'long_dt_co (Date) = 2000/01/01' in str(ogr_response_shp), f"long_dt_co column is not returning the correct Date & Value"
+        assert f'long_dt1_dt (Date) = 2004/08/04' in str(ogr_response_shp), f"long_dt1_dt column is not returning the correct Date & Value"
+        assert f'long_dt_co (Time) = 11:50:00' in str(ogr_response_shp), f"long_dt_co column is not returning the correct Time & Value"
+        assert f'long_dt1_dt (Time) = 07:20:00' in str(ogr_response_shp), f"long_dt1_dt column is not returning the correct Time & Value"
 
     @classmethod
     def teardown_class(cls):

--- a/pysqldb3/tests/test_geospatial.py
+++ b/pysqldb3/tests/test_geospatial.py
@@ -799,6 +799,32 @@ class TestWritegpkgPG:
         db.drop_table(schema=pg_schema, table=test_reuploaded_table_name)
         os.remove(os.path.join(FOLDER_PATH, gpkg_name))
 
+    def test_write_gpkg_dates_table(self):
+        db.query(f"""
+        drop table if exists {pg_schema}.{test_write_gpkg_table_name};
+        create table {pg_schema}.{test_write_gpkg_table_name} as
+        select now() dt_format, current_date today
+        """)
+
+        gpkg_name = 'testgpkg.gpkg'
+
+        # Write gpkg
+        s.write_geospatial(path=os.path.join(FOLDER_PATH, gpkg_name), dbo=db, schema=pg_schema, table=test_write_gpkg_table_name, print_cmd=True)
+
+        # Assert successful
+        assert os.path.isfile(os.path.join(FOLDER_PATH, gpkg_name))
+
+        # Assert that date columns are in the proper format
+        cmd_shp = f'ogrinfo -so -al "{FOLDER_PATH}/{gpkg_name}" '
+        ogr_response_shp = subprocess.check_output(shlex.split(cmd_shp), stderr=subprocess.STDOUT)   
+        assert 'dt_form_dt: Date' in str(ogr_response_shp), "'dt_form_dt column is not a Date data type when it should be"
+        assert 'dt_form_tm: String' in str(ogr_response_shp), "'dt_form_tm column is not a String data type when it should be"
+        assert 'today: Date' in str(ogr_response_shp), "'today column is not a Date data type when it should be"
+
+        # clean up
+        db.drop_table(schema=pg_schema, table=test_write_gpkg_table_name)
+        os.remove(os.path.join(FOLDER_PATH, gpkg_name))
+
     @classmethod
     def teardown_class(cls):
         helpers.clean_up_test_table_pg(db)
@@ -2088,6 +2114,7 @@ class TestWriteShpPG:
         cmd_shp = f'ogrinfo -so -al "{FOLDER_PATH}/{shp_name}" '
         ogr_response_shp = subprocess.check_output(shlex.split(cmd_shp), stderr=subprocess.STDOUT)   
         assert 'dt_col_dt: Date' in str(ogr_response_shp), "'dt_col_dt column is not a Date data type when it should be"
+        assert 'dt_col_tm: String' in str(ogr_response_shp), "'dt_col_tm column is not a String data type when it should be"
 
     @classmethod
     def teardown_class(cls):

--- a/pysqldb3/tests/test_geospatial.py
+++ b/pysqldb3/tests/test_geospatial.py
@@ -3,7 +3,7 @@ import configparser
 import pandas as pd
 import subprocess
 import shlex
-import pytest
+import re
 
 from .. import pysqldb3 as pysqldb
 from .. import geospatial as s
@@ -47,6 +47,8 @@ pg_schema = 'working'
 fgdb = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'test_data/lion/lion.gdb')
 fc = 'node.shp'
 
+db_int, db_geom = helpers.identify_default_dtypes(db, pg_schema)
+sql_int, sql_geom = helpers.identify_default_dtypes(sql, ms_schema)
 
 # TODO -  detect int types for GDAL and detect default geo column name for testing variables
 
@@ -447,29 +449,6 @@ class TestWritegpkgPG:
     def setup_class(cls):
         helpers.set_up_test_table_pg(db)
 
-    # todo - was missing test for table - didnt catch paren issue - add more tests
-    def test_write_shp_table(self):
-        db.query(f"""
-               drop table if exists {pg_schema}.{test_write_gpkg_table_name};
-
-               create table {pg_schema}.{test_write_gpkg_table_name} as
-               select *, now() as dt_col
-               from {pg_schema}.{pg_table_name}
-               order by id
-               limit 100
-               """)
-        shp_name = 'wrtie_shp_test.shp'
-        s.write_geospatial(path=os.path.join(FOLDER_PATH, shp_name), dbo=db, schema=pg_schema,
-                           table=test_write_gpkg_table_name)
-
-        # Assert successful
-        assert os.path.isfile(os.path.join(FOLDER_PATH, shp_name))
-
-        # clean up
-        db.drop_table(schema=pg_schema, table=test_write_gpkg_table_name)
-        os.remove(os.path.join(FOLDER_PATH, shp_name))
-
-
     def test_write_gpkg_table(self):
         db.query(f"""
         drop table if exists {pg_schema}.{test_write_gpkg_table_name};
@@ -864,7 +843,7 @@ class TestWritegpkgMS:
         # Assert before/after geom columns are all 0 ft from each other, even if represented differently
         dist_df = sql.dfquery(f"""
         select distinct b.geom.STDistance(a.geom) as distance
-        from {ms_schema}.{test_reuploaded_table_name} b
+        from {ms_schema}.{test_write_gpkg_table_name} b
         join {ms_schema}.{test_reuploaded_table_name} a
             on b.test_col1=a.test_col1
         """)
@@ -1958,7 +1937,7 @@ class TestWriteShpPG:
         s.upload_geospatial(dbo = db, path=fp, input_file=shp_name, schema=pg_schema, table=test_reuploaded_table_name, print_cmd=True)
 
         # Assert equality
-        db_df = db.dfquery(f"select * from {pg_schema}.{pg_table_name} order by id limit 100")
+        db_df = db.dfquery(f"select * from {pg_schema}.{test_write_shp_table_name} order by id limit 100")
         shp_uploaded_df = db.dfquery(f"select * from {pg_schema}.{test_reuploaded_table_name} order by id")
 
         assert len(db_df) == len(shp_uploaded_df)
@@ -2086,11 +2065,34 @@ class TestWriteShpPG:
         for ext in ('dbf', 'prj', 'shx', 'shp'):
             os.remove(os.path.join(FOLDER_PATH, shp_name.replace('shp', ext)))
 
+    def test_write_shp_dates_table(self):
+
+        shp_name = 'test_write.shp'
+
+        db.query(f"""
+                drop table if exists {pg_schema}.{test_write_shp_table_name};
+                create table {pg_schema}.{test_write_shp_table_name} as
+                select  now() as dt_col,
+                        current_date as dt_col2,
+                        cast('2020-01-01' as date) as next_dt_col,
+                        geom
+                from {pg_schema}.{pg_table_name};
+                """)
+
+        s.write_geospatial(path=os.path.join(FOLDER_PATH, shp_name), dbo=db, schema=pg_schema, table=test_write_shp_table_name, overwrite = True)
+
+        # Assert successful
+        assert os.path.isfile(os.path.join(FOLDER_PATH, shp_name))
+
+        # check that Date column is set as a Date type
+        cmd_shp = f'ogrinfo -so -al "{FOLDER_PATH}/{shp_name}" '
+        ogr_response_shp = subprocess.check_output(shlex.split(cmd_shp), stderr=subprocess.STDOUT)   
+        assert 'dt_col_dt: Date' in str(ogr_response_shp), "'dt_col_dt column is not a Date data type when it should be"
+
     @classmethod
     def teardown_class(cls):
         helpers.clean_up_test_table_pg(db)
         helpers.clean_up_shapefile()
-
 
 class TestWriteShpMS:
     def test_write_shp_table(self):
@@ -2130,7 +2132,7 @@ class TestWriteShpMS:
         # Assert before/after geom columns are all 0 ft from each other, even if represented differently
         dist_df = sql.dfquery(f"""
         select distinct b.geom.STDistance(a.geom) as distance
-        from {ms_schema}.{test_reuploaded_table_name} b
+        from {ms_schema}.{test_write_shp_table_name} b
         join {ms_schema}.{test_reuploaded_table_name} a
         on b.test_col1=a.test_col1
         """)
@@ -2260,6 +2262,39 @@ class TestWriteShpMS:
             except Exception as e:
                 print(e)
 
+    def test_write_shp_dates_table(self):
+        sql.drop_table(schema=ms_schema, table=test_write_shp_table_name)
+
+        # Add test_table
+        sql.query(f"""
+        create table {ms_schema}.{test_write_shp_table_name} (test_col1 int, test_col2 int, dte_standard date, dte datetime, geom geometry);
+        insert into {ms_schema}.{test_write_shp_table_name} VALUES(1, 2, getdate(), current_timestamp, geometry::Point(985831.79200444, 203371.60461367, 2263));
+        insert into {ms_schema}.{test_write_shp_table_name} VALUES(3, 4, getdate(), current_timestamp, geometry::Point(985831.79200444, 203371.60461367, 2263));
+        """)
+
+        fp = FOLDER_PATH
+        shp_name = 'test_write.shp'
+
+        # Write shp
+        s.write_geospatial(dbo=sql, path= os.path.join(fp, shp_name), table=test_write_shp_table_name, schema=ms_schema, print_cmd=True)
+
+        # Assert successful
+        assert os.path.isfile(os.path.join(fp, shp_name))
+
+        # check that Date column is set as a Date type
+        cmd_shp = f'ogrinfo -so -al "{FOLDER_PATH}/{shp_name}" '
+        ogr_response_shp = subprocess.check_output(shlex.split(cmd_shp), stderr=subprocess.STDOUT)   
+        assert 'dte: Date' in str(ogr_response_shp), "'dte column is not a Date data type when it should be"
+
+        # Clean up
+        sql.drop_table(schema=ms_schema, table=test_write_shp_table_name)
+
+        for ext in ('dbf', 'prj', 'shx', 'shp'):
+            try:
+                os.remove(os.path.join(fp, shp_name.replace('shp', ext)))
+            except Exception as e:
+                print(e)
+
     @classmethod
     def teardown_class(cls):
         helpers.clean_up_test_table_sql(sql)
@@ -2319,7 +2354,7 @@ class TestFeatureClassToTablePg:
         db.feature_class_to_table(path = fgdb, table=test_feature_class_table_name, feature_class=fc, schema=pg_schema, srid=4326)
         assert db.table_exists(test_feature_class_table_name, schema=pg_schema)
 
-        db.query(f'select distinct st_srid("Shape") from {pg_schema}.{test_feature_class_table_name}')
+        db.query(f'select distinct st_srid(geom) from {pg_schema}.{test_feature_class_table_name}')
         assert db.data[0][0] == 4326
 
         db.drop_table(pg_schema, test_feature_class_table_name)
@@ -2332,21 +2367,21 @@ class TestFeatureClassToTablePg:
         assert db.table_exists(test_feature_class_table_name, schema=db.default_schema)
 
         db.query(f"""
-            SELECT column_name, data_type
+            SELECT column_name, data_type, udt_name
             FROM information_schema.columns
             WHERE table_name = '{test_feature_class_table_name}'
             AND table_schema = '{db.default_schema}'
         """)
 
         columns = {i[0] for i in db.data}
-        types = {i[1] for i in db.data}
+        types = {i[1] if i[1] != 'USER-DEFINED' else i[2] for i in db.data} # use udt_type if user-defined
 
-        assert {'vintersect', 'objectid', 'Shape', 'nodeid'}.issubset(columns)
-        assert {'integer', 'integer', 'character varying', 'USER-DEFINED'}.issubset(types)
+        assert {'vintersect', 'objectid', 'geom', 'nodeid'}.issubset(columns)
+        assert {db_int, 'character varying', db_geom}.issubset(types)
 
         # check non geom data
         db.query(f"""
-                    select nodeid, vintersect, st_astext("Shape", 1) geom from {db.default_schema}.{test_feature_class_table_name} where nodeid in (88, 98, 100)
+                    select nodeid, vintersect, st_astext(geom, 1) geom from {db.default_schema}.{test_feature_class_table_name} where nodeid in (88, 98, 100)
                 """)
 
         row_values = [(88, 'VirtualIntersection', 'MULTIPOINT(914145.1 126536.1)'),
@@ -2360,7 +2395,7 @@ class TestFeatureClassToTablePg:
 
         # check geom matches (less than 1 ft off
         db.query(f"""
-            select st_distance(st_setsrid(ST_GeometryN("Shape", 1), 2263),
+            select st_distance(st_setsrid(ST_GeometryN(geom, 1), 2263),
                 st_setsrid(st_makepoint(914145.1,126536.1, 2263),2263))
             from {db.default_schema}.{test_feature_class_table_name}
             where nodeid=88
@@ -2368,7 +2403,7 @@ class TestFeatureClassToTablePg:
         assert db.data[0][0] < 1
 
         db.query(f"""
-            select st_distance(st_setsrid(ST_GeometryN("Shape", 1), 2263),
+            select st_distance(st_setsrid(ST_GeometryN(geom, 1), 2263),
                 st_setsrid(st_makepoint(920184.0, 138084.1, 2263),2263))
             from {db.default_schema}.{test_feature_class_table_name}
             where nodeid=888
@@ -2434,7 +2469,6 @@ class TestFeatureClassToTablePg:
     @classmethod
     def teardown_class(cls):
         db.cleanup_new_tables()
-
 
 class TestFeatureClassToTableMs:
     @classmethod
@@ -2507,10 +2541,10 @@ class TestFeatureClassToTableMs:
         """)
 
         columns = {i[0] for i in sql.data}
-        types = {i[1] for i in sql.data}
-
+        types = {re.sub('\s\((.*)\)$', '', i[1]) for i in sql.data}
+                     
         assert {'objectid', 'geom', 'nodeid', 'vintersect'}.issubset(columns)
-        assert {'int', 'geometry', 'int', 'nvarchar'}.issubset(types)
+        assert {sql_int, sql_geom, 'nvarchar'}.issubset(types)
 
         # check non geom data
         sql.query(f"""select nodeid, vintersect, geom.STAsText() geom from {sql.default_schema}.{test_feature_class_table_name} where nodeid in (88, 98, 100)
@@ -2586,7 +2620,7 @@ class TestFeatureClassToTableMs:
         sql.drop_table(table=test_feature_class_table_name, schema=ms_schema)
         assert not sql.table_exists(test_feature_class_table_name, schema=ms_schema)
 
-        sql.feature_class_to_table(path = fgdb, table = test_feature_class_table_name, feature_class = fc, schema=ms_schema, shp_name='lion.gdb',
+        sql.feature_class_to_table(path = fgdb, table = test_feature_class_table_name, feature_class = fc, schema=ms_schema,
                                     extra_cmd='-nlt MULTILINESTRING')
         assert sql.table_exists(test_feature_class_table_name, schema=ms_schema)
 

--- a/pysqldb3/tests/test_geospatial.py
+++ b/pysqldb3/tests/test_geospatial.py
@@ -2541,10 +2541,10 @@ class TestFeatureClassToTableMs:
         """)
 
         columns = {i[0] for i in sql.data}
-        types = {re.sub('\s\((.*)\)$', '', i[1]) for i in sql.data}
+        types = {i[1] for i in sql.data} 
                      
         assert {'objectid', 'geom', 'nodeid', 'vintersect'}.issubset(columns)
-        assert {sql_int, sql_geom, 'nvarchar'}.issubset(types)
+        assert {sql_int, re.sub('\s\((.*)\)$', '', sql_geom), 'nvarchar'}.issubset(types) # remove the max chars parentheses so they match the default dtype table
 
         # check non geom data
         sql.query(f"""select nodeid, vintersect, geom.STAsText() geom from {sql.default_schema}.{test_feature_class_table_name} where nodeid in (88, 98, 100)

--- a/pysqldb3/tests/test_query_to_geospatial.py
+++ b/pysqldb3/tests/test_query_to_geospatial.py
@@ -32,6 +32,9 @@ test_table_shp = f'__testing_query_to_geospatial_{db.user}__'
 ms_schema = 'dbo'
 pg_schema = 'working'
 
+db_int, db_geom = helpers.identify_default_dtypes(db, pg_schema)
+sql_int, sql_geom = helpers.identify_default_dtypes(sql, ms_schema)
+
 FOLDER_PATH = helpers.DIR
 
 class TestQueryToGpkgPg:
@@ -805,8 +808,7 @@ class TestQueryToGpkgMs:
         select
             case when t1.fld2 = t2.fld2 then 1 else 0 end,
             case when left(t1.fld3, 254) = left(t2.fld3, 254) then 1 else 0 end,
-            case when cast(t1.fld4 as date)=t2.fld4_dt then 1 else 0 end, -- shapefiles cannot store datetimes
-            case when cast(t1.fld4 as time)=t2.fld4_tm then 1 else 0 end, -- shapefiles cannot store datetimes
+            case when t1.fld4 =t2.fld4 then 1 else 0 end,
             case when t1.fld5 = t2.fld5 then 1 else 0 end,
             case when t1.fld6.STDistance(t2.fld6) < 1  then 1 else 0 end-- default name from pysqldb
         from {ms_schema}.{test_table} t1
@@ -859,8 +861,7 @@ class TestQueryToGpkgMs:
         select
             case when t1.fld2 = t2.fld2 then 1 else 0 end,
             case when left(t1.fld3, 254) = left(t2.fld3, 254) then 1 else 0 end,
-            case when cast(t1.longfld4 as date)=t2.longfld_dt then 1 else 0 end, -- shapefiles cannot store datetimes
-            case when cast(t1.longfld4 as time)=t2.longfld_tm then 1 else 0 end, -- shapefiles cannot store datetimes
+            case when t1.longfld4=t2.longfld4 then 1 else 0 end,
             case when t1.fld5 = t2.fld5 then 1 else 0 end,
             case when t1.fld6.STDistance(t2.fld6) < 1  then 1 else 0 end-- default name from pysqldb
         from {ms_schema}.{test_table} t1
@@ -903,10 +904,10 @@ class TestQueryToShpPg:
         db.drop_table(schema = pg_schema, table = test_table)
         # create table
         db.query(f"""
-            CREATE TABLE {pg_schema}.{test_table} (id int, txt text, dte timestamp, geom geometry(Point));
+            CREATE TABLE {pg_schema}.{test_table} (id int, txt text, dte timestamp, dt2 date, geom geometry(Point));
 
             INSERT INTO {pg_schema}.{test_table}
-             VALUES (1, 'test text', now(), st_setsrid(st_makepoint(1015329.1, 213793.1), 2263))
+             VALUES (1, 'test text', now(),  cast('2020-01-01' as date), st_setsrid(st_makepoint(1015329.1, 213793.1), 2263))
         """)
         assert db.table_exists(test_table, schema=pg_schema)
 
@@ -920,6 +921,11 @@ class TestQueryToShpPg:
         cmd = r'gdalsrsinfo {}\{}'.format(fldr, shp).replace('\\', '/')
         ogr_response = subprocess.check_output(shlex.split(cmd), stderr=subprocess.STDOUT)
         assert b'"EPSG",2263' in ogr_response or b'"EPSG","2263"' in ogr_response
+
+        # check the data types
+        table_types = db.get_table_columns(test_table, schema = pg_schema)
+        types = [x[1] for x in table_types]
+        assert {db_int, 'text', 'timestamp without time zone', 'date', db_geom}.issubset(types)
 
         # clean up
         db.drop_table(pg_schema, test_table)
@@ -1278,6 +1284,12 @@ class TestQueryToShpMs:
         ogr_response = subprocess.check_output(shlex.split(cmd), stderr=subprocess.STDOUT)
         assert b'"EPSG",2263' in ogr_response or b'"EPSG","2263"' in ogr_response
 
+        # check the data types
+        table_types = sql.get_table_columns(test_table, schema = ms_schema)
+        types = [x[1] for x in table_types]
+
+        assert {sql_int, 'text', 'datetime', sql_geom}.issubset(types)
+        
         # clean up
         sql.drop_table(ms_schema, test_table_shp)
         for ext in ('dbf', 'prj', 'shx', 'shp'):

--- a/pysqldb3/tests/test_rename_geom.py
+++ b/pysqldb3/tests/test_rename_geom.py
@@ -73,7 +73,7 @@ class TestRenamesGeomPg:
         # import with pysqldb
 
         assert db.table_exists(table, schema=db.default_schema) is False
-        db.feature_class_to_table(fgdb, table, schema=None, shp_name=fc)
+        db.feature_class_to_table(fgdb, table, schema=None, feature_class=fc)
 
         db.query("""
             SELECT column_name, data_type
@@ -193,7 +193,7 @@ class TestRenamesGeomMs:
         # import with pysqldb
         assert not sql.table_exists(table, schema=sql.default_schema)
 
-        sql.feature_class_to_table(fgdb, table, schema=None, shp_name=fc, skip_failures='-skip_failures')
+        sql.feature_class_to_table(fgdb, table, schema=None, feature_class=fc, skip_failures='-skip_failures')
 
         sql.query("""
             SELECT column_name, data_type


### PR DESCRIPTION
Follow up from last week where I needed to clean up the tests since gpkg didn't always have date errors

#### To-dos:

1.  query the user's data types for geometry (I included integer as well) instead of hardcoding them since they can vary by user and we want the tests to work for all users.
 2.   Add tests for the datetime fields so we know that they are working in PG and MS (this impacts Shp files AND Gpkg/PG)
3.    Edit `write_geo_cmd_query` so that we didn't need an extra line of code to remove columns where the data_type is None. This was happening because MS temp tables don't recognize Geometry fields and would set them to None.