### PR TITLE
Alter col name for long date col names

### DIFF
--- a/pysqldb3/geospatial.py
+++ b/pysqldb3/geospatial.py
@@ -125,7 +125,7 @@ def format_dte_columns(dbo, columns_with_types, columns_with_brackets):
 
     """
     Format the DateTime column so the geospatial output fit has formatted Date and Time columns.
-    This is applicable if the table is in PG, or MS and the output is a Shp, because it does not automatically format these dates.
+    This is applicable if the output is a Shp, because it does not automatically format these dates.
     
     :param dbo: Database connection
     :param columns_with_types: Output of get_table_columns that returns the column name and data type
@@ -145,9 +145,19 @@ def format_dte_columns(dbo, columns_with_types, columns_with_brackets):
         # if a date column exists, we must reformat them so that they will be compatible with Shp/Gpkg file
         results = ' , '.join([c for c in columns_with_brackets if c not in dt_col_names])
 
+        dtcolname_list = [] # create empty list of col names
+        dtcolname_suffix = 1 # start
+
         for col_name in dt_col_names:
 
-            shortened_col = col_name[:7]
+            if any(x == col_name[:11] for x in dtcolname_list): # if colname already claimed
+                shortened_col = col_name[:6] + str(dtcolname_suffix) # shortened column name
+                dtcolname_suffix = dtcolname_suffix + 1 # move number by 1
+            else:
+                # no change to the col_name, simply add to the reference list
+                dtcolname_list.append(col_name[:11])
+                shortened_col = col_name[:7]
+
             if dbo.type == PG:
                 results += ' , cast(\\"{col}\\" as date) \\"{shortened_col}_dt\\", ' \
                                 'cast(cast(\\"{col}\\" as time) as varchar) \\"{shortened_col}_tm\\" '.format(

--- a/pysqldb3/tests/test_geospatial.py
+++ b/pysqldb3/tests/test_geospatial.py
@@ -2264,10 +2264,10 @@ class TestWriteShpPG:
         cmd_shp = f'ogrinfo "{FOLDER_PATH}/{shp_name}" -sql "select * from test_write limit 1"'
         ogr_response_shp = subprocess.check_output(shlex.split(cmd_shp), stderr=subprocess.STDOUT)   
         
-        assert f'long_dt_co (Date) = 2000/01/01' in str(ogr_response_shp), f"long_dt_co column is not returning the correct Date & Value"
-        assert f'long_dt1_dt (Date) = 2004/08/04' in str(ogr_response_shp), f"long_dt1_dt column is not returning the correct Date & Value"
-        assert f'long_dt_co (Time) = 11:50:00' in str(ogr_response_shp), f"long_dt_co column is not returning the correct Time & Value"
-        assert f'long_dt1_dt (Time) = 07:20:00' in str(ogr_response_shp), f"long_dt1_dt column is not returning the correct Time & Value"
+        assert f'long_dt_dt (Date) = 2000/01/01' in str(ogr_response_shp), f"long_dt_dt column is not returning the correct Date & Value"
+        assert f'long_d1_dt (Date) = 2004/08/04' in str(ogr_response_shp), f"long_d1_dt column is not returning the correct Date & Value"
+        assert f'long_dt_tm (String) = 11:50:00' in str(ogr_response_shp), f"long_dt_tm column is not returning the correct Time & Value"
+        assert f'long_d1_tm (String) = 07:20:00' in str(ogr_response_shp), f"long_d1_tm column is not returning the correct Time & Value"
 
     @classmethod
     def teardown_class(cls):
@@ -2465,7 +2465,7 @@ class TestWriteShpMS:
         cmd_shp = f'ogrinfo "{FOLDER_PATH}/{shp_name}" -sql "select * from test_write limit 1"'
         ogr_response_shp = subprocess.check_output(shlex.split(cmd_shp), stderr=subprocess.STDOUT)   
         for dt_col in ['dte', 'dte2']:
-            assert f'{dt_col}_dt (Date) = 1965/09/01' in str(ogr_response_shp), f"{dt_col}_dt column is not returning the correct Date & Value"
+            assert f'{dt_col}_dt (String) = 1965-09-01' in str(ogr_response_shp), f"{dt_col}_dt column is not returning the correct Date & Value"
             assert f'{dt_col}_tm (String) = 18:00:00' in str(ogr_response_shp), f"{dt_col}_tm column is not returning the correct Time & Value"
 
         # Clean up
@@ -2483,8 +2483,8 @@ class TestWriteShpMS:
 
         # Add test_table
         sql.query(f"""
-        create table {ms_schema}.{test_write_shp_table_name} (test_col1 int, long_datetime datetime, dte2 datetime, geom geometry);
-        insert into {ms_schema}.{test_write_shp_table_name} VALUES(1, '9/1/1965 18:00:00', '9/1/1965 18:00:00',
+        create table {ms_schema}.{test_write_shp_table_name} (test_col1 int, long_datetime datetime, long_datetime2 datetime, geom geometry);
+        insert into {ms_schema}.{test_write_shp_table_name} VALUES(1, '01/01/2000 11:50:00', '08/04/2004 7:20:00',
                                                                 geometry::Point(985831.79200444, 203371.60461367, 2263));
         insert into {ms_schema}.{test_write_shp_table_name} VALUES(3, '9/1/1965 18:00:00', '9/1/1965 18:00:00',
                                                                 geometry::Point(985831.79200444, 203371.60461367, 2263));
@@ -2503,10 +2503,10 @@ class TestWriteShpMS:
         cmd_shp = f'ogrinfo "{FOLDER_PATH}/{shp_name}" -sql "select * from test_write limit 1"'
         ogr_response_shp = subprocess.check_output(shlex.split(cmd_shp), stderr=subprocess.STDOUT)   
         
-        assert f'long_dt_co (Date) = 2000/01/01' in str(ogr_response_shp), f"long_dt_co column is not returning the correct Date & Value"
-        assert f'long_dt1_dt (Date) = 2004/08/04' in str(ogr_response_shp), f"long_dt1_dt column is not returning the correct Date & Value"
-        assert f'long_dt_co (Time) = 11:50:00' in str(ogr_response_shp), f"long_dt_co column is not returning the correct Time & Value"
-        assert f'long_dt1_dt (Time) = 07:20:00' in str(ogr_response_shp), f"long_dt1_dt column is not returning the correct Time & Value"
+        assert f'long_da_dt (String) = 2000-01-01' in str(ogr_response_shp), f"long_da_dt column is not returning the correct Date & Value"
+        assert f'long_d1_dt (String) = 2004-08-04' in str(ogr_response_shp), f"long_d1_dt column is not returning the correct Date & Value"
+        assert f'long_da_tm (String) = 11:50:00' in str(ogr_response_shp), f"long_da_tm column is not returning the correct Time & Value"
+        assert f'long_d1_tm (String) = 07:20:00' in str(ogr_response_shp), f"long_d1_tm column is not returning the correct Time & Value"
 
     @classmethod
     def teardown_class(cls):


### PR DESCRIPTION
This PR addresses the scenario where there are 2 datetime columns with the same column name that is very long (ex. `original_datetime`). Currently, GDAL will automatically change the name of the second datetime column by truncating the name and adding a number, but this causes issues when pysqldb3 creates date and time columns derived from the renamed datetime column.

- This PR allows pysqldb3 to truncate the duplicated datetime column name before GDAL does it.
- It also alters the conditions for parsing out datetime columns into date and time.
- Under MS, the dates will default to date (shp) but when we parse out dedicated date and time columns, they become strings.