### PR TITLE
edit the SERVER param for the Azure connection

### DIFF
--- a/pysqldb3/pysqldb3.py
+++ b/pysqldb3/pysqldb3.py
@@ -263,7 +263,7 @@ class DbConnect:
 
         self.params = {
             'database': self.database,
-            'SERVER': self.server,
+            'host': self.server,
             'PORT' : '1433;DATABASE = '+self.database,
             'UID': self.user+'@dot.nyc.gov',
             'AUTHENTICATION' : 'ActiveDirectoryInteractive',


### PR DESCRIPTION
I couldn't get the azure connection to work until I made this change, because I got an error that `pymssql` did not recognize the SERVER parameter. Is it working for you? Not sure if this is a version issue....