### PR TITLE
Standardize geospatial input fille & db tbl names

### DIFF
--- a/pysqldb3/cmds.py
+++ b/pysqldb3/cmds.py
@@ -98,7 +98,7 @@ WRITE_GPKG_CMD_SHP = r'ogr2ogr -f "ESRI Shapefile" "{shp_path}" "{gpkg_path}" {g
 
 WRITE_GDB_CMD_GPKG = r'ogr2ogr -f GPKG {_update} "{gpkg_path}" -nln {gpkg_tbl}  "{shp_path}" {feature_class}'
 
-COUNT_GPKG_LAYERS = r'ogrinfo "{full_path}"' # command used for reading in all geopackage tables
+COUNT_GEOSPATIAL_LAYERS = r'ogrinfo "{full_path}"' # command used for reading in geopackage or geodatabase tables
 
 """
 Db to Db IO 

--- a/pysqldb3/geospatial.py
+++ b/pysqldb3/geospatial.py
@@ -175,31 +175,37 @@ def format_dte_columns(dbo, columns_with_types, columns_with_brackets):
 
     return results
 
-def write_geospatial(dbo, path,  table = None, schema = '', query = None, gpkg_tbl = None,
-                        srid='2263', gdal_data_loc=GDAL_DATA_LOC, cmd = None, overwrite = False, print_cmd=False):
+def write_geospatial(dbo, path,  table = None, schema = '', query = None, srid='2263',
+                     gdal_data_loc=GDAL_DATA_LOC, cmd = None, overwrite = False, print_cmd=False):
     
     """
     Converts a SQL or Postgresql query to a new Geospatial (Shapefile, GPKG) file. Cannot write to a GDB.
 
     :param dbo: Database connection
     :param path (str): File path to the output file. Must include file name and extension.
+                        If the output is a geopackage or geodatabase, the table name should be 
+                        added as '/[table name]' after the file extension. 
     :param table (str): DB Table to be written to a GPKG
     :param schema (str): DB schema
     :param query (str): DB query whose output is to be written to a GPKG
-    :param gpkg_tbl (str):  Name of the output table in the geopackage.
-                            Required input if you write a query to gpkg.
-                            Otherwise, optional if writing an existing db table to the gpkg; if blank, the table name
-                            in the geopackage output will match the name of the input db table.
     :param srid (str): SRID for geometry. Defaults to 2263
     :param cmd (str): Command
     :param overwrite (bool): Overwrite the specific table in the geopackage; defaults to False
     :param print_cmd (bool): Optional flag to print the GDAL command being used; defaults to False
-    :return:
+    :return: 
+
+    Examples:
+        write_geospatial(path = 'C:/User/Document/test1.shp', table = 'testing_table', schema = 'working')
+        write_geospatial(path = 'C:/User/Document/hello.gpkg/goodbye', query = 'select * from my_table')
+        write_geospatial(path = 'C:/User/Document/newyorkcity.gdb/streets', query = 'select * from nyc_streets')
     """
 
     ## INPUT CHECKS ##    
     # assert that a valid file format was input
-    assert path.endswith(('.gpkg', '.shp')), "Output path needs to end with .gpkg or .shp if no file name is supplied"
+    assert '.gpkg' in path or '.shp' in path, "Output path needs to include .gpkg or .shp if no file name is supplied"
+    geospatial_assert_formats(path) # check for proper table syntax if it's a geopackage
+
+    path, output_folder, output_path, output_tbl = decompress_and_parse_file_path(path)
 
     original_temp_flag = dbo.allow_temp_tables
     dbo.allow_temp_tables = True
@@ -207,7 +213,7 @@ def write_geospatial(dbo, path,  table = None, schema = '', query = None, gpkg_t
     if not query and not table:
         raise Exception('You must specify the db table or query to be written.')
     
-    if query and not gpkg_tbl and path.endswith('.gpkg'):
+    if query and not output_tbl and path.endswith('.gpkg' ):
         raise Exception ('You must specify a gpkg_tbl name in the function for the output table if you are writing a db query to a geopackage.')
 
     # defaults for table input
@@ -229,9 +235,6 @@ def write_geospatial(dbo, path,  table = None, schema = '', query = None, gpkg_t
         path = path[:-4].replace(".", "_") + ".shp"
         print(' The "." character is not allowed in output shp file names. Any "." have been replaced with "_".')
 
-    if not gpkg_tbl:
-        gpkg_tbl = table
-
     # overwrite vs update vs an issue has arisen
     if overwrite:
         # if explict overwrite, then create command line as directed
@@ -245,7 +248,7 @@ def write_geospatial(dbo, path,  table = None, schema = '', query = None, gpkg_t
     
     elif not overwrite and geospatial_exists(path) and path.endswith('.gpkg'): # check if the geopackage already exists
         
-        table_exists = geospatial_tbl_exists(path, geospatial_tbl = gpkg_tbl)
+        table_exists = geospatial_tbl_exists(path, geospatial_tbl = output_tbl)
         
         if table_exists == True:
             print("The table name to be exported already exists in the geopackage. Either change to Overwrite = True or check the name of the table to be copied.")
@@ -262,7 +265,7 @@ def write_geospatial(dbo, path,  table = None, schema = '', query = None, gpkg_t
 
     # run the final command
     if not cmd:
-        cmd = write_cmd(dbo, path, gpkg_tbl, table, _overwrite, _update, srid, gdal_data_loc, qry)
+        cmd = write_cmd(dbo, path, output_tbl, table, _overwrite, _update, srid, gdal_data_loc, qry)
 
     if print_cmd:
         print(print_cmd_string([dbo.password], cmd))
@@ -305,14 +308,11 @@ def geospatial_convert(path, output_file = None, overwrite = False, print_cmd = 
                         output_file = 'C:/Documents/export_files/my_new_gpkg.gpkg/resulting_table2')
     """
     ## ASSERTIONS ##
-    geo_convert_assert_formats(path = path, output_file = output_file)
-
-    # if the file happens to be a zip file, this will help us read it
-    input_path = add_zip_to_geo_path(path)
+    geospatial_assert_formats(path = path, output_file = output_file)
 
     # determine input/output paths and file names
-    input_full_path, input_folder, input_path, input_table = parse_file_path(path = input_path)
-    output_full_path, output_folder, output_path, output_table = parse_file_path(path = output_file)
+    input_full_path, input_folder, input_path, input_table = decompress_and_parse_file_path(path = path)
+    output_full_path, output_folder, output_path, output_table = decompress_and_parse_file_path(path = output_file)
 
     # if there is no file path from the output path argument, set to input path
     if output_folder == '':
@@ -375,7 +375,7 @@ def gpkg_to_shp_bulk(   path,
     assert path.endswith('.gpkg'), "The input file must end with .gpkg and the output file with .shp"
 
     try:
-        count_cmd = COUNT_GPKG_LAYERS.format(full_path = path)
+        count_cmd = COUNT_GEOSPATIAL_LAYERS.format(full_path = path)
         ogr_response = subprocess.check_output(shlex.split(count_cmd.replace('\n', ' ')), stderr=subprocess.STDOUT)
         tables_in_gpkg = re.findall(r"\\n\d+:\s(.*?)(?=\\r|\s\(.*\))", str(ogr_response)) 
 
@@ -390,20 +390,18 @@ def gpkg_to_shp_bulk(   path,
 
     return
 
-def upload_geospatial(dbo, path, schema = None, table = None, gpkg_tbl = None, feature_class = None, port = 5432,
-                                srid = '2263', gdal_data_loc=GDAL_DATA_LOC, precision=False, private=False, encoding=None, print_cmd=False, 
-                                skip_failures = '', temp = True, days = 7, extra_cmd = None):
+def upload_geospatial(dbo, path, schema = None, table = None, port = 5432, srid = '2263', gdal_data_loc=GDAL_DATA_LOC,
+                        precision=False, private=False, encoding=None, print_cmd=False, 
+                        skip_failures = '', temp = True, days = 7, extra_cmd = None):
 
     """
     Reads all tables within a Geopackage/Geodatabase file into SQL or Postgresql as tables.
-    Function is NOT applicable to Shapefiles.
 
-    :param path: Input file path for geopackage
+    :param path: Input file path for geospatial file (.shp/.gpkg/.gdb). If an sub-table/feature class
+            is to be uploaded, include as '/[table_name]'. If bulk uploading, 
     :param dbo: Database connection
     :param schema (str): Schema that the imported geopackage data will be found
     :param table (str): SINGLE TABLE EXPORT ONLY. Name of table in db.
-    :param gpkg_tbl (str): SINGLE TABLE EXPORT ONLY. Name of geopackage table for input to db.
-    :param feature_class (str): SINGLE TABLE EXPORT ONLY. Name of feature class in .gdb.
     :param port (int): Optional port
     :param srid (str): SRID for geometry. Defaults to 2263
     :param gdal_data_loc:
@@ -415,19 +413,19 @@ def upload_geospatial(dbo, path, schema = None, table = None, gpkg_tbl = None, f
     :param days (int): if temp=True, the number of days that the temp table will be kept. Defaults to 7.
     :param extra_cmd (str): Optional additional command. Helpful if you cmd = None and you want to add extra arguments
     :return: 
+
+    Example inputs:
+    upload_geospatial(path = 'C:/User/Name1/Documents/my_geopackage.gpkg/gpkg_tbl_for_upload') # single tbl
+    upload_geospatial(path = 'C:/User/Name1/Documents/my_geopdatabase.gdb/') # bulk upload all in geodatabase
+    upload_geospatial(path = 'C:/User/Name1/Documents/my_geopackage.shp')
     """
 
-    temp_dir = None
-    
-    # check input file path
-    assert path.endswith(('.shp', '.gpkg', '.gdb')), "The path should end with .gpkg, .shp, .gdb"
+    # check input file path syntax
+    # If bulk uploading, a table name is not required
+    geospatial_assert_formats(path = path, bulk_optional = True)
     
     # if the file happens to be a zip file, this will help us read it
-    path, input_table = read_compressed(temp_dir, path)
-
-    # if shapefile is selected, you can't have feature class filled in since it will not take that argument
-    if path.endswith('.shp'):
-        assert not feature_class, "feature_class input will not be considered if the input file is .shp"
+    path, file_dir, file_name, input_table = decompress_and_parse_file_path(path)
 
     # Use default schema from db object
     if not schema:
@@ -438,19 +436,17 @@ def upload_geospatial(dbo, path, schema = None, table = None, gpkg_tbl = None, f
     else:
         precision = ''
 
-    if feature_class:
-        if feature_class.endswith('.shp'):
-            feature_class = feature_class[:-4]
+    # create a dictionary 
+    input_tbl_names = set_up_geo_tbl_dict(dbo, path, table, input_table)
 
-    # clean table name if it's a single input   
-    table = clean_table_name(table, gpkg_tbl, path)
-
-    # if the inputs suggest bulk uploading
-    gpkg_tbl_names = bulk_upload_table_setup(dbo, path, table, feature_class, temp_dir, gpkg_tbl)
-
-    # start of loop
-    for gpkg_tbl, table in gpkg_tbl_names.items():
+    # loop through file names and db upload names
+    for file_tbl, table in input_tbl_names.items():
+        
         table = table.lower()
+        
+        # put double quotes if dbo = PG for any tbl names with special chars
+        if re.search(r'[^A-Za-z0-9_]+', table) and dbo.type == 'PG':
+            table = '"' + table + '"'
 
         if dbo.table_exists(table = table, schema = schema):
 
@@ -463,9 +459,9 @@ def upload_geospatial(dbo, path, schema = None, table = None, gpkg_tbl = None, f
                 dbo.drop_table(schema, table, cascade = True)
 
         # produce command
-        cmd = read_geospatial_command(dbo, gdal_data_loc, srid, path, schema,
-                            table, precision, port, gpkg_tbl, feature_class, skip_failures)
-        
+        cmd = read_geospatial_command(dbo, gdal_data_loc, srid, path, schema, table,
+                                      file_tbl, precision, port, skip_failures)
+    
         if extra_cmd:
             cmd = cmd + f' {extra_cmd}'
 
@@ -474,24 +470,20 @@ def upload_geospatial(dbo, path, schema = None, table = None, gpkg_tbl = None, f
 
         cmd_env = encoding_changes(encoding)
 
-        execute_cmd(dbo = dbo, cmd = cmd, feature_class = feature_class, cmd_env = cmd_env)
+        execute_cmd(dbo = dbo, cmd = cmd, cmd_env = cmd_env)
 
         # add a comment to the query
-        comment_query(dbo, feature_class, schema, table, path)
+        comment_query(dbo, schema, table, path)
 
         if not private and dbo.type == 'PG':
             # can only grant select to public in PG
-            dbo.query(f'grant select on {schema}."{table}" to public;', timeme=False, internal=True, strict=True)
+            dbo.query(f'grant select on {schema}.{table} to public;', timeme=False, internal=True, strict=True)
 
         rename_geom(dbo, schema, table)
         dbo.tables_created.append((dbo.server, dbo.database, schema,  table))
         
         if temp:
             dbo._run_table_logging([schema + "." + table], days=days)
-
-        # remove temp folders of any decompressed files
-        if temp_dir:
-            shutil.rmtree(temp_dir)
 
 
 def del_indexes(dbo, schema, table):

--- a/pysqldb3/pysqldb3.py
+++ b/pysqldb3/pysqldb3.py
@@ -1102,9 +1102,9 @@ class DbConnect:
         :param temp: Optional flag to make table temporary (defaults to True)
         :param allow_max_varchar: Boolean to allow unlimited/max varchar columns; defaults to False
         :param column_type_overrides: 'all' or Dict of type key=column name, value=column type. Will manually set the
-                raw column name as that type in the query, regardless of the pandas/postgres/sql server automatic
-                detection. **Will not override a custom table_schema, if inputted**
-                If 'all' is provided, all fields will be set to varchar(max).
+                    raw column name as that type in the query, regardless of the pandas/postgres/sql server automatic
+                    detection. **Will not override a custom table_schema, if inputted**
+                    If 'all' is provided, all fields will be set to varchar(max).
         :param days: if temp=True and table schema needs to be created, the number of days that the temp table will be
                      kept. Defaults to 7.
         :param temp_table: if True, dataframe created as a temporary table, which will be lost when db connection is closed
@@ -1993,55 +1993,53 @@ class DbConnect:
         write_geospatial(dbo = self, path = path, query = query,
                             cmd = cmd, gdal_data_loc = gdal_data_loc, print_cmd = print_cmd, srid = srid)
         
-    def feature_class_to_table(self, path, table, feature_class = None, schema=None, 
-                               port = 5432, srid = '2263', private=False, fc_encoding=None, skip_failures='', extra_cmd = None,
-                               temp = True, days = 7, print_cmd = False):
+    def feature_class_to_table(self, path, table, schema=None, port = 5432, srid = '2263', private=False,
+                               fc_encoding=None, skip_failures='', extra_cmd = None, temp = True, days = 7, print_cmd = False):
         """
         Imports shape file feature class to database. This uses GDAL to generate the table.
-        :param path: Filepath to the geodatabase
+        :param path: Filepath to the geodatabase. Must end with .gdb/[feature_class_name]
         :param table: Table name to use in the database
         :param schema: Schema to use in the database
-        :param shp_name:  FeatureClass name or Geodatabase name
-        :param feature_class: Optional featureclass name; fill in only if you are uploading from a Geodatabase
-        :param gdal_data_loc: Filepath/location of GDAL on computer
         :param port: Defaults to 5432
         :param srid: SRID to use (defaults to 2263)
         :param private: If True any new tables will override defaut grant select permissions; defaults to False
-        :param temp: If True any new tables will be logged for deletion at a future date; defaults to True
         :param fc_encoding: Defaults to None; if not None, sets the PG client encoding while uploading the feature class
-        Options inlude LATIN1, UTF-8.
-        :param days: if temp=True, the number of days that the temp table will be kept. Defaults to 7.
+                    Options inlude LATIN1, UTF-8.
         :param skip_failures: allows user to pass skip failures flag to OGR2OGR.
         :param extra_cmd: allows user to pass any additional flag/paramters to OGR2OGR.
+        :param temp: If True any new tables will be logged for deletion at a future date; defaults to True
+        :param days: if temp=True, the number of days that the temp table will be kept. Defaults to 7.
         :param print_cmd: Optional flag to print the GDAL command that is being used; defaults to False
         :return:
+
+        Example: feature_class_to_table(path = 'C:/Files/primary.gdb/first_feature_class', table = 'my_fc_table_final', schema = 'working')
         """
         if not schema:
             schema = self.default_schema
 
-        upload_geospatial(dbo = self, path = path, schema = schema, table = table, feature_class = feature_class,
-                                port = port, srid = srid, private = private, encoding = fc_encoding, skip_failures = skip_failures,
-                                extra_cmd = extra_cmd, temp = temp, days = days, print_cmd=print_cmd)
+        upload_geospatial(dbo = self, path = path, schema = schema, table = table, port = port, srid = srid, private = private,
+                          encoding = fc_encoding, skip_failures = skip_failures, extra_cmd = extra_cmd, temp = temp, days = days,
+                          print_cmd=print_cmd)
         
-    def query_to_gpkg(self, query, gpkg_tbl, path, overwrite = True, cmd=None,
-                      gdal_data_loc=GDAL_DATA_LOC, print_cmd=False, srid=2263):
+    def query_to_gpkg(self, query,path, overwrite = True, cmd=None, gdal_data_loc=GDAL_DATA_LOC, print_cmd=False, srid=2263):
         """
         Exports query results to a Geopackage file.
         :param query: SQL query as string type
-        :param gpkg_tbl: Geopackage table name (required)
-        :param path: folder path for output gpkg. Must end with .gpkg
+        :param path: folder path for output gpkg. Must end with .gpkg/[table_name]
         :param overwrite: Defaults to True. Will overwrite table with the same name if it exists.
         :param cmd: GDAL command to overwrite default
         :param gdal_data_loc: Path to gdal data, if not stored in system env correctly
         :param print_cmd: boolean to print ogr command (without password)
         :param srid: SRID to manually set output to; defaults to 2263
         :return:
+
+        Example: query_to_gpkg(query = 'select * from test_qry', path = 'C:/User/Docs/my_geopackage.gpkg/my_gpkg_tbl')
         """
 
-        write_geospatial(dbo = self, path = path, query = query, gpkg_tbl = gpkg_tbl,
-                            overwrite = overwrite, cmd = cmd, gdal_data_loc = gdal_data_loc, print_cmd = print_cmd, srid = srid)
+        write_geospatial(dbo = self, path = path, query = query, overwrite = overwrite, cmd = cmd,
+                         gdal_data_loc = gdal_data_loc, print_cmd = print_cmd, srid = srid)
 
-    def shp_to_table(self, path, table=None, schema=None, feature_class = None,
+    def shp_to_table(self, path, table=None, schema=None,
                      srid=2263, port=5432, gdal_data_loc=GDAL_DATA_LOC, precision=False, private=False, temp=True,
                      shp_encoding=None, extra_cmd = None, print_cmd=False, days=7):
         """
@@ -2049,52 +2047,52 @@ class DbConnect:
         :param path: File path of the shapefile (ending with .shp)
         :param table: Table name to use in the database
         :param schema: Schema to use in the database (defaults to db's default schema)
-        :param shp_name: Shapefile name (ends in .shp or .dbf)
-        :param feature_class: If shp_name ends with .dbf, specify the .shp file for input
         :param srid:  SRID to use (defaults to 2263)
-        :param port:
+        :param port: Defaults to 5432
         :param gdal_data_loc: File path fo the GDAL data (defaults to C:\\Program Files (x86)\\GDAL\\gdal-data)
         :param precision:  Sets precision flag in ogr (defaults to -lco precision=NO)
         :param private: Flag for permissions in database (Defaults to False - will only grant select to public)
         :param temp: If True any new tables will be logged for deletion at a future date; defaults to True
         :param shp_encoding: Defaults to None; if not None, sets the PG client encoding while uploading the shpfile.
-        Options inlude LATIN1, UTF-8.
+                            Options inlude LATIN1, UTF-8.
         :param extra_cmd: Defaults to None. Extra ogr2ogr commands you want to append
         :param print_cmd: Defaults to False; if True prints the cmd
         :param days: if temp=True, the number of days that the temp table will be kept. Defaults to 7.
         :return:
         """
 
-        upload_geospatial(dbo = self, path = path,  schema = schema, table = table, feature_class = feature_class, port = port,
+        upload_geospatial(dbo = self, path = path,  schema = schema, table = table, port = port,
                             srid = srid, gdal_data_loc = gdal_data_loc, precision=precision, private=private, encoding=shp_encoding,
                             temp = temp, days = days, extra_cmd = extra_cmd, print_cmd=print_cmd)
 
-    def gpkg_to_table(self, gpkg_name, gpkg_tbl, path=None, schema=None, table =None, 
+    def gpkg_to_table(self, path=None, schema=None, table =None, 
                      srid=2263, port=5432, gdal_data_loc=GDAL_DATA_LOC, precision=False, private=False, temp=True,
                      gpkg_encoding=None, extra_cmd = None, print_cmd=False, days=7):
         """
         Imports single geopackage table to database. This uses GDAL to generate the table.
         Use upload_geospatial() for bulk table upload from a Geopackage.
 
-        :param gpkg_name: Geopackage name (ends in .gpkg)
-        :param gpkg_tbl: Input table name from Geopackage.
-        :param path: File path of the geopackage
+        :param path: File path of the geopackage. Must end with .gpkg/[geopackage_table_name]
         :param schema: Schema to use in the database (defaults to db's default schema)
         :param table: (Optional) output table name in database. If blank, output name will match geopackage table name.
         :param srid:  SRID to use (defaults to 2263)
+        :param port: Defaults to 5432
         :param gdal_data_loc: File path fo the GDAL data (defaults to C:\\Program Files (x86)\\GDAL\\gdal-data)
         :param precision:  Sets precision flag in ogr (defaults to -lco precision=NO)
         :param private: Flag for permissions in database (Defaults to False - will only grant select to public)
         :param temp: If True any new tables will be logged for deletion at a future date; defaults to True
         :param gpkg_encoding: Defaults to None; if not None, sets the PG client encoding while uploading the gpkgfile.
-        Options inlude LATIN1, UTF-8.
+                            Options inlude LATIN1, UTF-8.
         :param extra_cmd: Defaults to None. Extra ogr2ogr commands you want to append
         :param print_cmd: Defaults to False; if True prints the cmd
         :param days: if temp=Tue, the number of days that the temp table will be kept. Defaults to 7.
         :return:
+
+        Example: gpkg_to_table(path = 'C:/User/Docs/my_geopackage.gpkg/my_gpkg_tbl')
+                 
         """
 
-        upload_geospatial(dbo = self, path = path, input_file = gpkg_name, schema = schema, table = table, gpkg_tbl = gpkg_tbl, port = port,
+        upload_geospatial(dbo = self, path = path, schema = schema, table = table, port = port,
                             srid = srid, gdal_data_loc = gdal_data_loc, precision=precision, private=private, encoding=gpkg_encoding,
                             temp = temp, days = days, extra_cmd = extra_cmd, print_cmd=print_cmd)
 

--- a/pysqldb3/tests/test_geospatial.py
+++ b/pysqldb3/tests/test_geospatial.py
@@ -45,7 +45,7 @@ ms_schema = 'dbo'
 pg_schema = 'working'
 
 fgdb = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'test_data/lion/lion.gdb')
-fc = 'node.shp'
+fc = 'node'
 
 db_int, db_geom = helpers.identify_default_dtypes(db, pg_schema)
 sql_int, sql_geom = helpers.identify_default_dtypes(sql, ms_schema)
@@ -67,7 +67,7 @@ class TestReadgpkgPG:
         db.drop_table(schema=pg_schema, table=test_read_gpkg_table_name)
 
         # Read gpkg to new, test table
-        s.upload_geospatial(path=FOLDER_PATH + '//' + gpkg_name, dbo=db, gpkg_tbl = test_layer1,
+        s.upload_geospatial(path=FOLDER_PATH + '//' + gpkg_name + '//' + test_layer1, dbo=db,
                                 table=test_read_gpkg_table_name, schema=pg_schema, print_cmd=True)
 
         # Assert read_gpkg happened successfully and contents are correct
@@ -192,7 +192,7 @@ class TestReadgpkgPG:
         db.drop_table(schema=pg_schema, table=test_layer2)
 
         # Read gpkg to new, test table
-        s.upload_geospatial(dbo=db, path=os.path.join(FOLDER_PATH, gpkg_name), gpkg_tbl = test_layer2,
+        s.upload_geospatial(dbo=db, path=os.path.join(FOLDER_PATH, gpkg_name, test_layer2),
                                 table = test_read_gpkg_table_name, print_cmd=True)
 
         # Assert read_gpkg happened successfully and contents are correct
@@ -231,7 +231,7 @@ class TestReadgpkgPG:
         db.drop_table(schema=pg_schema, table=test_read_gpkg_table_name)
 
         # Read gpkg to new, test table
-        s.upload_geospatial(path=subzip_filepath + '/' + gpkg_name, dbo=db, gpkg_tbl = test_layer1,
+        s.upload_geospatial(path=subzip_filepath + '/' + gpkg_name + '/' + test_layer1, dbo=db,
                                 table=test_read_gpkg_table_name, schema=pg_schema, print_cmd=True)
 
         # Assert read_gpkg happened successfully and contents are correct
@@ -265,6 +265,32 @@ class TestReadgpkgPG:
         # Cleanup
         db.drop_table(schema=pg_schema, table=test_read_gpkg_table_name)
 
+    def test_input_gpkg_special_char_name(self):
+
+        gpkg_name = "testgpkg.gpkg"
+        unique_table_name = 'F!unky N@mE?'
+
+        # Assert successful
+        assert gpkg_name in os.listdir(FOLDER_PATH)
+        db.drop_table(schema=pg_schema, table=test_read_gpkg_table_name)
+
+        # Read gpkg to new, test table (name with special chars)
+        s.upload_geospatial(path=FOLDER_PATH + '//' + gpkg_name + '//' + test_layer1, dbo=db,
+                                table=unique_table_name, schema=pg_schema, print_cmd=True)
+
+        # Assert read_gpkg happened successfully and contents are correct
+        assert db.table_exists(schema=pg_schema, table = unique_table_name)
+
+        table_df = db.dfquery(f'select * from {pg_schema}."{unique_table_name.lower()}"')
+
+        assert set(table_df.columns) == {'gid', 'some_value', 'fid', 'geom'}
+        assert len(table_df) == 2
+
+        assert db.tables_created[-1] == (db.server, db.database, pg_schema, '"' + unique_table_name.lower() + '"')
+
+        # Cleanup
+        db.drop_table(schema=pg_schema, table='"'+unique_table_name+'"')
+
     @classmethod
     def teardown_class(cls):
         helpers.clean_up_geopackage()
@@ -285,7 +311,7 @@ class TestReadgpkgMS:
         sql.query(f"drop table if exists {ms_schema}.{test_read_gpkg_table_name}")
 
         # Read gpkg to new, test table
-        s.upload_geospatial(dbo=sql, path=FOLDER_PATH + '//' + gpkg_name, gpkg_tbl = test_layer2,
+        s.upload_geospatial(dbo=sql, path=FOLDER_PATH + '//' + gpkg_name + '//' + test_layer2,
                                 table=test_read_gpkg_table_name, schema=ms_schema, print_cmd=True)
 
         # Assert read_gpkg happened successfully and contents are correct
@@ -414,7 +440,7 @@ class TestReadgpkgMS:
         sql.drop_table(schema=sql.default_schema, table=test_read_gpkg_table_name)
 
         # Read gpkg to new, test table
-        s.upload_geospatial(dbo=sql, path= os.path.join(FOLDER_PATH, gpkg_name), gpkg_tbl = test_layer1, table=test_read_gpkg_table_name, print_cmd=True)
+        s.upload_geospatial(dbo=sql, path= os.path.join(FOLDER_PATH, gpkg_name, test_layer1), table=test_read_gpkg_table_name, print_cmd=True)
 
         # Assert read_gpkg happened successfully and contents are correct
         assert sql.table_exists(schema=sql.default_schema, table=test_read_gpkg_table_name)
@@ -451,7 +477,7 @@ class TestReadgpkgMS:
         sql.query(f"drop table if exists {ms_schema}.{test_layer1}")
 
         # Read gpkg to new, test table
-        s.upload_geospatial(dbo=sql, path = os.path.join(FOLDER_PATH, gpkg_name), gpkg_tbl=test_layer1, schema=ms_schema, print_cmd=True)
+        s.upload_geospatial(dbo=sql, path = os.path.join(FOLDER_PATH, gpkg_name, test_layer1), schema=ms_schema, print_cmd=True)
 
         # Assert read_gpkg happened successfully and contents are correct
         assert sql.table_exists(schema = ms_schema, table= test_layer1)
@@ -487,10 +513,10 @@ class TestReadgpkgMS:
         subzip_filepath = FOLDER_PATH + '/subfolder_gpkg.zip/extra_subfolder'
         
         # Assert successful
-        db.drop_table(schema=ms_schema, table=test_read_gpkg_table_name)
+        sql.drop_table(schema=ms_schema, table=test_read_gpkg_table_name)
 
         # Read gpkg to new, test table
-        s.upload_geospatial(path=subzip_filepath + '/' + gpkg_name, dbo=sql, gpkg_tbl = test_layer1,
+        s.upload_geospatial(path=subzip_filepath + '/' + gpkg_name + '/' + test_layer1, dbo=sql,
                                 table=test_read_gpkg_table_name, schema=ms_schema, print_cmd=True)
 
         # Assert read_gpkg happened successfully and contents are correct
@@ -520,6 +546,35 @@ class TestReadgpkgMS:
 
         assert sql.tables_created[-1] == (sql.server, sql.database, ms_schema, test_read_gpkg_table_name)
 
+    def test_input_gpkg_special_char_name(self):
+
+        gpkg_name = "testgpkg.gpkg"
+        unique_table_name = 'FUNKY N@m3?'
+
+        # Assert successful
+        assert gpkg_name in os.listdir(FOLDER_PATH)
+
+        # remove temp table from MS SQL Server if it already exists
+        sql.query(f'drop table if exists {ms_schema}."{unique_table_name}"')
+
+        # Read gpkg to new, test table
+        s.upload_geospatial(dbo=sql, path=FOLDER_PATH + '//' + gpkg_name + '//' + test_layer2,
+                                table=unique_table_name, schema=ms_schema, print_cmd=True)
+
+        # Assert read_gpkg happened successfully and contents are correct
+        assert sql.table_exists(schema = ms_schema, table=unique_table_name)
+
+        # todo: this fails because odbc 17 driver isnt supporting geometry
+        table_df = sql.dfquery(f'select * from {ms_schema}."{unique_table_name}"')
+
+        assert set(table_df.columns) == {'fid', 'gid', 'some_value', 'geom'}
+        assert len(table_df) == 2
+
+        assert sql.tables_created[-1] == (sql.server, sql.database, ms_schema, unique_table_name.lower())
+
+        # Cleanup
+        sql.query(f'drop table if exists {ms_schema}."{unique_table_name}"')
+        
     @classmethod
     def teardown_class(cls):
         helpers.clean_up_geopackage()
@@ -545,13 +600,14 @@ class TestWritegpkgPG:
         gpkg_name = 'testgpkg.gpkg'
 
         # Write gpkg
-        s.write_geospatial(path=os.path.join(FOLDER_PATH, gpkg_name), dbo=db, schema=pg_schema, table=test_write_gpkg_table_name, print_cmd=True)
+        s.write_geospatial(path=os.path.join(FOLDER_PATH, gpkg_name, test_write_gpkg_table_name), dbo=db,
+                           schema=pg_schema, table=test_write_gpkg_table_name, print_cmd=True)
 
         # Assert successful
         assert os.path.isfile(os.path.join(FOLDER_PATH, gpkg_name))
 
         # Reupload as table
-        s.upload_geospatial(dbo = db, path= os.path.join(FOLDER_PATH, gpkg_name), gpkg_tbl = test_write_gpkg_table_name,
+        s.upload_geospatial(dbo = db, path= os.path.join(FOLDER_PATH, gpkg_name, test_write_gpkg_table_name),
                                 schema=pg_schema, table = test_reuploaded_table_name, print_cmd=True)
 
         # Assert equality
@@ -596,7 +652,8 @@ class TestWritegpkgPG:
         gpkg_name = 'testgpkg.gpkg'
 
         # Write gpkg
-        s.write_geospatial(path=os.path.join(FOLDER_PATH, gpkg_name), dbo=db, schema=pg_schema, table=test_write_gpkg_table_name, print_cmd=True)
+        s.write_geospatial(path=os.path.join(FOLDER_PATH, gpkg_name, test_write_gpkg_table_name),
+                           dbo=db, schema=pg_schema, table=test_write_gpkg_table_name, print_cmd=True)
 
         # Assert successful
         assert os.path.isfile(os.path.join(FOLDER_PATH, gpkg_name))
@@ -611,11 +668,11 @@ class TestWritegpkgPG:
         order by id
         limit 2
         """)
-        s.write_geospatial(path=os.path.join(FOLDER_PATH, gpkg_name), dbo=db, schema=pg_schema,
+        s.write_geospatial(path=os.path.join(FOLDER_PATH, gpkg_name, test_write_gpkg_table_name), dbo=db, schema=pg_schema,
                            table=test_write_gpkg_table_name, overwrite = True, print_cmd=True) # overwrite to 2 rows
 
         # Reupload as table
-        s.upload_geospatial(dbo = db, path= os.path.join(FOLDER_PATH, gpkg_name), schema=pg_schema, gpkg_tbl = test_write_gpkg_table_name,
+        s.upload_geospatial(dbo = db, path= os.path.join(FOLDER_PATH, gpkg_name, test_write_gpkg_table_name), schema=pg_schema,
                          table = test_reuploaded_table_name, print_cmd=True)
 
         # Assert equality
@@ -661,8 +718,8 @@ class TestWritegpkgPG:
         gpkg_name = 'testgpkg.gpkg'
 
         # Write gpkg
-        s.write_geospatial(path=FOLDER_PATH + '//' + gpkg_name, dbo=db, schema=pg_schema,
-                           gpkg_tbl = test_reuploaded_table_name, table= test_write_gpkg_table_name, print_cmd=True)
+        s.write_geospatial(path=FOLDER_PATH + '//' + gpkg_name + '//' + test_reuploaded_table_name, dbo=db, schema=pg_schema,
+                           table= test_write_gpkg_table_name, print_cmd=True)
 
         # Assert successful
         assert os.path.isfile(os.path.join(FOLDER_PATH, gpkg_name))
@@ -677,8 +734,9 @@ class TestWritegpkgPG:
         order by id
         limit 2
         """)
-        s.write_geospatial(dbo=db, schema=pg_schema, table = test_write_gpkg_table_name + '_2', path=os.path.join(FOLDER_PATH, gpkg_name),
-                           gpkg_tbl = test_reuploaded_table_name + '_2', overwrite = False, print_cmd=True) # add another table
+        s.write_geospatial(dbo=db, schema=pg_schema, table = test_write_gpkg_table_name + '_2',
+                           path=os.path.join(FOLDER_PATH, gpkg_name, test_reuploaded_table_name + '_2'),
+                           overwrite = False, print_cmd=True) # add another table
 
         assert os.path.isfile(os.path.join(FOLDER_PATH, gpkg_name)) # assert that the table is still there
 
@@ -746,14 +804,15 @@ class TestWritegpkgPG:
         gpkg_name = 'testgpkg.gpkg'
 
         # Write gpkg
-        s.write_geospatial(path=os.path.join(FOLDER_PATH, gpkg_name), dbo=db, table=test_write_gpkg_table_name, schema=pg_schema, print_cmd=True)
+        s.write_geospatial(path=os.path.join(FOLDER_PATH, gpkg_name, test_write_gpkg_table_name),
+                           dbo=db, table=test_write_gpkg_table_name, schema=pg_schema, print_cmd=True)
 
         # Assert successful
         assert os.path.isfile(os.path.join(FOLDER_PATH, gpkg_name))
 
         # Reupload as table
-        s.upload_geospatial(dbo = db, path=os.path.join(FOLDER_PATH, gpkg_name), schema=pg_schema,
-                         table=test_reuploaded_table_name, gpkg_tbl = test_write_gpkg_table_name, print_cmd=True)
+        s.upload_geospatial(dbo = db, path=os.path.join(FOLDER_PATH, gpkg_name, test_write_gpkg_table_name), schema=pg_schema,
+                            table=test_reuploaded_table_name, print_cmd=True)
 
         # Assert equality
         db_df = db.dfquery(f"select * from {pg_schema}.{pg_table_name} order by id limit 100")
@@ -799,14 +858,15 @@ class TestWritegpkgPG:
         gpkg_name = 'testgpkg.gpkg'
 
         # Write gpkg
-        s.write_geospatial(path=os.path.join(FOLDER_PATH, gpkg_name), dbo=db, table=test_write_gpkg_table_name, schema=pg_schema, print_cmd=True)
+        s.write_geospatial(path=os.path.join(FOLDER_PATH, gpkg_name, test_write_gpkg_table_name),
+                           dbo=db, table=test_write_gpkg_table_name, schema=pg_schema, print_cmd=True)
 
         # Assert successful
         assert os.path.isfile(os.path.join(FOLDER_PATH, gpkg_name))
 
         # Reupload as table
-        s.upload_geospatial(dbo = db, path= os.path.join(FOLDER_PATH, gpkg_name),schema=pg_schema,
-                        table=test_reuploaded_table_name, gpkg_tbl = test_write_gpkg_table_name, print_cmd=True)
+        s.upload_geospatial(dbo = db, path= os.path.join(FOLDER_PATH, gpkg_name, test_write_gpkg_table_name),
+                            schema=pg_schema, table=test_reuploaded_table_name, print_cmd=True)
 
         # Assert equality
         db_df = db.dfquery(f"select * from {pg_schema}.{pg_table_name} order by id limit 100")
@@ -844,14 +904,14 @@ class TestWritegpkgPG:
 
         # Write gpkg
         s.write_geospatial(dbo=db, query=f"""select * from {pg_schema}.{pg_table_name} order by id limit 100""",
-                            path=os.path.join(FOLDER_PATH, gpkg_name), gpkg_tbl = test_write_gpkg_table_name, print_cmd=True)
+                            path=os.path.join(FOLDER_PATH, gpkg_name, test_write_gpkg_table_name), print_cmd=True)
 
         # Check table in folder
         assert os.path.isfile(os.path.join(FOLDER_PATH, gpkg_name))
 
         # Reupload as table
-        s.upload_geospatial(dbo = db, path= os.path.join(FOLDER_PATH, gpkg_name), schema=pg_schema,
-                         table=test_reuploaded_table_name, gpkg_tbl = test_write_gpkg_table_name, print_cmd=True)
+        s.upload_geospatial(dbo = db, path= os.path.join(FOLDER_PATH, gpkg_name, test_write_gpkg_table_name), schema=pg_schema,
+                                table=test_reuploaded_table_name, print_cmd=True)
 
         # Assert equality
         db_df = db.dfquery(f"select * from {pg_schema}.{pg_table_name} order by id limit 100")
@@ -900,7 +960,8 @@ class TestWritegpkgPG:
             os.remove(os.path.join(FOLDER_PATH, gpkg_name))
 
         # Write gpkg
-        s.write_geospatial(path=os.path.join(FOLDER_PATH, gpkg_name), dbo=db, schema=pg_schema, table=test_write_gpkg_table_name, print_cmd=True)
+        s.write_geospatial(path=os.path.join(FOLDER_PATH, gpkg_name, test_write_gpkg_table_name),
+                           dbo=db, schema=pg_schema, table=test_write_gpkg_table_name, print_cmd=True)
 
         # Assert successful
         assert os.path.isfile(os.path.join(FOLDER_PATH, gpkg_name))
@@ -929,7 +990,8 @@ class TestWritegpkgPG:
             os.remove(os.path.join(FOLDER_PATH, gpkg_name))
 
         # Write gpkg
-        s.write_geospatial(path=os.path.join(FOLDER_PATH, gpkg_name), dbo=db, schema=pg_schema, table=test_write_gpkg_table_name, print_cmd=True)
+        s.write_geospatial(path=os.path.join(FOLDER_PATH, gpkg_name, test_write_gpkg_table_name),
+                           dbo=db, schema=pg_schema, table=test_write_gpkg_table_name, print_cmd=True)
 
         # Assert successful
         assert os.path.isfile(os.path.join(FOLDER_PATH, gpkg_name))
@@ -955,7 +1017,8 @@ class TestWritegpkgPG:
         gpkg_name = 'testgpkg.gpkg'
 
         # Write gpkg
-        s.write_geospatial(path=os.path.join(FOLDER_PATH, gpkg_name), dbo=db, schema=pg_schema, table=test_write_gpkg_table_name, print_cmd=True)
+        s.write_geospatial(path=os.path.join(FOLDER_PATH, gpkg_name, test_write_gpkg_table_name),
+                           dbo=db, schema=pg_schema, table=test_write_gpkg_table_name, print_cmd=True)
 
         # Assert successful
         assert os.path.isfile(os.path.join(FOLDER_PATH, gpkg_name))
@@ -991,14 +1054,15 @@ class TestWritegpkgMS:
         gpkg_name = 'test_write.gpkg'
 
         # Write gpkg
-        s.write_geospatial(dbo=sql, schema = ms_schema, path=os.path.join(FOLDER_PATH, gpkg_name), table=test_write_gpkg_table_name, print_cmd=True)
+        s.write_geospatial(dbo=sql, schema = ms_schema, path=os.path.join(FOLDER_PATH, gpkg_name, test_write_gpkg_table_name),
+                           table=test_write_gpkg_table_name, print_cmd=True)
 
         # # Assert successful
         assert os.path.isfile(os.path.join(FOLDER_PATH, gpkg_name))
 
         # Reupload as table
-        s.upload_geospatial(dbo = sql, path= os.path.join(FOLDER_PATH, gpkg_name), schema = ms_schema, table=test_reuploaded_table_name,
-                          gpkg_tbl = test_write_gpkg_table_name, print_cmd=True)
+        s.upload_geospatial(dbo = sql, path= os.path.join(FOLDER_PATH, gpkg_name, test_write_gpkg_table_name), schema = ms_schema,
+                            table=test_reuploaded_table_name, print_cmd=True)
 
         # # Assert equality
         db_df = sql.dfquery(f"select top 10 * from {ms_schema}.{test_write_gpkg_table_name} order by test_col1")
@@ -1041,7 +1105,8 @@ class TestWritegpkgMS:
         gpkg_name = 'test_write.gpkg'
 
         # Write gpkg. Gpkg table will be named the same as the query table
-        s.write_geospatial(path=os.path.join(FOLDER_PATH, gpkg_name), dbo=sql, schema = ms_schema, table=test_write_gpkg_table_name, print_cmd=True)
+        s.write_geospatial(path=os.path.join(FOLDER_PATH, gpkg_name, test_write_gpkg_table_name), dbo=sql,
+                           schema = ms_schema, table=test_write_gpkg_table_name, print_cmd=True)
 
         # # Assert successful
         assert os.path.isfile(os.path.join(FOLDER_PATH, gpkg_name))
@@ -1057,14 +1122,14 @@ class TestWritegpkgMS:
 
         # Write gpkg. Gpkg table will be named the same as the previous table to overwrite it
         s.write_geospatial(dbo=sql, schema = ms_schema, table=test_write_gpkg_table_name + '_2',
-                          path=os.path.join(FOLDER_PATH, gpkg_name), gpkg_tbl = test_write_gpkg_table_name, overwrite = True, print_cmd=True)
+                          path=os.path.join(FOLDER_PATH, gpkg_name, test_write_gpkg_table_name), overwrite = True, print_cmd=True)
 
         # Assert successful
         assert os.path.isfile(os.path.join(FOLDER_PATH, gpkg_name))
 
         # Reupload as table
-        s.upload_geospatial(dbo = sql, path=os.path.join(FOLDER_PATH, gpkg_name), schema = ms_schema,
-                          gpkg_tbl = test_write_gpkg_table_name, table=test_reuploaded_table_name, print_cmd=True)
+        s.upload_geospatial(dbo = sql, path=os.path.join(FOLDER_PATH, gpkg_name, test_write_gpkg_table_name), schema = ms_schema,
+                           table=test_reuploaded_table_name, print_cmd=True)
 
         # # Assert equality
         db_df = sql.dfquery(f"select top 10 * from {ms_schema}.{test_write_gpkg_table_name}_2 order by test_col3")
@@ -1110,7 +1175,7 @@ class TestWritegpkgMS:
 
         # Write gpkg. Gpkg table will be named the same as the query table
         s.write_geospatial(dbo=sql, schema = ms_schema, table= test_write_gpkg_table_name,
-                           path=os.path.join(FOLDER_PATH, gpkg_name), gpkg_tbl = test_reuploaded_table_name, print_cmd=True)
+                           path=os.path.join(FOLDER_PATH, gpkg_name, test_reuploaded_table_name), print_cmd=True)
 
         # # Assert successful
         assert os.path.isfile(os.path.join(FOLDER_PATH, gpkg_name))
@@ -1126,7 +1191,7 @@ class TestWritegpkgMS:
 
         # Write gpkg.
         s.write_geospatial(dbo=sql, schema = ms_schema, table = test_write_gpkg_table_name + '_2',
-                           path=os.path.join(FOLDER_PATH, gpkg_name), gpkg_tbl=test_reuploaded_table_name + '_2', print_cmd=True) # add second table
+                           path=os.path.join(FOLDER_PATH, gpkg_name, test_reuploaded_table_name + '_2'), print_cmd=True) # add second table
 
         # Assert successful
         assert os.path.isfile(os.path.join(FOLDER_PATH, gpkg_name))
@@ -1184,13 +1249,14 @@ class TestWritegpkgMS:
         gpkg_name = 'test_write.gpkg'
 
         # Write gpkg
-        s.write_geospatial(dbo=sql, path = os.path.join(FOLDER_PATH, gpkg_name), table= test_write_gpkg_table_name, gpkg_tbl = test_write_gpkg_table_name, schema=ms_schema, print_cmd=True)
+        s.write_geospatial(dbo=sql, path = os.path.join(FOLDER_PATH, gpkg_name, test_write_gpkg_table_name),
+                           table= test_write_gpkg_table_name, schema=ms_schema, print_cmd=True)
  
         # Assert successful
         assert os.path.isfile(os.path.join(FOLDER_PATH, gpkg_name))
  
         # Reupload as table
-        s.upload_geospatial(dbo = sql, path=os.path.join(FOLDER_PATH, gpkg_name), gpkg_tbl = test_write_gpkg_table_name,
+        s.upload_geospatial(dbo = sql, path=os.path.join(FOLDER_PATH, gpkg_name, test_write_gpkg_table_name),
                  schema=ms_schema, table=test_reuploaded_table_name, print_cmd=True)
 
         # Assert equality
@@ -1235,13 +1301,13 @@ class TestWritegpkgMS:
 
         # Write gpkg
         s.write_geospatial(dbo=sql, query=f"""select top 10 * from {ms_schema}.{test_write_gpkg_table_name} order by test_col1""",
-                            path= os.path.join(FOLDER_PATH, gpkg_name), gpkg_tbl = test_write_gpkg_table_name, print_cmd=True)
+                            path= os.path.join(FOLDER_PATH, gpkg_name, test_write_gpkg_table_name), print_cmd=True)
 
         # Check table in folder
         assert os.path.isfile(os.path.join(FOLDER_PATH, gpkg_name))
 
         # Reupload as table
-        s.upload_geospatial(dbo = sql, path=FOLDER_PATH + '//' + gpkg_name, gpkg_tbl = test_write_gpkg_table_name,
+        s.upload_geospatial(dbo = sql, path=FOLDER_PATH + '//' + gpkg_name + '//' + test_write_gpkg_table_name,
                             schema=ms_schema, table=test_reuploaded_table_name, print_cmd=True)
 
         # Assert equality
@@ -1291,7 +1357,8 @@ class TestWritegpkgMS:
             os.remove(os.path.join(FOLDER_PATH, gpkg_name))
 
         # Write gpkg
-        s.write_geospatial(path=os.path.join(FOLDER_PATH, gpkg_name), dbo=sql, schema=ms_schema, table=test_write_gpkg_table_name, print_cmd=True)
+        s.write_geospatial(path=os.path.join(FOLDER_PATH, gpkg_name, test_write_gpkg_table_name), dbo=sql,
+                           schema=ms_schema, table=test_write_gpkg_table_name, print_cmd=True)
 
         # Assert successful
         assert os.path.isfile(os.path.join(FOLDER_PATH, gpkg_name))
@@ -1323,7 +1390,7 @@ class TestWritegpkgMS:
 
         # Write gpkg
         s.write_geospatial(dbo=sql, query=f"select * from {ms_schema}.{test_write_gpkg_table_name}",
-                            path= os.path.join(FOLDER_PATH, gpkg_name), gpkg_tbl = test_write_gpkg_table_name, print_cmd=True)
+                            path= os.path.join(FOLDER_PATH, gpkg_name, test_write_gpkg_table_name), print_cmd=True)
 
         # Check table in folder
         assert os.path.isfile(os.path.join(FOLDER_PATH, gpkg_name))
@@ -1358,7 +1425,7 @@ class TestGpkgShpConversion:
 
         # write geopackage file
         s.write_geospatial(dbo=sql, table= test_write_gpkg_table_name, schema=ms_schema,
-                           path = os.path.join(FOLDER_PATH, gpkg_name), print_cmd=True)
+                           path = os.path.join(FOLDER_PATH, gpkg_name, test_write_gpkg_table_name), print_cmd=True)
 
         # # Check table in folder
         assert os.path.isfile(os.path.join(FOLDER_PATH, gpkg_name))
@@ -1401,7 +1468,8 @@ class TestGpkgShpConversion:
                 """)
 
         # write geopackage file
-        s.write_geospatial(dbo=sql, table= test_write_gpkg_table_name, schema=ms_schema, path = os.path.join(FOLDER_PATH, gpkg_name), print_cmd=True)
+        s.write_geospatial(dbo=sql, table= test_write_gpkg_table_name, schema=ms_schema,
+                           path = os.path.join(FOLDER_PATH, gpkg_name, test_write_gpkg_table_name), print_cmd=True)
 
         # add an extra table to test multiple
         sql.query(f"""drop table if exists {ms_schema}.{test_write_gpkg_table_name}_2;
@@ -1414,7 +1482,7 @@ class TestGpkgShpConversion:
         assert sql.table_exists(schema = ms_schema, table = f"{test_write_gpkg_table_name}_2")
 
         s.write_geospatial(dbo=sql, schema = ms_schema, table = test_write_gpkg_table_name + '_2',
-                           path = os.path.join(FOLDER_PATH, gpkg_name), print_cmd=True) # this will append 
+                           path = os.path.join(FOLDER_PATH, gpkg_name, test_write_gpkg_table_name + '_2'), print_cmd=True) # this will append 
 
         # Check table in folder
         assert os.path.isfile(os.path.join(FOLDER_PATH, gpkg_name))
@@ -1877,6 +1945,28 @@ class TestReadShpPG:
         # Cleanup
         db.drop_table(schema=db.default_schema, table=test_read_shp_table_name)
 
+    def test_read_shp_special_char(self):
+
+        fp = FOLDER_PATH
+        shp_name = "test.shp"
+        unique_table_name = '!!T@BLE !!'
+
+        # Assert successful
+        assert shp_name in os.listdir(fp)
+        db.drop_table(schema=pg_schema, table=unique_table_name)
+
+        # Read shp to new, test table
+        s.upload_geospatial(dbo=db, path=os.path.join(fp, shp_name), schema=pg_schema, table = unique_table_name, print_cmd=True)
+
+        # Assert read_shp happened successfully and contents are correct
+        assert db.table_exists(schema=pg_schema, table=unique_table_name.lower()), f'table {unique_table_name} does not exist'
+        table_df = db.dfquery(f'select * from {pg_schema}."{unique_table_name.lower()}"')
+
+        assert set(table_df.columns) == {'ogc_fid', 'gid', 'some_value', 'geom'}, "columns don't match"
+        assert len(table_df) == 2, "table size not 2"
+
+        # Cleanup
+        db.drop_table(schema=pg_schema, table=unique_table_name.lower())
 
     @classmethod
     def teardown_class(cls):
@@ -2153,6 +2243,29 @@ class TestReadShpMS:
 
         # Cleanup
         sql.drop_table(schema=sql.default_schema, table=test_read_shp_table_name)
+
+    def test_read_shp_special_char(self):
+        
+        fp = FOLDER_PATH
+        shp_name = "test.shp"
+        unique_table_name = '!!T@BLE !!'
+
+        # Assert successful
+        assert shp_name in os.listdir(fp)
+        sql.drop_table(schema=ms_schema, table=unique_table_name)
+
+        # Read shp to new, test table
+        s.upload_geospatial(dbo=sql, path=os.path.join(fp, shp_name), schema=ms_schema, table = unique_table_name, print_cmd=True)
+
+        # Assert read_shp happened successfully and contents are correct
+        assert sql.table_exists(schema=ms_schema, table=unique_table_name.lower())
+        table_df = sql.dfquery(f'select * from {ms_schema}."{unique_table_name.lower()}"')
+
+        assert set(table_df.columns) == {'gid', 'some_value', 'geom', 'ogr_fid'}
+        assert len(table_df) == 2
+
+        # Cleanup
+        sql.drop_table(schema=ms_schema, table=unique_table_name.lower())
 
     @classmethod
     def teardown_class(cls):
@@ -2678,7 +2791,7 @@ class TestFeatureClassToTablePg:
         db.drop_table(table=test_feature_class_table_name, schema=db.default_schema)
         assert not db.table_exists(test_feature_class_table_name, schema=db.default_schema)
 
-        db.feature_class_to_table(path = fgdb, table = test_feature_class_table_name, schema=None, feature_class=fc)
+        db.feature_class_to_table(path = os.path.join(fgdb, fc), table = test_feature_class_table_name, schema=None)
         assert db.table_exists(test_feature_class_table_name, schema=db.default_schema)
 
         db.drop_table(db.default_schema, test_feature_class_table_name)
@@ -2687,7 +2800,7 @@ class TestFeatureClassToTablePg:
         db.drop_table(table = test_feature_class_table_name, schema=db.default_schema)
         assert not db.table_exists(test_feature_class_table_name, schema=db.default_schema)
 
-        db.feature_class_to_table(path = fgdb, table=test_feature_class_table_name, schema=None, feature_class = fc)
+        db.feature_class_to_table(path = os.path.join(fgdb, fc), table=test_feature_class_table_name, schema=None)
         assert db.table_exists(test_feature_class_table_name, schema=db.default_schema)
 
         db.drop_table(db.default_schema, test_feature_class_table_name)
@@ -2697,7 +2810,8 @@ class TestFeatureClassToTablePg:
         db.drop_table(table=test_feature_class_table_name, schema=db.default_schema)
         assert not db.table_exists(test_feature_class_table_name, schema=db.default_schema)
 
-        db.feature_class_to_table(path = FOLDER_PATH + "/nyclion_21d.zip/lion/lion.gdb", table = test_feature_class_table_name, schema=None, feature_class=fc)
+        db.feature_class_to_table(path = FOLDER_PATH + f"/nyclion_21d.zip/lion/lion.gdb/{fc}",
+                                  table = test_feature_class_table_name, schema=None)
         assert db.table_exists(test_feature_class_table_name, schema=db.default_schema)
 
         db.drop_table(db.default_schema, test_feature_class_table_name)
@@ -2707,7 +2821,7 @@ class TestFeatureClassToTablePg:
         db.drop_table(table = test_feature_class_table_name, schema=pg_schema)
         assert not db.table_exists(test_feature_class_table_name, schema=pg_schema)
 
-        db.feature_class_to_table(path = fgdb, table=test_feature_class_table_name, feature_class = fc, schema=pg_schema)
+        db.feature_class_to_table(path = os.path.join(fgdb, fc), table=test_feature_class_table_name, schema=pg_schema)
         assert db.table_exists(test_feature_class_table_name, schema=pg_schema)
 
         db.query(f"select * from {pg_schema}.__temp_log_table_{db.user}__ where table_name = '{test_feature_class_table_name}'")
@@ -2720,7 +2834,7 @@ class TestFeatureClassToTablePg:
         db.drop_table(table=test_feature_class_table_name, schema=pg_schema)
         assert not db.table_exists(test_feature_class_table_name, schema=pg_schema)
 
-        db.feature_class_to_table(path = fgdb, table=test_feature_class_table_name, feature_class=fc, schema=pg_schema, srid=4326)
+        db.feature_class_to_table(path = os.path.join(fgdb, fc), table=test_feature_class_table_name, schema=pg_schema, srid=4326)
         assert db.table_exists(test_feature_class_table_name, schema=pg_schema)
 
         db.query(f'select distinct st_srid(geom) from {pg_schema}.{test_feature_class_table_name}')
@@ -2732,7 +2846,7 @@ class TestFeatureClassToTablePg:
         db.drop_table(table=test_feature_class_table_name, schema=db.default_schema)
         assert not db.table_exists(test_feature_class_table_name, schema=db.default_schema)
 
-        db.feature_class_to_table(path = fgdb, table=test_feature_class_table_name, schema=None, feature_class=fc)
+        db.feature_class_to_table(path = os.path.join(fgdb, fc), table=test_feature_class_table_name, schema=None)
         assert db.table_exists(test_feature_class_table_name, schema=db.default_schema)
 
         db.query(f"""
@@ -2788,7 +2902,7 @@ class TestFeatureClassToTablePg:
         assert not db.table_exists(test_feature_class_table_name, schema=db.default_schema)
 
         try:
-            db.feature_class_to_table(path = fgdb, table=test_feature_class_table_name, feature_class=fc, schema=pg_schema)
+            db.feature_class_to_table(path = os.path.join(fgdb, fc), table=test_feature_class_table_name, schema=pg_schema)
         except:
             assert not db.table_exists(test_feature_class_table_name, schema=pg_schema)
 
@@ -2800,7 +2914,7 @@ class TestFeatureClassToTablePg:
         db.drop_table(table=private_table, schema=pg_schema)
         assert not db.table_exists(private_table, schema=pg_schema)
 
-        db.feature_class_to_table(path = fgdb, table=private_table, feature_class=fc, schema=pg_schema, private=True)
+        db.feature_class_to_table(path = os.path.join(fgdb, fc), table=private_table, schema=pg_schema, private=True)
         assert db.table_exists(private_table, schema=pg_schema)
 
         db.query(f"""
@@ -2818,7 +2932,7 @@ class TestFeatureClassToTablePg:
         db.drop_table(table=not_temp_table, schema=pg_schema)
         assert not db.table_exists(not_temp_table, schema=pg_schema)
 
-        db.feature_class_to_table(path = fgdb, table=not_temp_table, feature_class=fc, schema=pg_schema, temp=False)
+        db.feature_class_to_table(path = os.path.join(fgdb, fc), table=not_temp_table, schema=pg_schema, temp=False)
         assert db.table_exists(not_temp_table, schema=pg_schema)
 
         db.query(f"select * from {pg_schema}.__temp_log_table_{db.user}__ where table_name = '{not_temp_table}'")
@@ -2830,7 +2944,7 @@ class TestFeatureClassToTablePg:
         db.drop_table(table=test_feature_class_table_name, schema=db.default_schema)
         assert not db.table_exists(test_feature_class_table_name, schema=db.default_schema)
 
-        db.feature_class_to_table(fgdb, test_feature_class_table_name, schema=None, feature_class='lion', extra_cmd='-nlt MULTILINESTRING')
+        db.feature_class_to_table(os.path.join(fgdb, 'lion'), test_feature_class_table_name, schema=None, extra_cmd='-nlt MULTILINESTRING')
         assert db.table_exists(test_feature_class_table_name, schema=db.default_schema)
 
         db.drop_table(db.default_schema, test_feature_class_table_name)
@@ -2842,10 +2956,24 @@ class TestFeatureClassToTablePg:
         db.drop_table(table=test_feature_class_table_name, schema=db.default_schema)
         assert not db.table_exists(test_feature_class_table_name, schema=db.default_schema)
 
-        db.feature_class_to_table(fgdb_subfolder, test_feature_class_table_name, schema=None, feature_class='lion', extra_cmd='-nlt MULTILINESTRING')
+        db.feature_class_to_table(os.path.join(fgdb_subfolder, 'lion'), test_feature_class_table_name,
+                                  schema=None,  extra_cmd='-nlt MULTILINESTRING')
         assert db.table_exists(test_feature_class_table_name, schema=db.default_schema)
 
         db.drop_table(db.default_schema, test_feature_class_table_name)
+
+    def test_import_fc_special_char(self):
+
+        unique_table_name = 'F!unky N@mE?'
+
+        db.drop_table(table=unique_table_name, schema=db.default_schema)
+        assert not db.table_exists(unique_table_name, schema=db.default_schema)
+
+        db.feature_class_to_table(os.path.join(fgdb, 'lion'), unique_table_name,
+                                  schema=None,  extra_cmd='-nlt MULTILINESTRING')
+        assert db.table_exists(unique_table_name.lower(), schema=db.default_schema)
+
+        db.drop_table(db.default_schema, unique_table_name.lower())
 
     @classmethod
     def teardown_class(cls):
@@ -2861,7 +2989,8 @@ class TestFeatureClassToTableMs:
         sql.drop_table(table=test_feature_class_table_name, schema=sql.default_schema)
         assert not sql.table_exists(test_feature_class_table_name, schema=sql.default_schema)
 
-        sql.feature_class_to_table(path = fgdb, table=test_feature_class_table_name, schema=None, feature_class=fc, print_cmd=True,skip_failures='-skip_failures')
+        sql.feature_class_to_table(path = os.path.join(fgdb, fc), table=test_feature_class_table_name,
+                                   schema=None, print_cmd=True,skip_failures='-skip_failures')
         assert sql.table_exists(test_feature_class_table_name, schema=sql.default_schema)
 
         sql.drop_table(sql.default_schema, test_feature_class_table_name)
@@ -2870,7 +2999,8 @@ class TestFeatureClassToTableMs:
         sql.drop_table(table=test_feature_class_table_name, schema=sql.default_schema)
         assert not sql.table_exists(test_feature_class_table_name, schema=sql.default_schema)
 
-        sql.feature_class_to_table(path = fgdb, table=test_feature_class_table_name, schema=None, feature_class=fc, skip_failures='-skip_failures')
+        sql.feature_class_to_table(path = os.path.join(fgdb, fc), table=test_feature_class_table_name,
+                                   schema=None, skip_failures='-skip_failures')
         assert sql.table_exists(test_feature_class_table_name, schema=sql.default_schema)
 
         sql.drop_table(sql.default_schema, test_feature_class_table_name)
@@ -2880,7 +3010,8 @@ class TestFeatureClassToTableMs:
         sql.drop_table(table=test_feature_class_table_name, schema=sql.default_schema)
         assert not sql.table_exists(test_feature_class_table_name, schema=sql.default_schema)
 
-        sql.feature_class_to_table(path = FOLDER_PATH + "/nyclion_21d.zip/lion/lion.gdb", table = test_feature_class_table_name, schema=None, feature_class=fc, skip_failures='-skip_failures')
+        sql.feature_class_to_table(path = FOLDER_PATH + f"/nyclion_21d.zip/lion/lion.gdb/{fc}",
+                                   table = test_feature_class_table_name, schema=None, skip_failures='-skip_failures')
         assert sql.table_exists(test_feature_class_table_name, schema=sql.default_schema)
 
         sql.drop_table(sql.default_schema, test_feature_class_table_name)
@@ -2890,7 +3021,8 @@ class TestFeatureClassToTableMs:
         sql.drop_table(table=test_feature_class_table_name, schema=ms_schema)
         assert not sql.table_exists(test_feature_class_table_name, schema=ms_schema)
 
-        sql.feature_class_to_table(path = fgdb, table=test_feature_class_table_name, feature_class=fc, schema=ms_schema, skip_failures='-skip_failures')
+        sql.feature_class_to_table(path = os.path.join(fgdb, fc), table=test_feature_class_table_name,
+                                   schema=ms_schema, skip_failures='-skip_failures')
         assert sql.table_exists(test_feature_class_table_name, schema=ms_schema)
 
         sql.drop_table(ms_schema, test_feature_class_table_name)
@@ -2900,7 +3032,8 @@ class TestFeatureClassToTableMs:
         sql.drop_table(table=test_feature_class_table_name, schema=ms_schema)
         assert not sql.table_exists(test_feature_class_table_name, schema=ms_schema)
 
-        sql.feature_class_to_table(path = fgdb, table=test_feature_class_table_name, feature_class=fc, schema = ms_schema, srid=4326, skip_failures='-skip_failures')
+        sql.feature_class_to_table(path = os.path.join(fgdb, fc), table=test_feature_class_table_name,
+                                    schema = ms_schema, srid=4326, skip_failures='-skip_failures')
         assert sql.table_exists(test_feature_class_table_name, schema = ms_schema)
 
         sql.query(f"select distinct geom.STSrid from {ms_schema}.{test_feature_class_table_name}")
@@ -2912,7 +3045,8 @@ class TestFeatureClassToTableMs:
         sql.drop_table(table=test_feature_class_table_name, schema=sql.default_schema)
 
         assert not sql.table_exists(test_feature_class_table_name, schema=sql.default_schema)
-        sql.feature_class_to_table(path = fgdb, table=test_feature_class_table_name, schema=None, feature_class=fc, skip_failures='-skip_failures')
+        sql.feature_class_to_table(path = os.path.join(fgdb, fc), table=test_feature_class_table_name, 
+                                   schema=None, skip_failures='-skip_failures')
 
         assert sql.table_exists(test_feature_class_table_name, schema=sql.default_schema)
         sql.query(f"""
@@ -2964,7 +3098,8 @@ class TestFeatureClassToTableMs:
         assert not sql.table_exists(test_feature_class_table_name, schema=schema)
 
         try:
-            sql.feature_class_to_table(path = fgdb, table = test_feature_class_table_name, feature_class=fc, schema=schema, skip_failures='-skip_failures')
+            sql.feature_class_to_table(path = os.path.join(fgdb, fc), table = test_feature_class_table_name,
+                                       schema=schema, skip_failures='-skip_failures')
         except:
             assert not sql.table_exists(test_feature_class_table_name, schema=schema)
 
@@ -2975,7 +3110,7 @@ class TestFeatureClassToTableMs:
         sql.drop_table(table=test_feature_class_table_name, schema = ms_schema)
         assert not sql.table_exists(test_feature_class_table_name, schema=ms_schema)
 
-        sql.feature_class_to_table(path = fgdb, table = test_feature_class_table_name, feature_class=fc, schema=ms_schema, temp=False,
+        sql.feature_class_to_table(path = os.path.join(fgdb, fc), table = test_feature_class_table_name, schema=ms_schema, temp=False,
         skip_failures='-skip_failures')
         assert sql.table_exists(test_feature_class_table_name, schema=ms_schema)
 
@@ -2989,7 +3124,7 @@ class TestFeatureClassToTableMs:
         sql.drop_table(table=test_feature_class_table_name, schema = ms_schema)
         assert not sql.table_exists(test_feature_class_table_name, schema=ms_schema)
 
-        sql.feature_class_to_table(path = fgdb, table=test_feature_class_table_name, feature_class=fc,
+        sql.feature_class_to_table(path = os.path.join(fgdb, fc), table=test_feature_class_table_name,
                                    schema = ms_schema, private=True, skip_failures='-skip_failures')
         assert sql.table_exists(table = test_feature_class_table_name, schema = ms_schema)
 
@@ -3002,7 +3137,7 @@ class TestFeatureClassToTableMs:
         sql.drop_table(table=test_feature_class_table_name, schema=ms_schema)
         assert not sql.table_exists(test_feature_class_table_name, schema=ms_schema)
 
-        sql.feature_class_to_table(path = fgdb, table = test_feature_class_table_name, feature_class = fc, schema=ms_schema,
+        sql.feature_class_to_table(path = os.path.join(fgdb, fc), table = test_feature_class_table_name, schema=ms_schema,
                                     extra_cmd='-nlt MULTILINESTRING')
         assert sql.table_exists(test_feature_class_table_name, schema=ms_schema)
 
@@ -3015,11 +3150,24 @@ class TestFeatureClassToTableMs:
         sql.drop_table(table=test_feature_class_table_name, schema=ms_schema)
         assert not sql.table_exists(test_feature_class_table_name, schema=ms_schema)
 
-        sql.feature_class_to_table(path = fgdb_subfolder, table = test_feature_class_table_name, feature_class = fc, schema=ms_schema,
+        sql.feature_class_to_table(path = fgdb_subfolder + '/' + fc, table = test_feature_class_table_name, schema=ms_schema,
                                     extra_cmd='-nlt MULTILINESTRING')
         assert sql.table_exists(test_feature_class_table_name, schema=ms_schema)
 
         sql.drop_table(ms_schema, test_feature_class_table_name)
+
+    def test_import_fc_special_char(self):
+
+        unique_table_name = 'F!unky N@mE?'
+
+        sql.drop_table(table=unique_table_name, schema=ms_schema)
+        assert not sql.table_exists(unique_table_name, schema=ms_schema)
+
+        sql.feature_class_to_table(os.path.join(fgdb, 'lion'), unique_table_name,
+                                  schema=ms_schema,  extra_cmd='-nlt MULTILINESTRING')
+        assert sql.table_exists(unique_table_name.lower(), schema=ms_schema)
+
+        sql.drop_table(ms_schema, unique_table_name.lower())
 
     @classmethod
     def teardown_class(cls):

--- a/pysqldb3/tests/test_query_to_geospatial.py
+++ b/pysqldb3/tests/test_query_to_geospatial.py
@@ -54,8 +54,8 @@ class TestQueryToGpkgPg:
         assert db.table_exists(test_table, schema=pg_schema)
 
         # table to gpkg
-        db.query_to_gpkg(query = f"select * from {pg_schema}.{test_table}", gpkg_tbl = test_table,
-                         path=os.path.join(FOLDER_PATH, gpkg), print_cmd=True, srid=2263)
+        db.query_to_gpkg(query = f"select * from {pg_schema}.{test_table}",
+                         path=os.path.join(FOLDER_PATH, gpkg,  test_table), print_cmd=True, srid=2263)
 
         # check table in folder
         assert os.path.isfile(os.path.join(FOLDER_PATH, gpkg))
@@ -85,11 +85,11 @@ class TestQueryToGpkgPg:
         assert db.table_exists(test_table, schema=pg_schema)
 
         # add first table
-        db.query_to_gpkg(query = f"select * from {pg_schema}.{test_table}", gpkg_tbl = test_table,
-                            path=os.path.join(FOLDER_PATH, gpkg), print_cmd=True, srid=2263)
+        db.query_to_gpkg(query = f"select * from {pg_schema}.{test_table}",
+                            path=os.path.join(FOLDER_PATH, gpkg, test_table), print_cmd=True, srid=2263)
         # add second table to the same gpkg
-        db.query_to_gpkg(query = f"select * from {pg_schema}.{test_table}", gpkg_tbl = test_table + '_2',
-                         path=os.path.join(FOLDER_PATH, gpkg), print_cmd=True, srid=2263)
+        db.query_to_gpkg(query = f"select * from {pg_schema}.{test_table}",
+                         path=os.path.join(FOLDER_PATH, gpkg, test_table + '_2'), print_cmd=True, srid=2263)
 
         # check table in folder
         assert os.path.isfile(os.path.join(FOLDER_PATH, gpkg))
@@ -123,8 +123,8 @@ class TestQueryToGpkgPg:
         
         assert db.table_exists(test_table, schema=pg_schema)
 
-        db.query_to_gpkg(query = f"select * from {pg_schema}.{test_table}", gpkg_tbl = test_table,
-                         path=os.path.join(FOLDER_PATH, gpkg), print_cmd=True, srid=2263)
+        db.query_to_gpkg(query = f"select * from {pg_schema}.{test_table}",
+                         path=os.path.join(FOLDER_PATH, gpkg, test_table), print_cmd=True, srid=2263)
 
         # create table
         db.query(f"""
@@ -136,8 +136,8 @@ class TestQueryToGpkgPg:
          """)
         
         # overwrite the table
-        db.query_to_gpkg(query = f"select * from {pg_schema}.{test_table}_2", gpkg_tbl = test_table, overwrite = True,
-                            path=os.path.join(FOLDER_PATH, gpkg), print_cmd=True, srid=2263)
+        db.query_to_gpkg(query = f"select * from {pg_schema}.{test_table}_2", overwrite = True,
+                            path=os.path.join(FOLDER_PATH, gpkg, test_table), print_cmd=True, srid=2263)
 
         # check table in folder
         assert os.path.isfile(os.path.join(FOLDER_PATH, gpkg))
@@ -171,7 +171,7 @@ class TestQueryToGpkgPg:
         assert db.table_exists(test_table, schema=pg_schema)
 
         # table to gpkg - make sure output_file overwrites any gpkg in the path
-        db.query_to_gpkg(query = f"select * from {pg_schema}.{test_table}", path=os.path.join(FOLDER_PATH, gpkg), gpkg_tbl = test_table, print_cmd=True)
+        db.query_to_gpkg(query = f"select * from {pg_schema}.{test_table}", path=os.path.join(FOLDER_PATH, gpkg, test_table), print_cmd=True)
 
         # check table in folder
         assert os.path.isfile(os.path.join(FOLDER_PATH, gpkg))
@@ -200,8 +200,8 @@ class TestQueryToGpkgPg:
         assert db.table_exists(test_table, schema=pg_schema)
 
         # table to gpkg - make sure gpkg_tbl overwrites any gpkg in the path
-        db.query_to_gpkg(query = f"select * from {pg_schema}.{test_table}", gpkg_tbl = test_table,
-                         path=os.path.join(FOLDER_PATH, 'test_' + gpkg), print_cmd=True)
+        db.query_to_gpkg(query = f"select * from {pg_schema}.{test_table}",
+                         path=os.path.join(FOLDER_PATH, 'test_' + gpkg, test_table), print_cmd=True)
 
         # check table in folder
         assert os.path.isfile(os.path.join(FOLDER_PATH, 'test_' + gpkg))
@@ -224,8 +224,8 @@ class TestQueryToGpkgPg:
         assert db.table_exists(test_table, schema=pg_schema)
 
         # table to gpkg
-        db.query_to_gpkg(query = f"select * from {pg_schema}.{test_table}", gpkg_tbl = test_table,
-                         path=os.path.join(FOLDER_PATH, gpkg), print_cmd=True)
+        db.query_to_gpkg(query = f"select * from {pg_schema}.{test_table}",
+                         path=os.path.join(FOLDER_PATH, gpkg, test_table), print_cmd=True)
 
         # check table in folder
         assert os.path.isfile(os.path.join(FOLDER_PATH, gpkg))
@@ -248,8 +248,8 @@ class TestQueryToGpkgPg:
         assert db.table_exists(test_table, schema=pg_schema)
 
         # table to gpkg
-        db.query_to_gpkg(query = f"select * from {pg_schema}.{test_table}", gpkg_tbl = test_table,
-                         path=os.path.join(FOLDER_PATH, gpkg), print_cmd=True)
+        db.query_to_gpkg(query = f"select * from {pg_schema}.{test_table}",
+                         path=os.path.join(FOLDER_PATH, gpkg, test_table), print_cmd=True)
 
         # check table in folder
         assert os.path.isfile(os.path.join(FOLDER_PATH, gpkg))
@@ -276,8 +276,8 @@ class TestQueryToGpkgPg:
         assert db.table_exists(test_table, schema=pg_schema)
 
         # table to gpkg
-        db.query_to_gpkg(f"select * from {pg_schema}.{test_table}", gpkg_tbl = test_table,
-                         path=os.path.join(FOLDER_PATH, gpkg), print_cmd=True)
+        db.query_to_gpkg(f"select * from {pg_schema}.{test_table}",
+                         path=os.path.join(FOLDER_PATH, gpkg, test_table), print_cmd=True)
 
         # check table in folder
         assert os.path.isfile(os.path.join(FOLDER_PATH, gpkg))
@@ -300,8 +300,8 @@ class TestQueryToGpkgPg:
         assert db.table_exists(test_table, schema=pg_schema)
 
         # table to gpkg
-        db.query_to_gpkg(query = f"select * from {pg_schema}.{test_table} limit 0", gpkg_tbl = test_table,
-                         path=os.path.join(FOLDER_PATH, gpkg), print_cmd=True)
+        db.query_to_gpkg(query = f"select * from {pg_schema}.{test_table} limit 0",
+                         path=os.path.join(FOLDER_PATH, gpkg, test_table), print_cmd=True)
 
         # check table in folder
         assert os.path.isfile(os.path.join(FOLDER_PATH, gpkg))
@@ -336,8 +336,8 @@ class TestQueryToGpkgPg:
         assert db.table_exists(test_table, schema=pg_schema)
 
         # table to gpkg
-        db.query_to_gpkg(query = f"select * from {pg_schema}.{test_table}", gpkg_tbl = test_table,
-                         path=os.path.join(FOLDER_PATH, gpkg), print_cmd=True)
+        db.query_to_gpkg(query = f"select * from {pg_schema}.{test_table}",
+                         path=os.path.join(FOLDER_PATH, gpkg, test_table), print_cmd=True)
 
         # check table in folder
         assert os.path.isfile(os.path.join(FOLDER_PATH, gpkg))
@@ -388,8 +388,8 @@ class TestQueryToGpkgPg:
         assert db.table_exists(test_table, schema=pg_schema)
 
         # table to gpkg
-        db.query_to_gpkg(query = f"select * from {pg_schema}.{test_table}", gpkg_tbl = test_table,
-                         path=os.path.join(FOLDER_PATH, gpkg), print_cmd=True)
+        db.query_to_gpkg(query = f"select * from {pg_schema}.{test_table}",
+                         path=os.path.join(FOLDER_PATH, gpkg, test_table), print_cmd=True)
 
         # check table in folder
         assert os.path.isfile(os.path.join(FOLDER_PATH, gpkg))
@@ -416,8 +416,8 @@ class TestQueryToGpkgPg:
 
         # This should fail
         try:
-            db.query_to_gpkg(query="select * from table_does_not_exist", gpkg_tbl = test_table,
-                             path=os.path.join(FOLDER_PATH, gpkg), print_cmd=True)
+            db.query_to_gpkg(query="select * from table_does_not_exist",
+                             path=os.path.join(FOLDER_PATH, gpkg, test_table), print_cmd=True)
         except:
             Failed = True
         # check table in not folder
@@ -442,8 +442,8 @@ class TestQueryToGpkgPg:
             os.remove(os.path.join(FOLDER_PATH, gpkg))
 
         # Write gpkg
-        db.query_to_gpkg(path=os.path.join(FOLDER_PATH, gpkg), query = f"select * from {pg_schema}.{test_table}",
-                         gpkg_tbl=test_table, print_cmd=True)
+        db.query_to_gpkg(path=os.path.join(FOLDER_PATH, gpkg, test_table),
+                         query = f"select * from {pg_schema}.{test_table}", print_cmd=True)
 
         # Assert successful
         assert os.path.isfile(os.path.join(FOLDER_PATH, gpkg))
@@ -485,8 +485,8 @@ class TestQueryToGpkgMs:
         assert sql.table_exists(test_table, schema=ms_schema)
 
         # table to gpkg
-        sql.query_to_gpkg(f"select * from {ms_schema}.{test_table}", gpkg_tbl = test_table,
-                          path=os.path.join(FOLDER_PATH, gpkg), print_cmd=True, srid=2263)
+        sql.query_to_gpkg(f"select * from {ms_schema}.{test_table}",
+                          path=os.path.join(FOLDER_PATH, gpkg, test_table), print_cmd=True, srid=2263)
 
         # check table in folder
         assert os.path.isfile(os.path.join(FOLDER_PATH, gpkg))
@@ -515,8 +515,8 @@ class TestQueryToGpkgMs:
              geometry::Point(1015329.1, 213793.1, 2263 ))
         """)
         assert sql.table_exists(test_table, schema=ms_schema)
-        sql.query_to_gpkg(f"select * from {ms_schema}.{test_table}", gpkg_tbl = test_table,
-                          path=os.path.join(FOLDER_PATH, gpkg), print_cmd=True, srid=2263)
+        sql.query_to_gpkg(f"select * from {ms_schema}.{test_table}",
+                          path=os.path.join(FOLDER_PATH, gpkg, test_table), print_cmd=True, srid=2263)
 
         sql.drop_table(schema=ms_schema, table=test_table)
         # add similar table under a different name in the same gpkg
@@ -529,8 +529,8 @@ class TestQueryToGpkgMs:
              geometry::Point(1015329.1, 213793.1, 2263 ))
         """)
         assert sql.table_exists(test_table, schema=ms_schema)
-        sql.query_to_gpkg(query = f"select * from {ms_schema}.{test_table}", gpkg_tbl = test_table + '_2',
-                          path=os.path.join(FOLDER_PATH, gpkg), print_cmd=True, srid=2263)
+        sql.query_to_gpkg(query = f"select * from {ms_schema}.{test_table}",
+                          path=os.path.join(FOLDER_PATH, gpkg, test_table + '_2'), print_cmd=True, srid=2263)
 
         # check table in folder
         assert os.path.isfile(os.path.join(FOLDER_PATH, gpkg))
@@ -561,8 +561,8 @@ class TestQueryToGpkgMs:
              VALUES (1, 'test text', CURRENT_TIMESTAMP,
              geometry::Point(1015329.1, 213793.1, 2263 ))
         """)
-        sql.query_to_gpkg(f"select * from {ms_schema}.{test_table}", gpkg_tbl = test_table,
-                          path=os.path.join(FOLDER_PATH, gpkg), print_cmd=True, srid=2263)
+        sql.query_to_gpkg(f"select * from {ms_schema}.{test_table}",
+                          path=os.path.join(FOLDER_PATH, gpkg, test_table), print_cmd=True, srid=2263)
 
         # create new, slightly different table
         sql.drop_table(schema=ms_schema, table=test_table)
@@ -577,8 +577,8 @@ class TestQueryToGpkgMs:
         assert sql.table_exists(test_table, schema=ms_schema)
 
         # overwrite the same table
-        sql.query_to_gpkg(query = f"select * from {ms_schema}.{test_table}", gpkg_tbl = test_table,
-                          path=os.path.join(FOLDER_PATH, gpkg), print_cmd=True, srid=2263)
+        sql.query_to_gpkg(query = f"select * from {ms_schema}.{test_table}",
+                          path=os.path.join(FOLDER_PATH, gpkg, test_table), print_cmd=True, srid=2263)
 
         # check table in folder
         assert os.path.isfile(os.path.join(FOLDER_PATH, gpkg))
@@ -615,8 +615,8 @@ class TestQueryToGpkgMs:
         assert sql.table_exists(test_table, schema=ms_schema)
 
         # table to geospatial - make sure geospatial overwrites any gpkg in the path
-        sql.query_to_gpkg(f"select * from {ms_schema}.{test_table}", gpkg_tbl = test_table,
-                        path= os.path.join(FOLDER_PATH, gpkg), print_cmd=True)
+        sql.query_to_gpkg(f"select * from {ms_schema}.{test_table}",
+                        path= os.path.join(FOLDER_PATH, gpkg, test_table), print_cmd=True)
 
         # check table in folder
         assert os.path.isfile(os.path.join(FOLDER_PATH, gpkg))
@@ -649,7 +649,8 @@ class TestQueryToGpkgMs:
         assert sql.table_exists(test_table, schema=ms_schema)
 
         # table to gpkg
-        sql.query_to_gpkg(query = f"select * from {ms_schema}.{test_table}", path=os.path.join(FOLDER_PATH, gpkg), gpkg_tbl = test_table, print_cmd=True)
+        sql.query_to_gpkg(query = f"select * from {ms_schema}.{test_table}",
+                          path=os.path.join(FOLDER_PATH, gpkg, test_table), print_cmd=True)
 
         # check table in folder
         assert os.path.isfile(os.path.join(FOLDER_PATH, gpkg))
@@ -675,8 +676,8 @@ class TestQueryToGpkgMs:
         assert sql.table_exists(test_table, schema=ms_schema)
 
         # table to gpkg - make sure Geopackage overwrites any gpkg in the path
-        sql.query_to_gpkg(f"select * from {ms_schema}.{test_table}", gpkg_tbl = test_table,
-                        path= os.path.join(FOLDER_PATH, gpkg), print_cmd=True)
+        sql.query_to_gpkg(f"select * from {ms_schema}.{test_table}",
+                        path= os.path.join(FOLDER_PATH, gpkg, test_table), print_cmd=True)
 
         # check table in folder
         assert os.path.isfile(os.path.join(FOLDER_PATH, gpkg))
@@ -702,8 +703,8 @@ class TestQueryToGpkgMs:
         assert sql.table_exists(test_table, schema=ms_schema)
 
         # table to gpkg
-        sql.query_to_gpkg(f"select * from {ms_schema}.{test_table}", gpkg_tbl = test_table,
-                          path=os.path.join(FOLDER_PATH, gpkg), print_cmd=True)
+        sql.query_to_gpkg(f"select * from {ms_schema}.{test_table}",
+                          path=os.path.join(FOLDER_PATH, gpkg, test_table), print_cmd=True)
 
         # check table in folder
         assert os.path.isfile(os.path.join(FOLDER_PATH, gpkg))
@@ -729,8 +730,8 @@ class TestQueryToGpkgMs:
         assert sql.table_exists(test_table, schema=ms_schema)
 
         # table to gpkg
-        sql.query_to_gpkg(f"select * from {ms_schema}.{test_table}", gpkg_tbl = test_table,
-                          path=os.path.join(FOLDER_PATH, gpkg), print_cmd=True)
+        sql.query_to_gpkg(f"select * from {ms_schema}.{test_table}",
+                          path=os.path.join(FOLDER_PATH, gpkg, test_table), print_cmd=True)
 
         # check table in folder
         assert os.path.isfile(os.path.join(FOLDER_PATH, gpkg))
@@ -759,8 +760,8 @@ class TestQueryToGpkgMs:
         assert sql.table_exists(test_table, schema=ms_schema)
 
         # table to gpkg
-        sql.query_to_gpkg(f"select * from {ms_schema}.{test_table}", gpkg_tbl = test_table,
-                          path=os.path.join(FOLDER_PATH, gpkg), print_cmd=True)
+        sql.query_to_gpkg(f"select * from {ms_schema}.{test_table}",
+                          path=os.path.join(FOLDER_PATH, gpkg, test_table), print_cmd=True)
 
         # check table in folder
         assert os.path.isfile(os.path.join(FOLDER_PATH, gpkg))
@@ -786,8 +787,8 @@ class TestQueryToGpkgMs:
         assert sql.table_exists(test_table, schema=ms_schema)
 
         # table to gpkg
-        sql.query_to_gpkg(f"select top 0 * from {ms_schema}.{test_table}", gpkg_tbl = test_table,
-                          path=os.path.join(FOLDER_PATH, gpkg), print_cmd=True)
+        sql.query_to_gpkg(f"select top 0 * from {ms_schema}.{test_table}",
+                          path=os.path.join(FOLDER_PATH, gpkg, test_table), print_cmd=True)
 
         # check table in folder
         assert os.path.isfile(os.path.join(FOLDER_PATH, gpkg))
@@ -821,8 +822,8 @@ class TestQueryToGpkgMs:
         assert sql.table_exists(test_table, schema=ms_schema)
 
         # table to gpkg
-        sql.query_to_gpkg(query = f"select * from {ms_schema}.{test_table}", gpkg_tbl = test_table,
-                          path=os.path.join(FOLDER_PATH, gpkg), print_cmd=True)
+        sql.query_to_gpkg(query = f"select * from {ms_schema}.{test_table}",
+                          path=os.path.join(FOLDER_PATH, gpkg, test_table), print_cmd=True)
 
         # check table in folder
         assert os.path.isfile(os.path.join(FOLDER_PATH, gpkg))
@@ -870,8 +871,8 @@ class TestQueryToGpkgMs:
         assert sql.table_exists(test_table, schema=ms_schema)
 
         # table to gpkg
-        sql.query_to_gpkg(query = f"select * from {ms_schema}.{test_table}", gpkg_tbl = test_table,
-                          path=os.path.join(FOLDER_PATH, gpkg), print_cmd=True)
+        sql.query_to_gpkg(query = f"select * from {ms_schema}.{test_table}",
+                          path=os.path.join(FOLDER_PATH, gpkg, test_table), print_cmd=True)
 
         # check table in folder
         assert os.path.isfile(os.path.join(FOLDER_PATH, gpkg))
@@ -898,8 +899,8 @@ class TestQueryToGpkgMs:
 
         # This should fail
         try:
-            sql.query_to_gpkg(query="select * from table_does_not_exist", gpkg_tbl = 'table_does_not_exist',
-                              path=os.path.join(FOLDER_PATH, gpkg), print_cmd=True)
+            sql.query_to_gpkg(query="select * from table_does_not_exist",
+                              path=os.path.join(FOLDER_PATH, gpkg, 'table_does_not_exist'), print_cmd=True)
         except:
             Failed = True
         # check table in not folder
@@ -925,8 +926,8 @@ class TestQueryToGpkgMs:
             os.remove(os.path.join(FOLDER_PATH, gpkg_name))
 
         # Write gpkg
-        sql.query_to_gpkg(path=os.path.join(FOLDER_PATH, gpkg_name), query = f"select * from {ms_schema}.{test_table}",
-                         gpkg_tbl=test_table, print_cmd=True)
+        sql.query_to_gpkg(path=os.path.join(FOLDER_PATH, gpkg_name, test_table),
+                          query = f"select * from {ms_schema}.{test_table}",  print_cmd=True)
 
         # Assert successful
         assert os.path.isfile(os.path.join(FOLDER_PATH, gpkg_name))

--- a/pysqldb3/tests/test_rename_geom.py
+++ b/pysqldb3/tests/test_rename_geom.py
@@ -73,7 +73,7 @@ class TestRenamesGeomPg:
         # import with pysqldb
 
         assert db.table_exists(table, schema=db.default_schema) is False
-        db.feature_class_to_table(fgdb, table, schema=None, feature_class=fc)
+        db.feature_class_to_table(os.path.join(fgdb, fc), table, schema=None)
 
         db.query("""
             SELECT column_name, data_type
@@ -139,6 +139,60 @@ class TestRenamesGeomPg:
 
         db.drop_table(db.default_schema, table)
 
+    @pytest.mark.order3
+    def test_rename_geom_shp_special_char(self):
+        fldr = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'test_data')
+        shp = 'test.shp'
+        special_char_tbl_name = 'Great!@'
+
+        # import data without pysqldb
+        db.drop_table(table=table, schema=db.default_schema)
+        assert not db.table_exists(table, schema=db.default_schema)
+
+        cmd = """
+        ogr2ogr --config GDAL_DATA "{gdal_data}" -nlt PROMOTE_TO_MULTI -overwrite -a_srs 
+        "EPSG:{srid}" -progress -f "PostgreSQL" PG:"host={host} port={port} dbname={dbname} 
+        user={user} password={password}" "{shp}" -nln {schema}.{tbl_name} 
+        """.format(gdal_data=util.GDAL_DATA_LOC,
+                   srid=2263,
+                   host=db.server,
+                   dbname=db.database,
+                   user=db.user,
+                   password=db.password,
+                   shp=os.path.join(fldr, shp),
+                   schema=db.default_schema,
+                   tbl_name=special_char_tbl_name,
+                   port=5432
+                   ).replace('\n', ' ')
+
+        subprocess.call(cmd, shell=True)
+
+        db.query("""
+                            SELECT column_name, data_type
+                            FROM information_schema.columns
+                            WHERE table_name  = '{t}'
+                            and column_name='geom'
+                        """.format(t=special_char_tbl_name.lower()))
+        assert db.data == []
+        db.drop_table(db.default_schema, special_char_tbl_name.lower())
+        # clean up gdal import
+
+        # import with pysqldb
+        assert not db.table_exists(special_char_tbl_name.lower(), schema=db.default_schema)
+
+        db.shp_to_table(path=os.path.join(fldr, shp), table=special_char_tbl_name.lower())
+
+        db.query("""
+                    SELECT column_name, data_type
+                    FROM information_schema.columns
+                    WHERE table_name  = '{t}'
+                    and column_name='geom'
+                """.format(t=special_char_tbl_name.lower()))
+
+        assert db.data[0] == ('geom', 'USER-DEFINED')
+
+        db.drop_table(db.default_schema, special_char_tbl_name.lower())
+
     @classmethod
     def teardown_class(cls):
         helpers.clean_up_feature_class()
@@ -151,7 +205,7 @@ class TestRenamesGeomMs:
         helpers.set_up_feature_class()
         helpers.set_up_shapefile()
 
-    @pytest.mark.order3
+    @pytest.mark.order4
     def test_rename_geom_fc(self):
         fgdb = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'test_data/lion/lion.gdb')
         fc = 'node'
@@ -193,7 +247,7 @@ class TestRenamesGeomMs:
         # import with pysqldb
         assert not sql.table_exists(table, schema=sql.default_schema)
 
-        sql.feature_class_to_table(fgdb, table, schema=None, feature_class=fc, skip_failures='-skip_failures')
+        sql.feature_class_to_table(os.path.join(fgdb, fc), table, schema=None, skip_failures='-skip_failures')
 
         sql.query("""
             SELECT column_name, data_type
@@ -207,7 +261,7 @@ class TestRenamesGeomMs:
 
         sql.drop_table(table=table, schema=sql.default_schema)
 
-    @pytest.mark.order4
+    @pytest.mark.order5
     def test_rename_geom_shp(self):
         fldr = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'test_data')
         shp = 'test.shp'
@@ -260,6 +314,64 @@ class TestRenamesGeomMs:
         assert sql.data[0][1] == u'geometry'
 
         sql.drop_table(sql.default_schema, table)
+
+    @pytest.mark.order6
+    def test_rename_geom_fc_special_char(self):
+        fgdb = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'test_data/lion/lion.gdb')
+        fc = 'node'
+        special_char_tbl_name = 'Wonder$Col'
+
+        # import data without pysqldb
+        sql.drop_table(table=special_char_tbl_name, schema=sql.default_schema)
+        assert sql.table_exists(special_char_tbl_name, schema=sql.default_schema) is False
+
+        cmd = """
+        ogr2ogr --config GDAL_DATA "{gdal_data}" -nlt PROMOTE_TO_MULTI -overwrite -a_srs 
+        "EPSG:{srid}" -f MSSQLSpatial "MSSQL:server={host};database={dbname};UID={user};PWD={password}"
+         "{gdb}" "{feature}" -nln {sch}.{tbl_name} -progress --config MSSQLSPATIAL_USE_GEOMETRY_COLUMNS NO
+        """.format(gdal_data=util.GDAL_DATA_LOC,
+                   srid=2263,
+                   host=sql.server,
+                   dbname=sql.database,
+                   user=sql.user,
+                   password=sql.password,
+                   gdb=fgdb,
+                   feature=fc,
+                   sch=sql.default_schema,
+                   tbl_name=special_char_tbl_name
+                   ).replace('\n', ' ')
+
+        subprocess.call(cmd, shell=True)
+
+        sql.query("""
+                    SELECT column_name, data_type
+                    FROM information_schema.columns
+                    WHERE table_name  = '{t}'
+                    AND TABLE_SCHEMA='{s}'
+                    and column_name='geom'
+                """.format(t=special_char_tbl_name, s=sql.default_schema))
+
+        assert sql.data == []
+        sql.drop_table(sql.default_schema, special_char_tbl_name)
+        # clean up gdal import
+
+        # import with pysqldb
+        assert not sql.table_exists(special_char_tbl_name.lower(), schema=sql.default_schema)
+
+        sql.feature_class_to_table(os.path.join(fgdb, fc), special_char_tbl_name.lower(),
+                                   schema=None, skip_failures='-skip_failures')
+
+        sql.query("""
+            SELECT column_name, data_type
+            FROM information_schema.columns
+            WHERE table_name  = '{t}'
+            and column_name='geom'
+        """.format(t=special_char_tbl_name.lower()))
+
+        assert sql.data[0][0] == u'geom'
+        assert sql.data[0][1] == u'geometry'
+
+        sql.drop_table(table=special_char_tbl_name.lower(), schema=sql.default_schema)
 
     @classmethod
     def teardown_class(cls):

--- a/pysqldb3/tests/test_util.py
+++ b/pysqldb3/tests/test_util.py
@@ -1,7 +1,8 @@
 import pandas as pd
 import os
 import zipfile
-from ..util import convert_geom_col, parse_table_string, parse_file_path, add_zip_to_geo_path
+import pytest
+from ..util import convert_geom_col, parse_table_string, geospatial_assert_formats, decompress_and_parse_file_path
 
 
 class TestStringParser:
@@ -170,7 +171,7 @@ class TestParseFilePathShp:
         file_path = 'E:\\RIS\\Staff Folders\\Seth H\\DATA\\OUTPUT_DATA\\test_shapefile.shp'
 
         # simple path and file
-        full_path, folder_dir, file_name, table_name = parse_file_path(path=file_path)
+        full_path, folder_dir, file_name, table_name = decompress_and_parse_file_path(path=file_path)
         
         assert full_path == 'E:\\RIS\\Staff Folders\\Seth H\\DATA\\OUTPUT_DATA/test_shapefile.shp'
         assert folder_dir == os.path.dirname(file_path)
@@ -182,7 +183,7 @@ class TestParseFilePathShp:
         file_path = 'test_shapefile.shp'
         
         # simple path and file
-        full_path, folder_dir, file_name, table_name = parse_file_path(path=file_path)
+        full_path, folder_dir, file_name, table_name = decompress_and_parse_file_path(path=file_path)
 
         assert full_path == '/test_shapefile.shp'
         assert folder_dir == ''
@@ -193,8 +194,7 @@ class TestParseFilePathShp:
 
         file_path = 'E:\\RIS\\Staff Folders\\Seth H\\DATA\\OUTPUT_DATA\\test_zipfile.zip\\test_shapefile.shp'
 
-        new_path = add_zip_to_geo_path(file_path)
-        full_path, folder_dir, file_name, table_name = parse_file_path(new_path)
+        full_path, folder_dir, file_name, table_name = decompress_and_parse_file_path(file_path)
 
         assert full_path == '/vsizip/E:\\RIS\\Staff Folders\\Seth H\\DATA\\OUTPUT_DATA\\test_zipfile.zip/test_shapefile.shp'
         assert folder_dir == '/vsizip/E:\\RIS\\Staff Folders\\Seth H\\DATA\\OUTPUT_DATA\\test_zipfile.zip'
@@ -205,8 +205,7 @@ class TestParseFilePathShp:
         
         file_path = 'E:\\RIS\\Staff Folders\\Seth H\\DATA\\OUTPUT_DATA\\test_zipfile.zip\\subfolder\\test_shapefile.shp'
 
-        new_path = add_zip_to_geo_path(file_path)
-        full_path, folder_dir, file_name, table_name = parse_file_path(new_path)
+        full_path, folder_dir, file_name, table_name = decompress_and_parse_file_path(file_path)
 
         assert full_path == '/vsizip/E:\\RIS\\Staff Folders\\Seth H\\DATA\\OUTPUT_DATA\\test_zipfile.zip\\subfolder/test_shapefile.shp'
         assert folder_dir == '/vsizip/E:\\RIS\\Staff Folders\\Seth H\\DATA\\OUTPUT_DATA\\test_zipfile.zip\\subfolder'
@@ -220,7 +219,7 @@ class TestParseFilePathGdb:
         file_path = 'E:\\RIS\\Staff Folders\\Seth H\\DATA\\OUTPUT_DATA\\test_geodb.gdb\\test_shapefile'
 
         # simple path and file
-        full_path, folder_dir, file_name, table_name = parse_file_path(file_path)
+        full_path, folder_dir, file_name, table_name = decompress_and_parse_file_path(file_path)
 
         assert full_path == 'E:\\RIS\\Staff Folders\\Seth H\\DATA\\OUTPUT_DATA\\test_geodb.gdb'
         assert folder_dir == 'E:\\RIS\\Staff Folders\\Seth H\\DATA\\OUTPUT_DATA'
@@ -233,7 +232,7 @@ class TestParseFilePathGdb:
         file_path = 'test_geodb.gdb\\test_shapefile'
 
         # simple path and file
-        full_path, folder_dir, file_name, table_name = parse_file_path(file_path)
+        full_path, folder_dir, file_name, table_name = decompress_and_parse_file_path(file_path)
 
         assert full_path == 'test_geodb.gdb'
         assert folder_dir == ''
@@ -245,7 +244,7 @@ class TestParseFilePathGdb:
         file_path = 'test_geodb.gdb'
 
         # simple path and file
-        full_path, folder_dir, file_name, table_name = parse_file_path(file_path)
+        full_path, folder_dir, file_name, table_name = decompress_and_parse_file_path(file_path)
 
         assert full_path == '/test_geodb.gdb'
         assert folder_dir == ''
@@ -271,8 +270,8 @@ class TestParseFilePathGdb:
         # add zip file to the existing
 
         # simple path and file
-        new_path = add_zip_to_geo_path('E:\\RIS\\Staff Folders\\Seth H\\DATA\\OUTPUT_DATA\\zip_file_name.zip\\15a\\lion.gdb\\node')
-        full_path, file_dir, file_name, table_name = parse_file_path(new_path)
+        new_path = 'E:\\RIS\\Staff Folders\\Seth H\\DATA\\OUTPUT_DATA\\zip_file_name.zip\\15a\\lion.gdb\\node'
+        full_path, file_dir, file_name, table_name = decompress_and_parse_file_path(new_path)
         
         assert full_path == '/vsizip/E:\\RIS\\Staff Folders\\Seth H\\DATA\\OUTPUT_DATA\\zip_file_name.zip\\15a\\lion.gdb'
         assert file_dir == '/vsizip/E:\\RIS\\Staff Folders\\Seth H\\DATA\\OUTPUT_DATA\\zip_file_name.zip\\15a'
@@ -289,7 +288,7 @@ class TestParseFilePathGpkg:
         file_path = 'E:\\RIS\\Staff Folders\\Seth H\\DATA\\OUTPUT_DATA\\test_geopackage.gpkg\\test_gpkg_table'
 
         # simple path and file
-        full_path, folder_dir, file_name, table_name = parse_file_path(file_path)
+        full_path, folder_dir, file_name, table_name = decompress_and_parse_file_path(file_path)
 
         assert full_path == 'E:\\RIS\\Staff Folders\\Seth H\\DATA\\OUTPUT_DATA\\test_geopackage.gpkg'
         assert folder_dir == 'E:\\RIS\\Staff Folders\\Seth H\\DATA\\OUTPUT_DATA'
@@ -301,7 +300,7 @@ class TestParseFilePathGpkg:
         file_path = 'test_geopackage.gpkg\\test_gpkg_table'
 
         # simple path and file
-        full_path, folder_dir, file_name, table_name = parse_file_path(file_path)
+        full_path, folder_dir, file_name, table_name = decompress_and_parse_file_path(file_path)
 
         assert full_path == 'test_geopackage.gpkg'
         assert folder_dir == ''
@@ -313,7 +312,7 @@ class TestParseFilePathGpkg:
         file_path = 'test_geopackage.gpkg'
 
         # simple path and file
-        full_path, folder_dir, file_name, table_name = parse_file_path(file_path)
+        full_path, folder_dir, file_name, table_name = decompress_and_parse_file_path(file_path)
 
         assert full_path == '/test_geopackage.gpkg'
         assert folder_dir == ''
@@ -325,9 +324,30 @@ class TestParseFilePathGpkg:
         file_path = 'E:\\RIS\\Staff Folders\\Seth H\\DATA\\OUTPUT_DATA\\zip_file_name.zip\\test_geodb.gpkg\\test_geopackage_table'
 
         # simple path and file
-        new_path = add_zip_to_geo_path(file_path)
-        full_path, file_dir, file_name, table_name = parse_file_path(new_path)
+        full_path, file_dir, file_name, table_name = decompress_and_parse_file_path(file_path)
         assert full_path == '/vsizip/E:\\RIS\\Staff Folders\\Seth H\\DATA\\OUTPUT_DATA\\zip_file_name.zip\\test_geodb.gpkg'
         assert file_dir == '/vsizip/E:\\RIS\\Staff Folders\\Seth H\\DATA\\OUTPUT_DATA\\zip_file_name.zip'
         assert file_name == '/vsizip/E:\\RIS\\Staff Folders\\Seth H\\DATA\\OUTPUT_DATA\\zip_file_name.zip\\test_geodb.gpkg'
         assert table_name == 'test_geopackage_table'
+
+    def test_geospatial_assert_formats(self):
+        
+        path = "C:/Documents/HelloThere?Cindy\\test.7z\\test.gdb/helpful_fc"
+        assert geospatial_assert_formats(path) is None
+
+        path = 'C:/fakepath/subfolder1/subfolder2/original_file_name.shp'
+        assert geospatial_assert_formats(path) is None
+        
+        path = 'C://fakepath/subfolder1//subfolder2/original_file_name.gpkg/extra_table'
+        assert geospatial_assert_formats(path) is None
+
+        with pytest.raises(ValueError) as error_info:
+            path = 'C://fakepath/subfolder1//subfolder2/original_file_name.gpkg'
+            geospatial_assert_formats(path)
+            assert 'gpkg' in str(error_info)
+
+            path = 'C:/fakepath/subfolder1/subfolder2/original_file_name.shp'
+            output_file = 'my_new_file_name' # no file extension
+            geospatial_assert_formats(path, output_file)
+            assert 'gpkg' in str(error_info)
+        

--- a/pysqldb3/util.py
+++ b/pysqldb3/util.py
@@ -731,7 +731,7 @@ def retrieve_input_tbl_names(dbo, full_path):
         gpkg_tbl_names[t_i_g] = insert_val # add the cleaned name
 
     # assert that the new cleaned names are unique. if not, we won't get the same dimensions
-    if len(gpkg_tbl_names) == len(tables_in_gpkg):
+    if len(gpkg_tbl_names) != len(tables_in_gpkg):
         raise Exception("Clean geopackage table names for db upload and make sure they are unique.")
 
     return gpkg_tbl_names

--- a/pysqldb3/util.py
+++ b/pysqldb3/util.py
@@ -373,6 +373,8 @@ def parse_file_path(path = None):
     """
     Parse the file name to separate the path and file name.
     :param path: Full file path or file name
+
+    :return: Clean file path
     """
     level1 = os.path.basename(path) # take base name
     level2 = os.path.dirname(path) # take directory
@@ -403,11 +405,22 @@ def rename_geom(db, schema, table):
     :param table: Table where geom is located
     :return:
     """
+
+    # remove double quotes for table names with special chars
+    # as it is not recognized in the information_schema
+    standard_table_name = re.sub('"', '', table)
+
+    # if double quotes are in the table name, need to create special variable
+    if re.search('"', table):
+        double_quote = '"'
+    else:
+        double_quote = ''
+
     db.query(f"""
                     SELECT column_name
                     FROM information_schema.columns
                     WHERE table_schema = '{schema}'
-                    AND table_name   = '{table}';
+                    AND table_name   = '{standard_table_name}';
                 """, timeme=False, internal=True)
     f = None
 
@@ -429,26 +442,33 @@ def rename_geom(db, schema, table):
             # Rename index
             db.query(f"""
                     ALTER INDEX IF EXISTS
-                    {schema}.{table}_{f}_geom_idx
-                    RENAME to {table}_geom_idx
+                    {schema}.{double_quote}{standard_table_name}_{f}_geom_idx{double_quote}
+                    RENAME to {double_quote}{standard_table_name}_geom_idx{double_quote}
                 """, timeme=False, internal=True)
 
         elif db.type == 'MS':
             # Rename index if exists
             try:
                 db.query(f"""
-                    EXEC sp_rename N'{schema}.{table}.ogr_{schema}_{table}_{f}_sidx', N'{table}_geom_idx', N'INDEX';
+                    EXEC sp_rename N'{schema}.{table}.ogr_{schema}_{standard_table_name}_{f}_sidx', N'{standard_table_name}_geom_idx', N'INDEX';
                 """, timeme=False, internal=True)
             except SystemExit as e:
                 print(e)
                 print('Warning - could not update index name after renaming geometry. It may not exist.')
 
 
-def read_compressed(temp_dir, path = None):
+def decompress_and_parse_file_path(path = None):
     
-    # unzip and read compressed file if applicable
+    """
+    Unzip all Geospatial files or decompress SHP file if it's in a particular compressed format.
 
-    # if file has other compressed format
+    If the file is not a compressed Shapefile, it can parse the file paths for all tables within
+    the Geospatial file, such as multiple geopackage or geodatabase tables.
+
+    :param path: (str) Full file path for file
+    :returns: 
+    """
+
     # note: Since the compressed file may contain multiple different SHP files, this logic only applies when the path
     # includes the name of the compressed file and the input file is the name of the specific SHP file.
     compressed_exts = ['.tar', '.gz', '.tgz', '.7z', '.rar']
@@ -491,16 +511,18 @@ def read_compressed(temp_dir, path = None):
 
         # Return the folder path, .shp filename, and temp dir for later cleanup
         path = os.path.join(str(shp_path.parent), shp_path.name)
+        file_dir = shp_path.parent
+        input_file = shp_path.name
         input_table = ''
 
     else:
         full_path = add_zip_to_geo_path(path) # this function only runs if applicable
         path, file_dir, input_file, input_table = parse_file_path(full_path)
 
-    return path, input_table
+    return path, file_dir, input_file, input_table
 
 def read_geospatial_command(dbo, gdal_data_loc, srid, full_path, schema,
-                            table, precision, port, gpkg_tbl = None, feature_class = None, skip_failures = None):
+                            table, input_tbl, precision, port, skip_failures = None):
     
     """"
     Generate the cmd text to read a Geospatial file into the database
@@ -515,7 +537,7 @@ def read_geospatial_command(dbo, gdal_data_loc, srid, full_path, schema,
             user=dbo.user,
             password=dbo.password,
             gpkg_name = full_path,
-            gpkg_tbl = gpkg_tbl,
+            gpkg_tbl = input_tbl,
             schema = schema,
             tbl_name = table,
             perc=precision,
@@ -530,7 +552,7 @@ def read_geospatial_command(dbo, gdal_data_loc, srid, full_path, schema,
                 host=dbo.server,
                 dbname=dbo.database,
                 gpkg_name=full_path,
-                gpkg_tbl = gpkg_tbl,
+                gpkg_tbl = input_tbl,
                 schema=schema,
                 tbl_name='"' + table + '"',
                 perc=precision,
@@ -547,14 +569,14 @@ def read_geospatial_command(dbo, gdal_data_loc, srid, full_path, schema,
                 user=dbo.user,
                 password=dbo.password,
                 gpkg_name=full_path,
-                gpkg_tbl = gpkg_tbl,
+                gpkg_tbl = input_tbl,
                 schema=schema,
                 tbl_name='"' + table + '"',
                 perc=precision,
                 port=port
             )
 
-    elif dbo.type == 'PG' and '.shp' in full_path and not feature_class:
+    elif dbo.type == 'PG' and '.shp' in full_path:
         
             cmd = READ_SHP_CMD_PG.format(
                     gdal_data = gdal_data_loc,
@@ -569,7 +591,7 @@ def read_geospatial_command(dbo, gdal_data_loc, srid, full_path, schema,
                     perc = precision,
                     port = port)
 
-    elif dbo.type == 'MS' and '.shp' in full_path and not feature_class:
+    elif dbo.type == 'MS' and '.shp' in full_path:
         
         if dbo.LDAP:
             cmd = READ_SHP_CMD_MS.format(
@@ -579,7 +601,7 @@ def read_geospatial_command(dbo, gdal_data_loc, srid, full_path, schema,
                 dbname = dbo.database,
                 shp = full_path,
                 schema = schema,
-                tbl_name = table,
+                tbl_name = '"' + table + '"',
                 perc = precision,
                 port = port
             )
@@ -595,12 +617,12 @@ def read_geospatial_command(dbo, gdal_data_loc, srid, full_path, schema,
                 password = dbo.password,
                 shp = full_path,
                 schema = schema,
-                tbl_name = table,
+                tbl_name = '"' + table + '"',
                 perc = precision,
                 port = port
             )
     
-    elif dbo.type == 'PG' and '.gdb' in full_path and feature_class:
+    elif dbo.type == 'PG' and '.gdb' in full_path:
         
         cmd = READ_FEATURE_CMD.format(
             gdal_data = gdal_data_loc,
@@ -609,12 +631,12 @@ def read_geospatial_command(dbo, gdal_data_loc, srid, full_path, schema,
             dbname = dbo.database,
             user = dbo.user,
             password= dbo.password,
-            gdb = full_path,
-            feature = feature_class,
+            gdb = full_path.replace('.shp', ''),
+            feature = input_tbl,
             tbl_name = table,
             sch = schema
         )
-    elif dbo.type == 'MS' and '.gdb' in full_path and feature_class:
+    elif dbo.type == 'MS' and '.gdb' in full_path:
             # TODO: add LDAP version trusted_connection=yes
         cmd = READ_FEATURE_CMD_MS.format(
                 gdal_data = gdal_data_loc,
@@ -623,26 +645,26 @@ def read_geospatial_command(dbo, gdal_data_loc, srid, full_path, schema,
                 ms_db = dbo.database,
                 ms_user = dbo.user,
                 ms_pass = dbo.password,
-                gdb = full_path,
-                feature= feature_class,
-                tbl_name=table,
+                gdb = full_path.replace('.shp', ''),
+                feature= input_tbl,
+                tbl_name= '"' + table + '"',
                 sch= schema,
                 sf=skip_failures
             )
     
     else:
-        AssertionError('Please check your inputs.')
+        raise ValueError('Please check your inputs.')
 
     return cmd
 
-def comment_query(dbo, feature_class = None, schema = None,
-                  table = None, path = None):
+def comment_query(dbo, schema = None, table = None, path = None):
     
     """
     Add a comment to a shp table
     """
     
-    if dbo.type == 'PG' and feature_class == True:
+    if dbo.type == 'PG' and '.gdb' in path:
+        # THIS IS FOR FEATURE CLASSES ONLY
         dbo.query(FEATURE_COMMENT_QUERY.format(
             s = schema,
             t = table,
@@ -650,7 +672,7 @@ def comment_query(dbo, feature_class = None, schema = None,
             d = datetime.datetime.now().strftime('%Y-%m-%d %H:%M')
         ), timeme=False, internal=True)
     
-    elif dbo.type == 'PG' and path.endswith('.shp') and feature_class == False:
+    elif dbo.type == 'PG' and '.shp' in path:
         dbo.query(SHP_COMMENT_QUERY.format(
                 s=schema,
                 t=table,
@@ -671,24 +693,31 @@ def encoding_changes(cmd_env, encoding = None):
 
     return cmd_env
 
-def retrieve_gpkg_tbl_names(dbo, full_path):
+def retrieve_input_tbl_names(dbo, full_path):
 
     """
-    Parse through a geopackage and identify all the table names. Clean table names if necessary to make it compatible for upload.
+    Parse through a geopackage and identify all the table names.
+    Clean table names if necessary to make it compatible for upload.
+
+    :param dbo: Database connection
+    :param full_path: Full file path
+    :return: dict
     """
+
     # create empty dictionary
     gpkg_tbl_names = {}
     
     # count numbre of tables and parse through them
     try:
-        count_cmd = COUNT_GPKG_LAYERS.format(full_path = full_path) 
-        ogr_response = subprocess.check_output(shlex.split(count_cmd.replace('\n', ' ')), stderr=subprocess.STDOUT)
-
         if full_path.endswith('.gpkg'):
+            count_cmd = COUNT_GEOSPATIAL_LAYERS.format(full_path = full_path) 
+            ogr_response = subprocess.check_output(shlex.split(count_cmd.replace('\n', ' ')), stderr=subprocess.STDOUT)
             tables_in_gpkg = re.findall(r"\\n\d+:\s(.*?)(?=\\r|\s\(.*\))", str(ogr_response))
         # only allows tables names with underscores, numbers, and letters as the first character
         # excludes any dtype description that's also returned by the command line
         else: # .gdb
+            count_cmd = COUNT_GEOSPATIAL_LAYERS.format(full_path = os.path.dirname(full_path)) 
+            ogr_response = subprocess.check_output(shlex.split(count_cmd.replace('\n', ' ')), stderr=subprocess.STDOUT)
             tables_in_gpkg = re.findall(r"Layer:\s(.*?)(?=\\r|\s\(.*\))", str(ogr_response))
 
     except subprocess.CalledProcessError as e:
@@ -702,7 +731,8 @@ def retrieve_gpkg_tbl_names(dbo, full_path):
         gpkg_tbl_names[t_i_g] = insert_val # add the cleaned name
 
     # assert that the new cleaned names are unique. if not, we won't get the same dimensions
-    assert len(gpkg_tbl_names) == len(tables_in_gpkg), "Clean the geopackage table names so they can be uploaded as tables (by removing special characters other than _) and make sure they are unique."
+    if len(gpkg_tbl_names) == len(tables_in_gpkg):
+        raise Exception("Clean geopackage table names for db upload and make sure they are unique.")
 
     return gpkg_tbl_names
 
@@ -742,7 +772,7 @@ def convert_cmd(input_full_path, output_full_path, _update = None, _overwrite = 
         
     return cmd
         
-def write_cmd(dbo, full_path, gpkg_tbl = None, table = None,
+def write_cmd(dbo, full_path, input_tbl = None, table = None,
                     _overwrite = None, _update = None, srid = None, gdal_data_loc = None, qry = None):
     
     """
@@ -762,7 +792,7 @@ def write_cmd(dbo, full_path, gpkg_tbl = None, table = None,
     if full_path.endswith('.gpkg'):
         cmd = WRITE_GPKG_CMD.format(full_path=full_path,
                                     sql_select=qry,
-                                    gpkg_tbl = gpkg_tbl,
+                                    gpkg_tbl = input_tbl,
                                     tbl_name = table,
                                     _overwrite = _overwrite,
                                     _update = _update,
@@ -779,7 +809,7 @@ def write_cmd(dbo, full_path, gpkg_tbl = None, table = None,
 
     return cmd
 
-def execute_cmd(cmd, dbo = None, feature_class = None, cmd_env = None):
+def execute_cmd(cmd, dbo = None, cmd_env = None):
 
     if cmd_env is None:
         try:
@@ -801,79 +831,99 @@ def execute_cmd(cmd, dbo = None, feature_class = None, cmd_env = None):
             print(ogr_response)
         except subprocess.CalledProcessError as e:
             print("Ogr2ogr Output:\n", e.output)
-            if feature_class == True:
-                (f'Ogr2ogr command failed. The feature class was not read in.')
-            else:
-                print(f'Ogr2ogr command failed. The file was not read in.')
+            print(f'Ogr2ogr command failed. The file was not read in.')
             raise subprocess.CalledProcessError(cmd=print_cmd_string([dbo.password], cmd), returncode=1)
         
     return
 
-def clean_table_name(table = None, gpkg_tbl = None, full_path = None):
+def clean_table_name(table = None, input_tbl = None, full_path = None):
     """
-    Clean the table name for input_geospatial_bulk
+    If a DB table name is not specified, name will be based on existing upload file
+    or file's table name.
+
+    :param table: Database table name
+    :param input_tbl: Table of GPKG or GDB table
+    :param full_path: Full file path
+    :returns: Cleaned table name
     """
 
-    if table:
-        assert table == re.sub(r'[^A-Za-z0-9_]+', r'_', table) # make sure the name will load into the database
-    elif not table and gpkg_tbl:
-        table = gpkg_tbl.replace('.gpkg', '').replace('.shp', '').lower()
+    if not table and input_tbl:
+        table = input_tbl.replace('.gpkg', '').replace('.shp', '').lower()
         # if the gpkg_table is left blank, we will populate the name using input_gpkg
     elif not table and full_path.endswith(('.shp')):
         table = os.path.basename(full_path).replace('.shp', '').lower()
 
     return table
 
-def bulk_upload_table_setup(dbo, full_path, table, feature_class = None, temp_dir = None, gpkg_tbl = None):
+def set_up_geo_tbl_dict(dbo, full_path, table, input_tbl = None):
 
     """
     Sets up the dictionary for bulk uploading loop based on the type of geospatial input file
+
+    :param dbo: Database connection where geospatial table will be uploaded
+    :param full_path: Full file path
+    :param table: Database table name to be uploaded
+    :param input_tbl: If the file is a GPKG or GDB, this is the feature class or GPKG table name.
+    :returns: Dictionary of table names to be uploaded
     """
 
     # create empty dictionary
-    gpkg_tbl_names = {}
+    file_tbl_names = {}
 
-    if (not gpkg_tbl and full_path.endswith('.gpkg')) or (full_path.endswith('.gdb') and not feature_class):
+    # take only the file name for cleaning
+    file_name = os.path.basename(full_path)
+
+    # if this ends up being a bulk upload, table gets overwritten anyway
+    table = clean_table_name(table = table, input_tbl = input_tbl, full_path = file_name)
+
+    ## BULK UPLOADING OPTION ##
+    if not input_tbl and ('.gpkg' in full_path or '.gdb' in full_path):
         # retrieve all the table names from the geopackage
-        gpkg_tbl_names = retrieve_gpkg_tbl_names(dbo, full_path)
+        # remove any feature class name that ends with .shp if applicable
+        file_tbl_names = retrieve_input_tbl_names(dbo, full_path)
 
-    elif full_path.endswith('.shp') and not temp_dir:
+    elif file_name.endswith('.shp') and '.gdb' not in full_path:
         # exclude compressed files from this if statement
-        gpkg_tbl_names[full_path.replace('.shp', '')] = table
+        file_tbl_names[file_name.replace('.shp', '')] = table
         
-    elif full_path.endswith('.shp') and '.zip' in full_path: # this is for zip files
-        gpkg_tbl_names[os.path.basename(full_path).replace('.shp', '')] = table
+    elif file_name.endswith('.shp') and '.zip' in full_path and '.gdb' not in full_path:
+        # this is for zip files containing sShps
+        file_tbl_names[file_name.replace('.shp', '')] = table
 
-    elif full_path.endswith('.shp') and temp_dir:
+    elif file_name.endswith('.shp') and '.gdb' not in full_path:
         # compressed files if statement
-        gpkg_tbl_names[os.path.basename(full_path).replace('.shp', '')] = table
+        file_tbl_names[file_name.replace('.shp', '')] = table
       
-    elif full_path.endswith('.gdb') and feature_class:
-        gpkg_tbl_names[feature_class.replace('.shp', '')] = table
-   
-    elif full_path.endswith('.gpkg') and gpkg_tbl:
-        gpkg_tbl_names[gpkg_tbl] = table
+    elif '.gdb' in full_path and input_tbl:
+        file_tbl_names[input_tbl.replace('.shp', '')] = table
 
-    return gpkg_tbl_names
+    elif '.gpkg' in full_path and input_tbl:
+        file_tbl_names[input_tbl] = table
+
+    return file_tbl_names
 
 
-def geo_convert_assert_formats(path, output_file = None):
+def geospatial_assert_formats(path, output_file = None, bulk_optional = False):
     
     """
-    Check the file types included in the geospatial_convert function
-    :param path: Path argument from geospatial_convert function
-    :param output_file: Output file argument from geospatial_convert function
+    Check the file types in the arguments for the geospatial functions
+    :param path: Path argument from geospatial function
+    :param output_file: Output file argument from geospatial_convert function, if applicable
+    :param bulk_optional: (bool) .  Defaults to False.
     """
 
-        # assert the INPUT file formats are correct
-    assert path.endswith('.shp') or any(x in path for x in ['.gpkg/', '.gpkg\\', '.gdb/', '']), \
-        "The input file must end with .shp. Or .gpkg or .gdb files must end with their table name"
-    assert not path.endswith(('.gpkg', '.gdb', '.gpkg/', '.gdb/', '.gdb\\', '.gpkg\\')), \
-        "Specify the gpkg or feature class table in the output name"
+    # assert the INPUT file formats are correct
+    if not (path.endswith('.shp') or any(x in path for x in ['.gpkg/', '.gpkg\\', '.gdb/', ''])): 
+        raise ValueError("The input file must end with .shp. Or .gpkg or .gdb files must end with their table name")
+    
+    # only check this condition if no bulk upload involved
+    if bulk_optional is False:
+        if path.endswith(('.gpkg', '.gdb', '.gpkg/', '.gdb/', '.gdb\\', '.gpkg\\')):
+            raise ValueError("Specify the gpkg or feature class table in the output name")
     
     # assert the OUTPUT file formats are correct
     if output_file:
-        assert output_file.endswith('.shp') or any(x in output_file for x in ['.gpkg/', '.gpkg\\']), \
-            "The output file must end with .shp or .gpkg/[gpkg_tbl]. Cannot create new Geodatabase via GDAL"
+        if not (output_file.endswith('.shp') or any(x in output_file for x in ['.gpkg/', '.gpkg\\'])):
+            raise ValueError("The output file must end with .shp or .gpkg/[gpkg_tbl]. Cannot create new Geodatabase via GDAL")
 
     return


### PR DESCRIPTION
This PR:
- Standardize all the geospatial input file names and eliminate arguments like `gpkg_tbl` and `feature_class`.
    - Now, files are input as "C:/Documents/Cindy/geopackage.gpkg/my_table" instead of "C:/Documents/Cindy/geopackage.gpkg' and a separate input for 'my_table'.
- Allow database table names to include special characters by uploading special character names with double quotes
- Update tests to include new `util` functions


**TO DO:**
- Potentially create new tests in `test_io.py` to check that `rename_geom` is working correctly, since it now accommodates table names with special characters in double quotes (something that was not explicitly accommodated before)