### PR TITLE
Fix identical long date column names

### DIFF
--- a/pysqldb3/geospatial.py
+++ b/pysqldb3/geospatial.py
@@ -145,9 +145,19 @@ def format_dte_columns(dbo, columns_with_types, columns_with_brackets):
         # if a date column exists, we must reformat them so that they will be compatible with Shp/Gpkg file
         results = ' , '.join([c for c in columns_with_brackets if c not in dt_col_names])
 
+        dtcolname_list = [] # create empty list of col names
+        dtcolname_suffix = 1 # start
+
         for col_name in dt_col_names:
 
-            shortened_col = col_name[:7]
+            if any(x == col_name[:11] for x in dtcolname_list): # if colname already claimed
+                shortened_col = col_name[:6] + str(dtcolname_suffix) # shortened column name
+                dtcolname_suffix = dtcolname_suffix + 1 # move number by 1
+            else:
+                # no change to the col_name, simply add to the reference list
+                dtcolname_list.append(col_name[:11]) # add to the list
+                shortened_col = col_name[:7]
+
             if dbo.type == PG:
                 results += ' , cast(\\"{col}\\" as date) \\"{shortened_col}_dt\\", ' \
                                 'cast(cast(\\"{col}\\" as time) as varchar) \\"{shortened_col}_tm\\" '.format(

--- a/pysqldb3/geospatial.py
+++ b/pysqldb3/geospatial.py
@@ -110,7 +110,7 @@ def write_geo_cmd_query(dbo, query_or_table, path, is_query = False, schema = ''
     columns_with_brackets = [left_bracket + c[0] + right_bracket for c in columns_with_types]
 
     # certain database connections + output formats require formatting for dates
-    if dbo.type == PG or (dbo.type == MS and path.endswith('shp')):
+    if dbo.type == PG:
         results = format_dte_columns(dbo, columns_with_types, columns_with_brackets)
     else:
         results = ' , '.join([c for c in columns_with_brackets])

--- a/pysqldb3/geospatial.py
+++ b/pysqldb3/geospatial.py
@@ -125,7 +125,7 @@ def format_dte_columns(dbo, columns_with_types, columns_with_brackets):
 
     """
     Format the DateTime column so the geospatial output fit has formatted Date and Time columns.
-    This is applicable if the table is in PG, or MS and the output is a Shp, because it does not automatically format these dates.
+    This is applicable if the table is in PG because it does not automatically format these dates.
     
     :param dbo: Database connection
     :param columns_with_types: Output of get_table_columns that returns the column name and data type

--- a/pysqldb3/tests/test_geospatial.py
+++ b/pysqldb3/tests/test_geospatial.py
@@ -2392,8 +2392,7 @@ class TestWriteShpMS:
         # check that Date column is set as a Date type
         cmd_shp = f'ogrinfo "{FOLDER_PATH}/{shp_name}" -sql "select * from test_write limit 1"'
         ogr_response_shp = subprocess.check_output(shlex.split(cmd_shp), stderr=subprocess.STDOUT)   
-        assert f'dte_dt (Date) = 1965/09/01' in str(ogr_response_shp), f"dte_dt column is not returning the correct Date & Value"
-        assert f'dte_tm (String) = 18:00:00' in str(ogr_response_shp), f"dte_tm column is not returning the correct Time & Value"
+        assert f'dte (Date) = 1965/09/01' in str(ogr_response_shp), f"dte_dt column is not returning the correct Date & Value"
 
         # Clean up
         sql.drop_table(schema=ms_schema, table=test_write_shp_table_name)
@@ -2403,35 +2402,6 @@ class TestWriteShpMS:
                 os.remove(os.path.join(fp, shp_name.replace('shp', ext)))
             except Exception as e:
                 print(e)
-
-    def test_write_shp_longdate_table(self):
-
-        sql.drop_table(schema=ms_schema, table=test_write_shp_table_name)
-
-        # Add test_table
-        sql.query(f"""
-        create table {ms_schema}.{test_write_shp_table_name} (test_col1 int, long_datetime datetime, long_datetime_new datetime, geom geometry);
-        insert into {ms_schema}.{test_write_shp_table_name} VALUES(1, '9/1/1965 18:00:00', '12/31/2005 05:22:00',
-                                                                geometry::Point(985831.79200444, 203371.60461367, 2263));
-        """)
-
-        fp = FOLDER_PATH
-        shp_name = 'test_write.shp'
-
-        # Write shp
-        s.write_geospatial(dbo=sql, path= os.path.join(fp, shp_name), table=test_write_shp_table_name, schema=ms_schema, print_cmd=True)
-
-        # Assert successful
-        assert os.path.isfile(os.path.join(fp, shp_name))
-
-        # check that Date column is set as a Date type
-        cmd_shp = f'ogrinfo "{FOLDER_PATH}/{shp_name}" -sql "select * from test_write limit 1"'
-        ogr_response_shp = subprocess.check_output(shlex.split(cmd_shp), stderr=subprocess.STDOUT)   
-        
-        assert f'long_da_dt (Date) = 1965/09/01' in str(ogr_response_shp), f"long_da_dt column is not returning the correct Date & Value"
-        assert f'long_da_tm (String) = 18:00:00' in str(ogr_response_shp), f"long_da_tm column is not returning the correct Time & Value"
-        assert f'long_d1_dt (Date) = 2005/12/31' in str(ogr_response_shp), f"long_d1_dt column is not returning the correct Date & Value"
-        assert f'long_d1_tm (String) = 05:22:00' in str(ogr_response_shp), f"long_d1_tm column is not returning the correct Time & Value"
 
     @classmethod
     def teardown_class(cls):

--- a/pysqldb3/tests/test_geospatial.py
+++ b/pysqldb3/tests/test_geospatial.py
@@ -845,15 +845,14 @@ class TestWritegpkgPG:
         # Assert that date columns are in the proper format
         cmd_shp = f'ogrinfo "{FOLDER_PATH}/{gpkg_name}" -sql "select * from {test_write_gpkg_table_name}"'
         ogr_response_shp = subprocess.check_output(shlex.split(cmd_shp), stderr=subprocess.STDOUT)   
-        assert 'dt_form_dt (Date) = 2010/10/14' in str(ogr_response_shp), "'dt_form_dt column is not returning the correct Date and Type"
-        assert 'dt_form_tm (String) = 19:12:00' in str(ogr_response_shp), "'dt_form_tm column is not returning the correct Type and Time"
-        assert 'dtformat (Date) = 1988/07/11' in str(ogr_response_shp), "'dt_form_dt column is not returning the correct Date and Type"
-        assert 'dtformat (String) = 03:05:00' in str(ogr_response_shp), "'dt_form_tm column is not returning the correct Type and Time"
+        assert 'dtforma_dt (Date) = 2010/10/14' in str(ogr_response_shp), "'dtforma_dt column is not returning the correct Date and Type"
+        assert 'dtforma_tm (String) = 19:12:00' in str(ogr_response_shp), "'dtforma_tm column is not returning the correct Type and Time"
+        assert 'dtform1_dt (Date) = 1988/07/11' in str(ogr_response_shp), "'dtform1_dt column is not returning the correct Date and Type"
+        assert 'dtform1_tm (String) = 03:05:00' in str(ogr_response_shp), "'dtform1_tm column is not returning the correct Type and Time"
 
         # clean up
         db.drop_table(schema=pg_schema, table=test_write_gpkg_table_name)
         os.remove(os.path.join(FOLDER_PATH, gpkg_name))
-
 
     @classmethod
     def teardown_class(cls):
@@ -2193,10 +2192,10 @@ class TestWriteShpPG:
         cmd_shp = f'ogrinfo "{FOLDER_PATH}/{shp_name}" -sql "select * from test_write limit 1"'
         ogr_response_shp = subprocess.check_output(shlex.split(cmd_shp), stderr=subprocess.STDOUT)   
         
-        assert f'long_dt_co (Date) = 2000/01/01' in str(ogr_response_shp), f"long_dt_co column is not returning the correct Date & Value"
-        assert f'long_dt1_dt (Date) = 2004/08/04' in str(ogr_response_shp), f"long_dt1_dt column is not returning the correct Date & Value"
-        assert f'long_dt_co (Time) = 11:50:00' in str(ogr_response_shp), f"long_dt_co column is not returning the correct Time & Value"
-        assert f'long_dt1_dt (Time) = 07:20:00' in str(ogr_response_shp), f"long_dt1_dt column is not returning the correct Time & Value"
+        assert f'long_dt_dt (Date) = 2000/01/01' in str(ogr_response_shp), f"long_dt_dt column is not returning the correct Date & Value"
+        assert f'long_d1_dt (Date) = 2004/08/04' in str(ogr_response_shp), f"long_d1_dt column is not returning the correct Date & Value"
+        assert f'long_dt_tm (String) = 11:50:00' in str(ogr_response_shp), f"long_dt_tm column is not returning the correct Time & Value"
+        assert f'long_d1_tm (String) = 07:20:00' in str(ogr_response_shp), f"long_d1_tm column is not returning the correct Time & Value"
 
     @classmethod
     def teardown_class(cls):
@@ -2376,9 +2375,9 @@ class TestWriteShpMS:
 
         # Add test_table
         sql.query(f"""
-        create table {ms_schema}.{test_write_shp_table_name} (test_col1 int, dte datetime, dte2 datetime, geom geometry);
-        insert into {ms_schema}.{test_write_shp_table_name} VALUES(1, '9/1/1965 18:00:00', '9/1/1965 18:00:00',
-                                                                geometry::Point(985831.79200444, 203371.60461367, 2263));
+        create table {ms_schema}.{test_write_shp_table_name} (test_col1 int, dte datetime, geom geometry);
+        insert into {ms_schema}.{test_write_shp_table_name} VALUES(1, '1965-09-01 18:00:00',
+                                                            geometry::Point(985831.79200444, 203371.60461367, 2263));
         """)
 
         fp = FOLDER_PATH
@@ -2393,9 +2392,8 @@ class TestWriteShpMS:
         # check that Date column is set as a Date type
         cmd_shp = f'ogrinfo "{FOLDER_PATH}/{shp_name}" -sql "select * from test_write limit 1"'
         ogr_response_shp = subprocess.check_output(shlex.split(cmd_shp), stderr=subprocess.STDOUT)   
-        for dt_col in ['dte', 'dte2']:
-            assert f'{dt_col}_dt (Date) = 1965/09/01' in str(ogr_response_shp), f"{dt_col}_dt column is not returning the correct Date & Value"
-            assert f'{dt_col}_tm (String) = 18:00:00' in str(ogr_response_shp), f"{dt_col}_tm column is not returning the correct Time & Value"
+        assert f'dte_dt (Date) = 1965/09/01' in str(ogr_response_shp), f"dte_dt column is not returning the correct Date & Value"
+        assert f'dte_tm (String) = 18:00:00' in str(ogr_response_shp), f"dte_tm column is not returning the correct Time & Value"
 
         # Clean up
         sql.drop_table(schema=ms_schema, table=test_write_shp_table_name)
@@ -2412,10 +2410,8 @@ class TestWriteShpMS:
 
         # Add test_table
         sql.query(f"""
-        create table {ms_schema}.{test_write_shp_table_name} (test_col1 int, long_datetime datetime, dte2 datetime, geom geometry);
-        insert into {ms_schema}.{test_write_shp_table_name} VALUES(1, '9/1/1965 18:00:00', '9/1/1965 18:00:00',
-                                                                geometry::Point(985831.79200444, 203371.60461367, 2263));
-        insert into {ms_schema}.{test_write_shp_table_name} VALUES(3, '9/1/1965 18:00:00', '9/1/1965 18:00:00',
+        create table {ms_schema}.{test_write_shp_table_name} (test_col1 int, long_datetime datetime, long_datetime_new datetime, geom geometry);
+        insert into {ms_schema}.{test_write_shp_table_name} VALUES(1, '9/1/1965 18:00:00', '12/31/2005 05:22:00',
                                                                 geometry::Point(985831.79200444, 203371.60461367, 2263));
         """)
 
@@ -2432,10 +2428,10 @@ class TestWriteShpMS:
         cmd_shp = f'ogrinfo "{FOLDER_PATH}/{shp_name}" -sql "select * from test_write limit 1"'
         ogr_response_shp = subprocess.check_output(shlex.split(cmd_shp), stderr=subprocess.STDOUT)   
         
-        assert f'long_dt_co (Date) = 2000/01/01' in str(ogr_response_shp), f"long_dt_co column is not returning the correct Date & Value"
-        assert f'long_dt1_dt (Date) = 2004/08/04' in str(ogr_response_shp), f"long_dt1_dt column is not returning the correct Date & Value"
-        assert f'long_dt_co (Time) = 11:50:00' in str(ogr_response_shp), f"long_dt_co column is not returning the correct Time & Value"
-        assert f'long_dt1_dt (Time) = 07:20:00' in str(ogr_response_shp), f"long_dt1_dt column is not returning the correct Time & Value"
+        assert f'long_da_dt (Date) = 1965/09/01' in str(ogr_response_shp), f"long_da_dt column is not returning the correct Date & Value"
+        assert f'long_da_tm (String) = 18:00:00' in str(ogr_response_shp), f"long_da_tm column is not returning the correct Time & Value"
+        assert f'long_d1_dt (Date) = 2005/12/31' in str(ogr_response_shp), f"long_d1_dt column is not returning the correct Date & Value"
+        assert f'long_d1_tm (String) = 05:22:00' in str(ogr_response_shp), f"long_d1_tm column is not returning the correct Time & Value"
 
     @classmethod
     def teardown_class(cls):

--- a/pysqldb3/tests/test_query_to_geospatial.py
+++ b/pysqldb3/tests/test_query_to_geospatial.py
@@ -863,7 +863,7 @@ class TestQueryToGpkgMs:
             case when left(t1.fld3, 254) = left(t2.fld3, 254) then 1 else 0 end,
             case when t1.longfld4=t2.longfld4 then 1 else 0 end,
             case when t1.fld5 = t2.fld5 then 1 else 0 end,
-            case when t1.fld6.STDistance(t2.fld6) < 1  then 1 else 0 end-- default name from pysqldb
+            case when t1.fld6.STDistance(t2.fld6) < 1 then 1 else 0 end-- default name from pysqldb
         from {ms_schema}.{test_table} t1
         join {ms_schema}.{test_table}QA t2
         on t1.fld1=t2.fld1


### PR DESCRIPTION
This PR addresses the scenario where there are 2 datetime columns with the same column name that is very long (ex. `original_datetime`). Currently, GDAL will automatically change the name of the second datetime column by truncating the name and adding a number, but this causes issues when `pysqldb3` creates date and time columns derived from the renamed datetime column.

* This PR allows `pysqldb3` to truncate the duplicated datetime column name before GDAL does it. 
* It also alters the conditions for parsing out datetime columns into `date` and `time` (line 113 in `geospatial.py` function `write_geo_cmd_query`) so that it only applies to `PG` (instead of `PG` and sometimes `MS`).
   * Under `MS`, the dates will default to date (shp) or datetime (gpkg) so it doesn't need to be reformatted. BUT this updated condition causes 2 date-related tests to fail in `test_query_to_geospatial.py`, which I don't fix in this PR. I think the issue will get resolved in future pair programming sessions when we review the `write_geospatial` function 